### PR TITLE
Aefos AI is free software: GPL v3, from today

### DIFF
--- a/ADDITIONAL-PERMISSIONS.md
+++ b/ADDITIONAL-PERMISSIONS.md
@@ -1,0 +1,141 @@
+# Aefos AI — Additional Permissions
+
+**Version 1.0**
+
+Aefos AI is free software: you can redistribute it and/or modify it under the
+terms of the **GNU General Public License, version 3**, as published by the Free
+Software Foundation. The full text of that licence is in [`LICENSE`](LICENSE).
+
+This file grants **additional permissions** under **section 7 of the GNU General
+Public License version 3**. They *widen* what you may do; they never narrow it.
+If anything in this file were ever read as restricting a right the GPL gives you,
+the GPL wins and that reading is void.
+
+In this document:
+
+* **"Aefos"** and **"the Program"** mean the Aefos AI software — the RAD Studio
+  Delphi plugin suite and its Lazarus/FPC edition — as distributed by the
+  copyright holder under the GPL.
+* **"You"** means a licensee of the Program.
+
+---
+
+## 1. Output Exception — the code Aefos writes for you is yours
+
+**Grant.** Code, text, configuration, project files and other material that
+Aefos generates, suggests, completes, scaffolds, refactors or inserts into your
+own project (together, the **"Output"**) is **not** covered by the GNU General
+Public License, and is **not** a derivative work of Aefos for the purposes of
+this licence.
+
+To the extent that any part of Aefos's own source code — templates, snippets,
+boilerplate, scaffolding, generated headers or the like — is reproduced in the
+Output, the copyright holder grants you an unlimited, irrevocable, worldwide,
+royalty-free permission to use, copy, modify and distribute that part **under
+any licence you choose**, including a proprietary one.
+
+**What this means in practice.** Using Aefos to develop software places **no
+licensing obligation whatsoever on that software**. You may build closed-source,
+commercial, proprietary products with Aefos and distribute them under whatever
+terms you like. You do not have to publish your source. You do not have to
+mention Aefos. Aefos is a tool, and running a tool over your code does not
+infect your code.
+
+**Scope.** This exception is about the *Output*. It does not grant permission to
+redistribute Aefos itself, or a modified Aefos, outside the GPL — that is
+governed by section 2 below and by the GPL.
+
+*(This clause follows the spirit of the GCC Runtime Library Exception: a
+compiler that is free software must never make the programs it compiles
+unfree.)*
+
+---
+
+## 2. Embarcadero and Platform Library Linking Exception
+
+### 2.1 The problem this solves
+
+Aefos is an **IDE plugin**. A RAD Studio design-time package (`.bpl`) cannot
+exist at all without linking against Embarcadero's `designide` and the RAD
+Studio runtime — those libraries are proprietary and are not GPL-compatible.
+Without an explicit permission, the GPL's terms on combining with non-free
+libraries would make it impossible to distribute a working Aefos build.
+
+### 2.2 Grant
+
+You have permission to **link or combine** Aefos, or any modified version of
+Aefos, with:
+
+* **Embarcadero RAD Studio runtime and design-time libraries** and their
+  Delphi/C++Builder interface units — including but not limited to `rtl`,
+  `vcl`, `vclx`, `vclie`, `vclimg`, `fmx`, `dbrtl`, `designide`, `ToolsAPI`,
+  `FireDAC`, `IndyCore`/`IndyProtocols`, `soaprtl`, `xmlrtl`, the `dcl*`
+  design-time packages, and any other library distributed by Embarcadero
+  Technologies, Inc. as part of RAD Studio, Delphi or C++Builder;
+* **Microsoft Edge WebView2** and the Microsoft Windows platform libraries and
+  runtimes that Aefos calls or hosts;
+
+and to **convey the resulting work**, including compiled design-time and
+runtime packages (`.bpl`), executables and installers, under the terms of the
+GNU General Public License version 3 — notwithstanding anything in that licence
+to the contrary about combining GPL-covered work with libraries that are not
+themselves under a GPL-compatible licence.
+
+### 2.3 What this exception does *not* do
+
+* It grants **no rights in Embarcadero's or Microsoft's software**. Those
+  libraries remain licensed to you by their own vendors, under their own terms,
+  and you must have a valid licence for them. This exception is a permission
+  from the Aefos copyright holder only.
+* It does **not** cover linking Aefos with arbitrary unrelated proprietary
+  libraries. It is limited to the platform and IDE libraries listed above — the
+  ones an IDE plugin cannot function without.
+* The GPL still applies in full to Aefos's own source code. If you distribute a
+  modified Aefos, you must still release your modifications under the GPL and
+  provide the corresponding source.
+
+---
+
+## 3. These permissions are removable
+
+As **GPLv3 section 7** expressly allows, you may **remove any or all of the
+additional permissions in this file** from any copy of Aefos, or from any part
+of it, that you convey — and you may require that they be removed from
+downstream copies you receive with material you add.
+
+Removing an additional permission has **no effect on the rest of the licence**:
+the GNU General Public License version 3 continues to apply in full to the
+Program either way. Removing a permission simply means the recipient of that
+copy gets the plain GPL without that extra freedom.
+
+If you remove a permission, the sensible thing is to say so plainly in your
+distribution, so your users are not misled by a copy of this file that no longer
+describes what they received.
+
+---
+
+## 4. No warranty
+
+These additional permissions change nothing about warranty or liability.
+Sections 15, 16 and 17 of the GNU General Public License version 3 apply to
+Aefos in full: **the Program is provided without any warranty**, and Aefos is a
+harness for autonomous AI tools that can change, move and delete code and run
+commands — **you are responsible for reviewing every change it makes, keeping
+backups, and validating any generated output before you rely on it.**
+
+---
+
+## 5. Notes
+
+* **Third-party components** bundled with or vendored into Aefos keep their own
+  licences. See [`THIRD-PARTY-NOTICES.md`](THIRD-PARTY-NOTICES.md).
+* **The hosted commercial services** — the licence-key backend, activation, the
+  Pro and Enterprise subscriptions, and paid support — are *services*, not the
+  software, and are governed by [`EULA.md`](EULA.md). Nothing there restricts
+  your rights in the GPL-licensed software.
+* This document is not legal advice and its authors are not lawyers. If you need
+  certainty for a commercial deployment, have your own counsel read it.
+
+---
+
+Copyright © 2026 Isaque de Souza Pinheiro.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ Dates are in `YYYY-MM-DD`.
 
 ## [Unreleased]
 
+### Licence
+
+**Aefos AI became free software on 2026-08-05.** The software is now licensed
+under the **GNU General Public License version 3**, with two additional
+permissions granted under GPLv3 section 7 (`ADDITIONAL-PERMISSIONS.md`):
+
+- the code Aefos generates for you is **yours**, under any licence you choose,
+  including a proprietary one — using Aefos places no obligation on what you
+  build with it;
+- linking with the Embarcadero RAD Studio libraries is expressly permitted,
+  without which a design-time package could not be distributed at all.
+
+Until this date the software was proprietary, governed by an EULA. That agreement
+is kept in the repository as `EULA-historical.md` — the record of what the licence
+used to be, not a document that still governs the software.
+
+What did **not** change: the hosted services around the software (the licence-key
+backend, the Pro and Enterprise subscriptions, paid support) are services, not
+the software, and are not covered by the GPL. Releases continue to be published
+from this repository.
+
+
 ## [1.1.0] - 2026-07-15
 
 **Aefos AI now works out of the box.** This release bundles a ready-to-use AI CLI right in the installer, so a fresh install is productive immediately — no separate CLI download, no PATH setup. **Delphi 12 Athens (BDS 23.0)** and **Delphi 13 (BDS 37.0)**; the installer detects your installed versions and lets you pick.

--- a/EULA-historical.md
+++ b/EULA-historical.md
@@ -1,0 +1,371 @@
+> # HISTORICAL DOCUMENT — no longer the licence of this software
+>
+> **On 5 August 2026 Aefos AI became free software, licensed under the
+> GNU General Public License version 3.** See [`LICENSE`](LICENSE) and
+> [`ADDITIONAL-PERMISSIONS.md`](ADDITIONAL-PERMISSIONS.md).
+>
+> The agreement below is the End User License Agreement that governed the
+> software **until that date**. It is kept here as the record of what the
+> licence used to be — nothing in it applies to the GPL-licensed software any
+> more, and where the two disagree, the GPL wins.
+>
+> What it still describes accurately are the **hosted commercial services** —
+> the licence-key backend and activation, the paid Pro and Enterprise
+> subscriptions, and paid support. Those are services, not the software, and
+> they are not covered by the GPL.
+
+---
+
+# AEFOS AI END USER LICENSE AGREEMENT (EULA)
+
+**Last Updated:** June 2026
+
+This End User License Agreement ("Agreement") is a legal agreement between you ("User", "Customer", "you") and Aefos AI ("Aefos", "we", "us", or "our") governing your installation, access, and use of the Aefos AI software, including Community, Pro, and Enterprise editions, related plugins, agents, tools, integrations, updates, documentation, and associated services (collectively, the "Software").
+
+By installing, accessing, or using the Software, you agree to be bound by this Agreement.
+
+If you do not agree to these terms, do not install or use the Software.
+
+**Acceptance, authority, and eligibility.** If you accept this Agreement or use the
+Software on behalf of a company, organization, government body, or other legal
+entity, "you" and "your" refer to that entity, and you represent and warrant that
+you have the authority to bind that entity to this Agreement. You must be at least 18
+years old, or the age of legal majority in your jurisdiction, to use the Software,
+which is intended for software-development professionals and is not directed to
+anyone under the age of 13.
+
+---
+
+# PLAIN-LANGUAGE SUMMARY (non-binding)
+
+This summary is provided for convenience only. It is **not** a substitute for the
+numbered terms below, which are the binding agreement; if there is any conflict,
+the numbered terms control.
+
+* **The Community Edition is free — for everyone.** Individuals, commercial
+  companies, enterprises, educational institutions, non-profits, and government
+  organizations may all use it **at no charge**, including for **internal
+  commercial and business purposes**.
+* **No fee, no per-seat charge, no headcount limit, and no penalty** apply to
+  Community Edition internal use. A company of any size may roll it out across its
+  organization for internal software development for free.
+* **You own everything you create** with the Software — your code, content, and
+  outputs are yours.
+* **Pro and Enterprise editions are optional.** They add paid convenience,
+  automation, support, and governance features; they are never required for the
+  core free use described above.
+* **What you may not do:** resell, redistribute, rebrand, host as a competing
+  service, or build a competing product out of the Software itself (see Section 4).
+* **You use it at your own risk.** The Software can autonomously read, change, and
+  delete code and run commands (often via third-party AI tools you choose). **You
+  are responsible for reviewing every change, keeping backups, and verifying any
+  generated output before using it.** The Software is provided "AS IS", with no
+  warranty, and the maintainer's liability is limited (see Sections 10–13).
+
+---
+
+# 1. LICENSE GRANT
+
+Subject to compliance with this Agreement, Aefos grants you a limited, non-exclusive, non-transferable, non-sublicensable license to install and use the Software.
+
+The license granted under this Agreement is a license to use the Software and does not transfer ownership of the Software or any intellectual property rights.
+
+---
+
+# 2. EDITIONS
+
+## 2.1 Community Edition
+
+The Community Edition may be used **free of charge** by:
+
+* Individual users
+* Educational institutions
+* Non-profit organizations
+* Commercial businesses and enterprises of any size
+* Government organizations
+
+**Internal commercial and business use is expressly permitted at no charge.** This
+includes installing and using the Community Edition across your organization, by an
+unlimited number of employees, contractors, and seats, for internal software
+development, evaluation, and production work.
+
+No fee, subscription, registration, headcount limit, organization-size limit, or
+usage penalty is imposed on Community Edition internal use. Aefos will not charge,
+audit-penalize, or otherwise restrict a company solely because it is a commercial or
+enterprise entity using the Community Edition for its own internal purposes.
+
+The Community Edition license is **perpetual for the version you install** and does
+not expire so long as you comply with this Agreement.
+
+## 2.2 Pro Edition
+
+The Pro Edition is available through a paid subscription and may include additional features, tools, integrations, models, automation capabilities, support, or usage limits.
+
+**Right of withdrawal (Brazilian consumers).** Where you purchase a paid Edition online as a consumer ("consumidor") and the Brazilian Consumer Protection Code (Law No. 8.078/1990, "CDC") applies, you may withdraw from the purchase within **seven (7) days** of the contract date or receipt of the license, as provided in Article 49 of the CDC, and receive a refund of amounts paid. To exercise this right, contact us at the address in Section 20; the refund follows the procedure of the payment provider used at checkout. This right is in addition to, and does not limit, any other refund terms offered.
+
+## 2.3 Enterprise Edition
+
+The Enterprise Edition is licensed under a separate commercial agreement and may include enterprise-specific functionality, support, deployment options, compliance features, and custom licensing terms.
+
+---
+
+# 3. PERMITTED USE
+
+You may:
+
+* Use the Software for personal purposes.
+* Use the Software for educational purposes.
+* Use the Software within commercial organizations and enterprises, for internal business purposes, by an unlimited number of users and seats (Community Edition, at no charge).
+* Use the Software to develop commercial software, products, or services.
+* Use outputs generated by the Software for commercial purposes.
+* Create extensions, integrations, scripts, and workflows that interact with the Software through supported mechanisms.
+
+Ownership of any code, documentation, content, or other outputs generated through your use of the Software remains with you, subject to applicable third-party model, API, or service terms.
+
+---
+
+# 4. RESTRICTIONS
+
+Unless expressly authorized in writing by Aefos, you may not:
+
+* Sell, rent, lease, sublicense, distribute, or transfer the Software.
+* Redistribute Software binaries.
+* Offer the Software as a hosted, managed, cloud, SaaS, or competing service.
+* Modify, repackage, or rebrand the Software for redistribution.
+* Remove or alter copyright, trademark, licensing, or attribution notices.
+* Circumvent licensing, subscription, activation, security, or usage controls.
+* Use the Software to create a competing AI development platform, IDE assistant, agent framework, or substantially similar commercial product derived from the Software.
+* Reverse engineer, decompile, disassemble, or attempt to derive source code except where such restriction is prohibited by applicable law.
+
+---
+
+# 5. INTELLECTUAL PROPERTY
+
+The Software is licensed, not sold.
+
+Aefos and its licensors retain all right, title, and interest in and to the Software, including:
+
+* Source code
+* Binaries
+* User interfaces
+* Trademarks
+* Logos
+* Documentation
+* Agent systems
+* Workflows
+* Architecture
+* Proprietary technologies
+
+No rights are granted except those expressly stated in this Agreement.
+
+---
+
+# 6. THIRD-PARTY SERVICES
+
+The Software may integrate with third-party services, including AI providers, APIs, cloud services, package registries, development tools, and external platforms.
+
+Your use of such services may be subject to separate terms, conditions, privacy policies, fees, or limitations imposed by the respective providers.
+
+Aefos is not responsible for third-party services or their availability.
+
+---
+
+# 7. UPDATES
+
+Aefos may provide updates, patches, bug fixes, feature enhancements, security updates, or new versions.
+
+Certain updates may require an active subscription.
+
+Aefos is not obligated to provide updates for any specific period.
+
+---
+
+# 8. TELEMETRY AND DIAGNOSTICS
+
+The Software may collect limited technical and diagnostic information necessary to:
+
+* Maintain service reliability
+* Improve product quality
+* Detect abuse
+* Enforce licensing
+* Diagnose software issues
+
+Such information does not intentionally include source code, proprietary business information, or user content unless explicitly authorized by the user.
+
+Data collection practices are governed by the Aefos Privacy Policy (see the
+`PRIVACY.md` file distributed with the Software) and by applicable data-protection
+law, including the Brazilian General Data Protection Law (Lei nº 13.709/2018 —
+"LGPD").
+
+---
+
+# 9. OPEN SOURCE COMPONENTS
+
+The Software may include or interact with open-source and other third-party
+software components.
+
+Such components remain subject to their respective licenses, which are reproduced in
+full in the `THIRD-PARTY-NOTICES.txt` file distributed with the Software.
+
+Nothing in this Agreement limits rights granted under those applicable third-party or
+open-source licenses.
+
+---
+
+# 10. DISCLAIMER OF WARRANTIES
+
+THE SOFTWARE IS PROVIDED "AS IS" AND "AS AVAILABLE."
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, AEFOS DISCLAIMS ALL WARRANTIES, WHETHER EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, INCLUDING WARRANTIES OF:
+
+* MERCHANTABILITY
+* FITNESS FOR A PARTICULAR PURPOSE
+* NON-INFRINGEMENT
+* ACCURACY
+* RELIABILITY
+* AVAILABILITY
+
+AEFOS DOES NOT WARRANT THAT THE SOFTWARE WILL OPERATE WITHOUT INTERRUPTION OR ERROR.
+
+AEFOS DOES NOT AUTHOR, CONTROL, OR ENDORSE, AND DOES NOT WARRANT THE ACCURACY, SECURITY, LEGALITY, NON-INFRINGEMENT, OR FITNESS OF, ANY CODE, TEXT, OR OTHER OUTPUT GENERATED BY OR THROUGH THE SOFTWARE OR BY ANY THIRD-PARTY AI MODEL, AGENT, OR COMMAND-LINE TOOL THAT THE SOFTWARE INVOKES. ALL SUCH OUTPUT MUST BE REVIEWED AND VALIDATED BY YOU BEFORE USE.
+
+PRE-RELEASE, BETA, "COMMUNITY", AND SIMILAR EVALUATION BUILDS MAY CONTAIN DEFECTS AND ARE PROVIDED WITHOUT ANY SERVICE-LEVEL COMMITMENT, SUPPORT OBLIGATION, OR WARRANTY, AND MAY BE CHANGED, SUSPENDED, OR DISCONTINUED AT ANY TIME WITHOUT LIABILITY.
+
+---
+
+# 11. LIMITATION OF LIABILITY
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, AEFOS SHALL NOT BE LIABLE FOR:
+
+* INDIRECT DAMAGES
+* INCIDENTAL DAMAGES
+* SPECIAL DAMAGES
+* CONSEQUENTIAL DAMAGES
+* LOSS OF PROFITS
+* LOSS OF REVENUE
+* LOSS OF BUSINESS
+* LOSS OF DATA
+* BUSINESS INTERRUPTION
+
+IN NO EVENT SHALL AEFOS'S TOTAL LIABILITY EXCEED THE AMOUNT PAID BY THE CUSTOMER FOR THE SOFTWARE DURING THE TWELVE (12) MONTHS PRECEDING THE CLAIM.
+
+IF NO FEES WERE PAID, AEFOS'S TOTAL LIABILITY SHALL NOT EXCEED ONE HUNDRED U.S. DOLLARS (USD $100).
+
+The limitations and exclusions in this Section and in Section 10 apply only to the extent permitted by applicable law. Where you use the Software as a consumer ("consumidor") and the Brazilian Consumer Protection Code (Law No. 8.078/1990) applies, nothing in this Agreement excludes or limits liability that, under that Code, cannot lawfully be excluded or limited.
+
+---
+
+# 12. ASSUMPTION OF RISK; AI AND AGENT FEATURES; USER RESPONSIBILITY
+
+The Software includes autonomous, agent-based, and AI-assisted features that can, at your direction or on your behalf, read, generate, modify, move, rename, and delete source code and files; change project, editor, and IDE state; and execute build, run, version-control, shell, and command-line operations — including by delegating to third-party AI command-line tools and models that **you** select and configure. The Software is a harness: it bundles no AI model and manages no credentials, and the substantive output is produced by those third-party tools.
+
+You acknowledge and agree that:
+
+* These capabilities carry **inherent risk**, including the risk of unintended code changes, data loss, build or runtime failures, security vulnerabilities, and incorrect, insecure, or infringing output.
+* **You are solely responsible** for supervising and reviewing every action and output of the Software before accepting it (for example, through the inline change-review/consent mechanisms the Software provides), for maintaining adequate backups and version control, and for independently verifying the correctness, security, legality, and fitness of any result before relying on it or using it in production.
+* You are solely responsible for your use of the Software, for complying with all applicable laws and with the terms of any third-party tool, model, or service you use with it, and for ensuring you have the rights to any code, data, or content you process with it.
+* **You use the Software at your own risk.**
+
+To the maximum extent permitted by applicable law, Aefos is not responsible or liable for any code change, deletion, data loss, build or runtime effect, security issue, third-party output, or other result arising from your use of these features or from any third-party AI tool, model, or service.
+
+---
+
+# 13. INDEMNIFICATION
+
+To the maximum extent permitted by applicable law, you agree to defend, indemnify, and hold harmless Aefos and its maintainer(s), contributors, officers, agents, and licensors (the "Indemnified Parties") from and against any and all third-party claims, demands, actions, proceedings, damages, losses, liabilities, fines, costs, and expenses (including reasonable attorneys' fees and legal costs) arising out of or related to:
+
+* (a) your use, misuse, or inability to use the Software;
+* (b) your violation of this Agreement or of any applicable law, regulation, or sanction;
+* (c) your violation or infringement of any third-party right, including intellectual property, personality, privacy, or data-protection rights;
+* (d) any code, data, content, or output you create, modify, process, distribute, or deploy using the Software; and
+* (e) your use of any third-party AI tool, model, service, or command-line interface in connection with the Software.
+
+The Indemnified Parties may, at their option and expense, participate in the defense of any such claim with counsel of their choosing. This Section does not apply to the extent a claim results from the Indemnified Parties' own willful misconduct, and, where you act as a consumer ("consumidor") and the Brazilian Consumer Protection Code (Law No. 8.078/1990) applies, it applies only to the extent permitted by that Code.
+
+---
+
+# 14. TERMINATION
+
+This Agreement automatically terminates if you violate its terms.
+
+Upon termination, you must cease all use of the Software and destroy all copies in your possession or control.
+
+Sections relating to intellectual property, assumption of risk and user responsibility, indemnification, disclaimers, liability limitations, and governing law shall survive termination.
+
+---
+
+# 15. EXPORT CONTROL AND SANCTIONS
+
+The Software may be subject to export control and economic sanctions laws, including those of Brazil, the United States, and other applicable jurisdictions. You agree to comply with all such export, re-export, import, and sanctions laws and regulations.
+
+You represent and warrant that: (a) you are not located in, organized under the laws of, or ordinarily resident in any country or territory subject to comprehensive governmental or international sanctions; (b) you are not identified on, and are not owned or controlled by or acting on behalf of any person identified on, any applicable list of restricted or prohibited parties; and (c) you will not use, export, re-export, or provide the Software for any prohibited end use, including any use related to the development of nuclear, chemical, or biological weapons, missile technology, or any prohibited military end use.
+
+---
+
+# 16. FEEDBACK
+
+If you provide Aefos with any ideas, suggestions, enhancement requests, bug reports, code contributions, or other feedback regarding the Software ("Feedback"), you grant Aefos a worldwide, perpetual, irrevocable, royalty-free, fully paid-up, transferable, and sublicensable license to use, reproduce, modify, exploit, and incorporate that Feedback into the Software and into any Aefos product or documentation, for any purpose and without obligation or compensation to you. You are not required to provide Feedback, and you should not provide Feedback you are not authorized to share.
+
+---
+
+# 17. GOVERNING LAW; JURISDICTION; WAIVERS
+
+This Agreement shall be governed by and construed in accordance with the laws of the Federative Republic of Brazil, without regard to conflict-of-law principles, including, where applicable, Law No. 9.609/1998 (Software Law), Law No. 9.610/1998 (Copyright Law), Law No. 12.965/2014 (Internet Civil Framework), and Law No. 13.709/2018 (LGPD). The United Nations Convention on Contracts for the International Sale of Goods does not apply to this Agreement.
+
+The parties elect the courts of the Judicial District (Comarca) of Aracruz, State of Espírito Santo, Brazil, as the exclusive venue for any dispute arising from or relating to this Agreement, and each party irrevocably submits to that jurisdiction and waives any objection of inconvenient forum — **except** where applicable mandatory law (including the Brazilian Consumer Protection Code, Law No. 8.078/1990, "CDC") requires a different venue (such as the consumer's domicile), in which case that mandatory venue prevails.
+
+To the maximum extent permitted by applicable law, any dispute shall be resolved on an individual basis only, and you waive any right to bring or participate in a class, collective, or representative action. This waiver does not apply where, and only to the extent that, applicable mandatory law (including the CDC and the Brazilian rules governing collective actions) does not permit it.
+
+This Agreement is drafted in English, which is the controlling language; any translation is provided for convenience only. Nothing in this Agreement limits any non-waivable right or remedy granted to you by applicable law, including the acts a lawful licensee may perform under Article 6 of Law No. 9.609/1998 regardless of any contractual restriction.
+
+---
+
+# 18. GENERAL PROVISIONS
+
+**Entire Agreement.** This Agreement — together with the `PRIVACY.md` and `THIRD-PARTY-NOTICES.txt` files distributed with the Software and any applicable Pro/Enterprise order — is the entire agreement between you and Aefos regarding the Software and supersedes all prior or contemporaneous understandings on that subject.
+
+**Severability.** If any provision of this Agreement is held invalid or unenforceable, that provision will be limited or severed to the minimum extent necessary, and the remaining provisions will remain in full force and effect.
+
+**No Waiver.** Aefos's failure to enforce any right or provision of this Agreement is not a waiver of that right or provision.
+
+**Assignment.** You may not assign or transfer this Agreement or any rights under it, by operation of law or otherwise, without Aefos's prior written consent; any attempted assignment in violation of this Section is void. Aefos may freely assign or transfer this Agreement.
+
+**Force Majeure.** Aefos is not liable for any delay or failure to perform resulting from causes beyond its reasonable control.
+
+**No Agency.** Nothing in this Agreement creates any partnership, joint venture, agency, fiduciary, or employment relationship between the parties.
+
+**Notices.** Legal notices to Aefos must be sent to the contact in Section 20.
+
+**Headings.** Section headings are for convenience only and do not affect interpretation.
+
+**Survival.** Provisions that by their nature should survive termination — including Sections 5, 10, 11, 12, 13, 16, 17, and 18 — survive any expiration or termination of this Agreement.
+
+---
+
+# 19. CHANGES TO THIS AGREEMENT
+
+Aefos may modify this Agreement from time to time.
+
+Updated versions will be published through official distribution channels.
+
+Continued use of the Software after publication of an updated Agreement constitutes acceptance of the revised terms, to the extent permitted by applicable law.
+
+For **material changes that adversely affect a paying subscriber**, Aefos will give reasonable prior notice (e.g. by e-mail or in-product notice) before the change takes effect, and the subscriber may decline by terminating the paid subscription and receiving a pro-rata refund of the unused, prepaid period.
+
+---
+
+# 20. CONTACT
+
+For licensing, legal, partnership, or compliance inquiries:
+
+**Aefos AI** — a product of **Isaque de Souza Pinheiro** (Empresário Individual / ME)
+CNPJ: **02.565.249/0001-70**
+Address: **Av. Aurélio Alvarenga, 33-A, Guaraná, Aracruz – ES, Brazil, CEP 29.195-421**
+
+Email: [tecsisinfo.com.br@gmail.com](mailto:tecsisinfo.com.br@gmail.com)
+
+Official distribution channel: https://www.pubpascal.dev
+
+---
+
+By installing, accessing, or using Aefos AI Community, Pro, or Enterprise Edition, you acknowledge that you have read, understood, and agree to be bound by this Agreement.

--- a/LICENSE
+++ b/LICENSE
@@ -1,353 +1,674 @@
-# AEFOS AI END USER LICENSE AGREEMENT (EULA)
-
-**Last Updated:** June 2026
-
-This End User License Agreement ("Agreement") is a legal agreement between you ("User", "Customer", "you") and Aefos AI ("Aefos", "we", "us", or "our") governing your installation, access, and use of the Aefos AI software, including Community, Pro, and Enterprise editions, related plugins, agents, tools, integrations, updates, documentation, and associated services (collectively, the "Software").
-
-By installing, accessing, or using the Software, you agree to be bound by this Agreement.
-
-If you do not agree to these terms, do not install or use the Software.
-
-**Acceptance, authority, and eligibility.** If you accept this Agreement or use the
-Software on behalf of a company, organization, government body, or other legal
-entity, "you" and "your" refer to that entity, and you represent and warrant that
-you have the authority to bind that entity to this Agreement. You must be at least 18
-years old, or the age of legal majority in your jurisdiction, to use the Software,
-which is intended for software-development professionals and is not directed to
-anyone under the age of 13.
-
----
-
-# PLAIN-LANGUAGE SUMMARY (non-binding)
-
-This summary is provided for convenience only. It is **not** a substitute for the
-numbered terms below, which are the binding agreement; if there is any conflict,
-the numbered terms control.
-
-* **The Community Edition is free — for everyone.** Individuals, commercial
-  companies, enterprises, educational institutions, non-profits, and government
-  organizations may all use it **at no charge**, including for **internal
-  commercial and business purposes**.
-* **No fee, no per-seat charge, no headcount limit, and no penalty** apply to
-  Community Edition internal use. A company of any size may roll it out across its
-  organization for internal software development for free.
-* **You own everything you create** with the Software — your code, content, and
-  outputs are yours.
-* **Pro and Enterprise editions are optional.** They add paid convenience,
-  automation, support, and governance features; they are never required for the
-  core free use described above.
-* **What you may not do:** resell, redistribute, rebrand, host as a competing
-  service, or build a competing product out of the Software itself (see Section 4).
-* **You use it at your own risk.** The Software can autonomously read, change, and
-  delete code and run commands (often via third-party AI tools you choose). **You
-  are responsible for reviewing every change, keeping backups, and verifying any
-  generated output before using it.** The Software is provided "AS IS", with no
-  warranty, and the maintainer's liability is limited (see Sections 10–13).
-
----
-
-# 1. LICENSE GRANT
-
-Subject to compliance with this Agreement, Aefos grants you a limited, non-exclusive, non-transferable, non-sublicensable license to install and use the Software.
-
-The license granted under this Agreement is a license to use the Software and does not transfer ownership of the Software or any intellectual property rights.
-
----
-
-# 2. EDITIONS
-
-## 2.1 Community Edition
-
-The Community Edition may be used **free of charge** by:
-
-* Individual users
-* Educational institutions
-* Non-profit organizations
-* Commercial businesses and enterprises of any size
-* Government organizations
-
-**Internal commercial and business use is expressly permitted at no charge.** This
-includes installing and using the Community Edition across your organization, by an
-unlimited number of employees, contractors, and seats, for internal software
-development, evaluation, and production work.
-
-No fee, subscription, registration, headcount limit, organization-size limit, or
-usage penalty is imposed on Community Edition internal use. Aefos will not charge,
-audit-penalize, or otherwise restrict a company solely because it is a commercial or
-enterprise entity using the Community Edition for its own internal purposes.
-
-The Community Edition license is **perpetual for the version you install** and does
-not expire so long as you comply with this Agreement.
-
-## 2.2 Pro Edition
-
-The Pro Edition is available through a paid subscription and may include additional features, tools, integrations, models, automation capabilities, support, or usage limits.
-
-**Right of withdrawal (Brazilian consumers).** Where you purchase a paid Edition online as a consumer ("consumidor") and the Brazilian Consumer Protection Code (Law No. 8.078/1990, "CDC") applies, you may withdraw from the purchase within **seven (7) days** of the contract date or receipt of the license, as provided in Article 49 of the CDC, and receive a refund of amounts paid. To exercise this right, contact us at the address in Section 20; the refund follows the procedure of the payment provider used at checkout. This right is in addition to, and does not limit, any other refund terms offered.
-
-## 2.3 Enterprise Edition
-
-The Enterprise Edition is licensed under a separate commercial agreement and may include enterprise-specific functionality, support, deployment options, compliance features, and custom licensing terms.
-
----
-
-# 3. PERMITTED USE
-
-You may:
-
-* Use the Software for personal purposes.
-* Use the Software for educational purposes.
-* Use the Software within commercial organizations and enterprises, for internal business purposes, by an unlimited number of users and seats (Community Edition, at no charge).
-* Use the Software to develop commercial software, products, or services.
-* Use outputs generated by the Software for commercial purposes.
-* Create extensions, integrations, scripts, and workflows that interact with the Software through supported mechanisms.
-
-Ownership of any code, documentation, content, or other outputs generated through your use of the Software remains with you, subject to applicable third-party model, API, or service terms.
-
----
-
-# 4. RESTRICTIONS
-
-Unless expressly authorized in writing by Aefos, you may not:
-
-* Sell, rent, lease, sublicense, distribute, or transfer the Software.
-* Redistribute Software binaries.
-* Offer the Software as a hosted, managed, cloud, SaaS, or competing service.
-* Modify, repackage, or rebrand the Software for redistribution.
-* Remove or alter copyright, trademark, licensing, or attribution notices.
-* Circumvent licensing, subscription, activation, security, or usage controls.
-* Use the Software to create a competing AI development platform, IDE assistant, agent framework, or substantially similar commercial product derived from the Software.
-* Reverse engineer, decompile, disassemble, or attempt to derive source code except where such restriction is prohibited by applicable law.
-
----
-
-# 5. INTELLECTUAL PROPERTY
-
-The Software is licensed, not sold.
-
-Aefos and its licensors retain all right, title, and interest in and to the Software, including:
-
-* Source code
-* Binaries
-* User interfaces
-* Trademarks
-* Logos
-* Documentation
-* Agent systems
-* Workflows
-* Architecture
-* Proprietary technologies
-
-No rights are granted except those expressly stated in this Agreement.
-
----
-
-# 6. THIRD-PARTY SERVICES
-
-The Software may integrate with third-party services, including AI providers, APIs, cloud services, package registries, development tools, and external platforms.
-
-Your use of such services may be subject to separate terms, conditions, privacy policies, fees, or limitations imposed by the respective providers.
-
-Aefos is not responsible for third-party services or their availability.
-
----
-
-# 7. UPDATES
-
-Aefos may provide updates, patches, bug fixes, feature enhancements, security updates, or new versions.
-
-Certain updates may require an active subscription.
-
-Aefos is not obligated to provide updates for any specific period.
-
----
-
-# 8. TELEMETRY AND DIAGNOSTICS
-
-The Software may collect limited technical and diagnostic information necessary to:
-
-* Maintain service reliability
-* Improve product quality
-* Detect abuse
-* Enforce licensing
-* Diagnose software issues
-
-Such information does not intentionally include source code, proprietary business information, or user content unless explicitly authorized by the user.
-
-Data collection practices are governed by the Aefos Privacy Policy (see the
-`PRIVACY.md` file distributed with the Software) and by applicable data-protection
-law, including the Brazilian General Data Protection Law (Lei nº 13.709/2018 —
-"LGPD").
-
----
-
-# 9. OPEN SOURCE COMPONENTS
-
-The Software may include or interact with open-source and other third-party
-software components.
-
-Such components remain subject to their respective licenses, which are reproduced in
-full in the `THIRD-PARTY-NOTICES.txt` file distributed with the Software.
-
-Nothing in this Agreement limits rights granted under those applicable third-party or
-open-source licenses.
-
----
-
-# 10. DISCLAIMER OF WARRANTIES
-
-THE SOFTWARE IS PROVIDED "AS IS" AND "AS AVAILABLE."
-
-TO THE MAXIMUM EXTENT PERMITTED BY LAW, AEFOS DISCLAIMS ALL WARRANTIES, WHETHER EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, INCLUDING WARRANTIES OF:
-
-* MERCHANTABILITY
-* FITNESS FOR A PARTICULAR PURPOSE
-* NON-INFRINGEMENT
-* ACCURACY
-* RELIABILITY
-* AVAILABILITY
-
-AEFOS DOES NOT WARRANT THAT THE SOFTWARE WILL OPERATE WITHOUT INTERRUPTION OR ERROR.
-
-AEFOS DOES NOT AUTHOR, CONTROL, OR ENDORSE, AND DOES NOT WARRANT THE ACCURACY, SECURITY, LEGALITY, NON-INFRINGEMENT, OR FITNESS OF, ANY CODE, TEXT, OR OTHER OUTPUT GENERATED BY OR THROUGH THE SOFTWARE OR BY ANY THIRD-PARTY AI MODEL, AGENT, OR COMMAND-LINE TOOL THAT THE SOFTWARE INVOKES. ALL SUCH OUTPUT MUST BE REVIEWED AND VALIDATED BY YOU BEFORE USE.
-
-PRE-RELEASE, BETA, "COMMUNITY", AND SIMILAR EVALUATION BUILDS MAY CONTAIN DEFECTS AND ARE PROVIDED WITHOUT ANY SERVICE-LEVEL COMMITMENT, SUPPORT OBLIGATION, OR WARRANTY, AND MAY BE CHANGED, SUSPENDED, OR DISCONTINUED AT ANY TIME WITHOUT LIABILITY.
-
----
-
-# 11. LIMITATION OF LIABILITY
-
-TO THE MAXIMUM EXTENT PERMITTED BY LAW, AEFOS SHALL NOT BE LIABLE FOR:
-
-* INDIRECT DAMAGES
-* INCIDENTAL DAMAGES
-* SPECIAL DAMAGES
-* CONSEQUENTIAL DAMAGES
-* LOSS OF PROFITS
-* LOSS OF REVENUE
-* LOSS OF BUSINESS
-* LOSS OF DATA
-* BUSINESS INTERRUPTION
-
-IN NO EVENT SHALL AEFOS'S TOTAL LIABILITY EXCEED THE AMOUNT PAID BY THE CUSTOMER FOR THE SOFTWARE DURING THE TWELVE (12) MONTHS PRECEDING THE CLAIM.
-
-IF NO FEES WERE PAID, AEFOS'S TOTAL LIABILITY SHALL NOT EXCEED ONE HUNDRED U.S. DOLLARS (USD $100).
-
-The limitations and exclusions in this Section and in Section 10 apply only to the extent permitted by applicable law. Where you use the Software as a consumer ("consumidor") and the Brazilian Consumer Protection Code (Law No. 8.078/1990) applies, nothing in this Agreement excludes or limits liability that, under that Code, cannot lawfully be excluded or limited.
-
----
-
-# 12. ASSUMPTION OF RISK; AI AND AGENT FEATURES; USER RESPONSIBILITY
-
-The Software includes autonomous, agent-based, and AI-assisted features that can, at your direction or on your behalf, read, generate, modify, move, rename, and delete source code and files; change project, editor, and IDE state; and execute build, run, version-control, shell, and command-line operations — including by delegating to third-party AI command-line tools and models that **you** select and configure. The Software is a harness: it bundles no AI model and manages no credentials, and the substantive output is produced by those third-party tools.
-
-You acknowledge and agree that:
-
-* These capabilities carry **inherent risk**, including the risk of unintended code changes, data loss, build or runtime failures, security vulnerabilities, and incorrect, insecure, or infringing output.
-* **You are solely responsible** for supervising and reviewing every action and output of the Software before accepting it (for example, through the inline change-review/consent mechanisms the Software provides), for maintaining adequate backups and version control, and for independently verifying the correctness, security, legality, and fitness of any result before relying on it or using it in production.
-* You are solely responsible for your use of the Software, for complying with all applicable laws and with the terms of any third-party tool, model, or service you use with it, and for ensuring you have the rights to any code, data, or content you process with it.
-* **You use the Software at your own risk.**
-
-To the maximum extent permitted by applicable law, Aefos is not responsible or liable for any code change, deletion, data loss, build or runtime effect, security issue, third-party output, or other result arising from your use of these features or from any third-party AI tool, model, or service.
-
----
-
-# 13. INDEMNIFICATION
-
-To the maximum extent permitted by applicable law, you agree to defend, indemnify, and hold harmless Aefos and its maintainer(s), contributors, officers, agents, and licensors (the "Indemnified Parties") from and against any and all third-party claims, demands, actions, proceedings, damages, losses, liabilities, fines, costs, and expenses (including reasonable attorneys' fees and legal costs) arising out of or related to:
-
-* (a) your use, misuse, or inability to use the Software;
-* (b) your violation of this Agreement or of any applicable law, regulation, or sanction;
-* (c) your violation or infringement of any third-party right, including intellectual property, personality, privacy, or data-protection rights;
-* (d) any code, data, content, or output you create, modify, process, distribute, or deploy using the Software; and
-* (e) your use of any third-party AI tool, model, service, or command-line interface in connection with the Software.
-
-The Indemnified Parties may, at their option and expense, participate in the defense of any such claim with counsel of their choosing. This Section does not apply to the extent a claim results from the Indemnified Parties' own willful misconduct, and, where you act as a consumer ("consumidor") and the Brazilian Consumer Protection Code (Law No. 8.078/1990) applies, it applies only to the extent permitted by that Code.
-
----
-
-# 14. TERMINATION
-
-This Agreement automatically terminates if you violate its terms.
-
-Upon termination, you must cease all use of the Software and destroy all copies in your possession or control.
-
-Sections relating to intellectual property, assumption of risk and user responsibility, indemnification, disclaimers, liability limitations, and governing law shall survive termination.
-
----
-
-# 15. EXPORT CONTROL AND SANCTIONS
-
-The Software may be subject to export control and economic sanctions laws, including those of Brazil, the United States, and other applicable jurisdictions. You agree to comply with all such export, re-export, import, and sanctions laws and regulations.
-
-You represent and warrant that: (a) you are not located in, organized under the laws of, or ordinarily resident in any country or territory subject to comprehensive governmental or international sanctions; (b) you are not identified on, and are not owned or controlled by or acting on behalf of any person identified on, any applicable list of restricted or prohibited parties; and (c) you will not use, export, re-export, or provide the Software for any prohibited end use, including any use related to the development of nuclear, chemical, or biological weapons, missile technology, or any prohibited military end use.
-
----
-
-# 16. FEEDBACK
-
-If you provide Aefos with any ideas, suggestions, enhancement requests, bug reports, code contributions, or other feedback regarding the Software ("Feedback"), you grant Aefos a worldwide, perpetual, irrevocable, royalty-free, fully paid-up, transferable, and sublicensable license to use, reproduce, modify, exploit, and incorporate that Feedback into the Software and into any Aefos product or documentation, for any purpose and without obligation or compensation to you. You are not required to provide Feedback, and you should not provide Feedback you are not authorized to share.
-
----
-
-# 17. GOVERNING LAW; JURISDICTION; WAIVERS
-
-This Agreement shall be governed by and construed in accordance with the laws of the Federative Republic of Brazil, without regard to conflict-of-law principles, including, where applicable, Law No. 9.609/1998 (Software Law), Law No. 9.610/1998 (Copyright Law), Law No. 12.965/2014 (Internet Civil Framework), and Law No. 13.709/2018 (LGPD). The United Nations Convention on Contracts for the International Sale of Goods does not apply to this Agreement.
-
-The parties elect the courts of the Judicial District (Comarca) of Aracruz, State of Espírito Santo, Brazil, as the exclusive venue for any dispute arising from or relating to this Agreement, and each party irrevocably submits to that jurisdiction and waives any objection of inconvenient forum — **except** where applicable mandatory law (including the Brazilian Consumer Protection Code, Law No. 8.078/1990, "CDC") requires a different venue (such as the consumer's domicile), in which case that mandatory venue prevails.
-
-To the maximum extent permitted by applicable law, any dispute shall be resolved on an individual basis only, and you waive any right to bring or participate in a class, collective, or representative action. This waiver does not apply where, and only to the extent that, applicable mandatory law (including the CDC and the Brazilian rules governing collective actions) does not permit it.
-
-This Agreement is drafted in English, which is the controlling language; any translation is provided for convenience only. Nothing in this Agreement limits any non-waivable right or remedy granted to you by applicable law, including the acts a lawful licensee may perform under Article 6 of Law No. 9.609/1998 regardless of any contractual restriction.
-
----
-
-# 18. GENERAL PROVISIONS
-
-**Entire Agreement.** This Agreement — together with the `PRIVACY.md` and `THIRD-PARTY-NOTICES.txt` files distributed with the Software and any applicable Pro/Enterprise order — is the entire agreement between you and Aefos regarding the Software and supersedes all prior or contemporaneous understandings on that subject.
-
-**Severability.** If any provision of this Agreement is held invalid or unenforceable, that provision will be limited or severed to the minimum extent necessary, and the remaining provisions will remain in full force and effect.
-
-**No Waiver.** Aefos's failure to enforce any right or provision of this Agreement is not a waiver of that right or provision.
-
-**Assignment.** You may not assign or transfer this Agreement or any rights under it, by operation of law or otherwise, without Aefos's prior written consent; any attempted assignment in violation of this Section is void. Aefos may freely assign or transfer this Agreement.
-
-**Force Majeure.** Aefos is not liable for any delay or failure to perform resulting from causes beyond its reasonable control.
-
-**No Agency.** Nothing in this Agreement creates any partnership, joint venture, agency, fiduciary, or employment relationship between the parties.
-
-**Notices.** Legal notices to Aefos must be sent to the contact in Section 20.
-
-**Headings.** Section headings are for convenience only and do not affect interpretation.
-
-**Survival.** Provisions that by their nature should survive termination — including Sections 5, 10, 11, 12, 13, 16, 17, and 18 — survive any expiration or termination of this Agreement.
-
----
-
-# 19. CHANGES TO THIS AGREEMENT
-
-Aefos may modify this Agreement from time to time.
-
-Updated versions will be published through official distribution channels.
-
-Continued use of the Software after publication of an updated Agreement constitutes acceptance of the revised terms, to the extent permitted by applicable law.
-
-For **material changes that adversely affect a paying subscriber**, Aefos will give reasonable prior notice (e.g. by e-mail or in-product notice) before the change takes effect, and the subscriber may decline by terminating the paid subscription and receiving a pro-rata refund of the unused, prepaid period.
-
----
-
-# 20. CONTACT
-
-For licensing, legal, partnership, or compliance inquiries:
-
-**Aefos AI** — a product of **Isaque de Souza Pinheiro** (Empresário Individual / ME)
-CNPJ: **02.565.249/0001-70**
-Address: **Av. Aurélio Alvarenga, 33-A, Guaraná, Aracruz – ES, Brazil, CEP 29.195-421**
-
-Email: [tecsisinfo.com.br@gmail.com](mailto:tecsisinfo.com.br@gmail.com)
-
-Official distribution channel: https://www.pubpascal.dev
-
----
-
-By installing, accessing, or using Aefos AI Community, Pro, or Enterprise Edition, you acknowledge that you have read, understood, and agree to be bound by this Agreement.
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   - Replace https://moderndelphiworks.github.io/Aefos/ with the GitHub Pages / custom-domain URL (e.g. https://aefos.pubpascal.dev)
   - Replace <REPO_URL> with https://github.com/ModernDelphiWorks/Aefos
   - Releases link assumes this repo hosts the installer as a Release asset.
-  This is the PUBLIC repo (downloads + manual + issues). The source code is private.
+  This is the PUBLIC repo: source code, downloads, the manual and the issue tracker.
 -->
 <div align="center">
 
@@ -18,7 +18,7 @@ already use (Claude Code, Codex, GitHub Copilot CLI, Gemini).
 
 [![Version](https://img.shields.io/badge/version-0.23.0--beta-orange)](CHANGELOG.md)
 [![Platform](https://img.shields.io/badge/platform-Windows-0078D6)](#requirements)
-[![License](https://img.shields.io/badge/license-EULA%20%E2%80%94%20Community%20free-blue)](LICENSE)
+[![License](https://img.shields.io/badge/license-GPL%20v3-blue)](LICENSE)
 [![CRA-ready](https://img.shields.io/badge/CRA--ready-SBOM%20%2B%20Security%20policy-success)](https://www.pubpascal.dev/packages/aefos)
 
 [⬇️ Download](../../releases) · [📖 User Manual](https://moderndelphiworks.github.io/Aefos/) · [🐛 Report a bug](../../issues/new/choose) · [🔒 Security](SECURITY.md)
@@ -27,9 +27,9 @@ already use (Claude Code, Codex, GitHub Copilot CLI, Gemini).
 
 </div>
 
-> **This is the public home of Aefos AI** — downloads, the user manual, and the issue
-> tracker. The product source code is private; this repository hosts the things users
-> need.
+> **This is the public home of Aefos AI** — the source code, downloads, the user
+> manual, and the issue tracker. Aefos AI is **free software under the GNU GPL v3**
+> (since 5 August 2026).
 
 ## What it is
 
@@ -107,6 +107,17 @@ The Chat talks to the AI CLI you already use. Point Aefos at it once:
 3. Open **View → Aefos AI (Chat)** and start typing.
 
 ## License & activation
+
+**The software is free software under the [GNU GPL v3](LICENSE)**, with two
+additional permissions granted under GPLv3 section 7 (see
+[`ADDITIONAL-PERMISSIONS.md`](ADDITIONAL-PERMISSIONS.md)): the code Aefos writes
+for you is **yours**, under any licence you choose, and linking with the RAD Studio
+libraries a design-time package cannot exist without is expressly allowed. The
+licence that governed the software before 5 August 2026 is kept, for the record,
+in [`EULA-historical.md`](EULA-historical.md).
+
+A **license key** buys the hosted service around the software, not the software
+itself.
 
 **The Community edition is free — no license key required.** Install it and use the
 Chat (including **Agent mode**) right away. Community is free for **personal,

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -11,7 +11,7 @@ que você já usa (Claude Code, Codex, GitHub Copilot CLI, Gemini).
 
 [![Versão](https://img.shields.io/badge/vers%C3%A3o-0.17.0--beta-orange)](CHANGELOG.md)
 [![Plataforma](https://img.shields.io/badge/plataforma-Windows-0078D6)](#requisitos)
-[![Licença](https://img.shields.io/badge/licen%C3%A7a-EULA%20%E2%80%94%20Community%20gr%C3%A1tis-blue)](LICENSE)
+[![Licença](https://img.shields.io/badge/licen%C3%A7a-GPL%20v3-blue)](LICENSE)
 [![CRA-ready](https://img.shields.io/badge/CRA--ready-SBOM%20%2B%20Pol%C3%ADtica%20de%20Seguran%C3%A7a-success)](https://www.pubpascal.dev/packages/aefos)
 
 [⬇️ Download](../../releases) · [📖 Manual do Usuário](https://moderndelphiworks.github.io/Aefos/) · [🐛 Reportar bug](../../issues/new/choose) · [🔒 Segurança](SECURITY.md)
@@ -20,9 +20,9 @@ que você já usa (Claude Code, Codex, GitHub Copilot CLI, Gemini).
 
 </div>
 
-> **Esta é a casa pública do Aefos AI** — downloads, manual do usuário e abertura de
-> issues. O código-fonte do produto é privado; este repositório hospeda o que os
-> usuários precisam.
+> **Esta é a casa pública do Aefos AI** — o código-fonte, downloads, manual
+> do usuário e abertura de issues. O Aefos AI é **software livre sob a GNU GPL
+> v3** (desde 5 de agosto de 2026).
 
 ## O que é
 
@@ -100,7 +100,11 @@ Passos completos no [manual](https://moderndelphiworks.github.io/Aefos/).
 
 ## Privacidade e licença
 
-- 📄 [EULA](LICENSE) — proprietária; edição Community grátis (incl. uso empresarial interno).
+- 📄 [GNU GPL v3](LICENSE) — software livre, com duas permissões adicionais
+  da §7 ([ADDITIONAL-PERMISSIONS.md](ADDITIONAL-PERMISSIONS.md)): o código que o
+  Aefos gera é **seu**, sob qualquer licença, e a linkagem com as bibliotecas do
+  RAD Studio é expressamente permitida. A licença anterior fica como registro
+  em [EULA-historical.md](EULA-historical.md).
 - 🔐 [Política de Privacidade](PRIVACY.pt-BR.md) ([EN](PRIVACY.md)) — alinhada à LGPD.
 
 ---

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -75,6 +75,56 @@ Passos completos no [manual](https://moderndelphiworks.github.io/Aefos/).
 | CLI de IA | Pelo menos uma: Claude Code / Codex / GitHub Copilot CLI / Gemini (traga a sua) |
 | Markdown rico (opcional) | [Runtime do WebView2](https://aka.ms/webview2) |
 
+## Licença e ativação
+
+**O software é software livre sob a [GNU GPL v3](LICENSE)**, com duas permissões
+adicionais concedidas pela seção 7 da GPLv3 (veja
+[`ADDITIONAL-PERMISSIONS.md`](ADDITIONAL-PERMISSIONS.md)): o código que o Aefos escreve
+para você é **seu**, sob qualquer licença que você escolher, e a linkagem com as
+bibliotecas do RAD Studio — sem as quais um pacote design-time não pode existir —
+é expressamente permitida. A licença que governava o software antes de 5 de agosto
+de 2026 fica registrada em [`EULA-historical.md`](EULA-historical.md).
+
+Uma **chave de licença** compra o serviço hospedado em volta do software, não o
+software em si.
+
+**A edição Community é grátis — nenhuma chave necessária.** Instale e use o Chat
+(incluindo o **modo Agent**) na hora. A Community é grátis para uso **pessoal,
+educacional e empresarial interno** — sem taxa por assento, sem limite de usuários,
+sem pegadinha.
+
+**Pro / Enterprise** liberam o Terminal, configuração automática de MCP, assistentes,
+histórico de sessões e contexto avançado. Para ativar uma chave:
+
+1. Abra **View → Aefos AI (Chat)** e clique no **item de licença** no topo — ele mostra
+   seu status atual (ex.: *License: Trial* ou *License: active*).
+2. Cole sua **chave de licença**.
+3. Pronto — isso vincula **esta cópia do Delphi** ao seu assento. O status passa a
+   *active*.
+
+**Como a licença funciona:**
+- **Uma chave = um Delphi ativo** por máquina/usuário (assento único, node-locked).
+- **Funciona offline:** após a primeira validação online, continua funcionando
+  **sem internet** dentro de uma janela de tolerância.
+- **Sem chave?** Um **período de avaliação** embutido deixa você testar os recursos Pro.
+
+## Atualizar, reinstalar e mudar de máquina
+
+Esta é a parte que mais gera dúvida — leia antes de desinstalar.
+
+| Situação | O que fazer | O que acontece com sua licença |
+|-----------|-------------|--------------------------------|
+| **Atualizar para uma versão nova** (mesma máquina) | Feche o RAD Studio e rode o novo `Aefos-Setup-*.exe` **por cima** do antigo | ✅ **Preservada** — você **não** redigita a chave nem desativa |
+| **Reinstalar** (mesma máquina) | Igual acima — é só rodar o instalador de novo | ✅ **Preservada** (a ativação está ligada a esta máquina) |
+| **Mudar de máquina** | **Desative primeiro** na antiga: **View → Aefos AI (Chat) → item de licença → Deactivate**. Depois instale na nova e ative a chave lá. | 🔄 O assento é **liberado e reutilizado** na nova máquina (transferência por você mesmo) |
+| **Desinstalar de vez** | Use **Configurações → Aplicativos** do Windows (ou o desinstalador). Se pretende usar a chave em outro lugar, **desative antes** (acima) | ⚠️ Desinstalar sozinho **não** libera o assento — **desative** para liberá-lo |
+
+> ⚠️ **Ponto-chave:** desinstalar e reinstalar na **mesma** máquina mantém sua
+> licença. Só **mudar de máquina** exige **Deactivate** antes, para o assento único
+> ficar livre para ativar em outro lugar. (A Community não precisa de nada disso.)
+
+Passo a passo completo no [Manual do Usuário](https://moderndelphiworks.github.io/Aefos/).
+
 ## Edições
 
 | Edição | Preço | Para quem |

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,142 @@
+﻿# Aefos AI — Third-Party Components and GPLv3 Compatibility
+
+Aefos AI is licensed under the **GNU General Public License version 3** (see
+[`LICENSE`](LICENSE)) with the additional permissions in
+[`ADDITIONAL-PERMISSIONS.md`](ADDITIONAL-PERMISSIONS.md).
+
+This file is the **inventory and compatibility assessment** of everything Aefos
+vendors, embeds, links or ships. The **full verbatim licence texts** remain in
+[`THIRD-PARTY-NOTICES.txt`](THIRD-PARTY-NOTICES.txt), which is the file the
+distributed product carries; that file is unchanged and is not superseded by
+this one.
+
+**Reviewed:** August 2026, against the tracked tree.
+**Verdict:** **No GPLv3-incompatible component found.** One item (the bundled
+font) is compatible but rests on a reading worth a lawyer's confirmation — see
+§3.
+
+---
+
+## 1. Vendored source — compiled into the product
+
+| # | Component | Version / pin | Licence | Where | GPLv3 |
+|---|-----------|---------------|---------|-------|-------|
+| 1 | **libvterm** | commit `934bc2fbf21800ac3458a499df8820ca5fb45fd3` | **MIT** | `source/terminal/ThirdParty/libvterm/` (`LICENSE` present) | ✅ Compatible — permissive, one-way into GPL |
+| 2 | **SQLite** (amalgamation) | 3.46.1 | **Public domain** | `source/data/ThirdParty/sqlite/` (no `LICENSE` file; provenance in `UPSTREAM.txt`, sha256-pinned) | ✅ Compatible — no restrictions to conflict with |
+
+**Note on SQLite:** it has no licence *file* in the vendored directory. This is
+not a "missing licence" risk — SQLite is explicitly dedicated to the public
+domain by its authors (<https://www.sqlite.org/copyright.html>), and the
+directory records the exact upstream ZIP and its sha256. Public-domain code can
+be incorporated into a GPL work without any conflict.
+
+## 2. Vendored JavaScript / CSS — embedded as string constants in the Chat WebView
+
+| # | Component | Version | Licence | Where | GPLv3 |
+|---|-----------|---------|---------|-------|-------|
+| 3 | **marked** | 14.1.4 | **MIT** | `meta/chat/vendor/marked/` (`LICENSE` present) | ✅ Compatible |
+| 4 | **Markdown** (John Gruber, syntax description shipped inside marked's `LICENSE`) | — | **BSD 3-Clause** | `meta/chat/vendor/marked/LICENSE` | ✅ Compatible — **3**-clause, no advertising clause |
+| 5 | **highlight.js** | 11.11.1 | **BSD 3-Clause** | `meta/chat/vendor/highlight/` (`LICENSE` present) | ✅ Compatible — **3**-clause, no advertising clause |
+
+Both BSD notices were read in full and confirmed to be the **3-clause** form.
+Neither contains the GPL-incompatible **4-clause "advertising"** term ("All
+advertising materials mentioning features or use of this software must
+display…"). That was the specific hazard to check, and it is absent.
+
+## 3. Bundled binary assets
+
+| # | Component | Licence | Where | GPLv3 |
+|---|-----------|---------|-------|-------|
+| 6 | **CaskaydiaCove Nerd Font Mono** (Nerd Fonts patch of Microsoft **Cascadia Code**) | **SIL Open Font License 1.1** | `packages/Delphi/CaskaydiaCoveNerdFontMono-Regular.ttf`, compiled into `Aefos.OTA.TerminalFont.RES` | ⚠️ Compatible, with a caveat — see below |
+
+The OFL 1.1 is a free copyleft licence for *fonts*. It says the Font Software
+"must be distributed entirely under this license, and must not be distributed
+under any other license" — but it **expressly permits** bundling and embedding:
+*"Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy contains
+the above copyright notice and this license."* Aefos satisfies that condition by
+shipping the full OFL text in `THIRD-PARTY-NOTICES.txt`.
+
+**The caveat, stated honestly:** the font is not merely shipped alongside the
+binary — it is compiled into a Windows resource (`.RES`) and linked into the
+Terminal BPL. That is still "bundled/embedded" in the plain sense the OFL
+permits, and the font remains font *data*, not linked code, so the usual
+analysis is that this is aggregation and no GPL conflict arises. This is how
+GNU/Linux distributions have shipped OFL fonts with GPL software for years.
+**It is not a blocker.** But it is the one line in this inventory that rests on
+an interpretation rather than on an explicit grant, so if the relicense is
+reviewed by counsel, this is the item to point at. The zero-risk alternative is
+to stop embedding the font and fall back to a system font, which is a code
+change, not a licensing one.
+
+*Reserved Font Names:* "Cascadia Code" and "Cascadia Mono" are reserved under
+the OFL. Aefos ships the font unmodified under the Nerd Fonts name, so the
+reserved-name restriction is not triggered.
+
+## 4. Not redistributed — linked or invoked at runtime
+
+These are **not** shipped by Aefos. They live on the user's machine under the
+user's own licence. They are the reason
+[`ADDITIONAL-PERMISSIONS.md`](ADDITIONAL-PERMISSIONS.md) §2 exists.
+
+| Component | Licence | Relationship | GPLv3 |
+|-----------|---------|--------------|-------|
+| **Embarcadero RAD Studio** runtime + design-time (`rtl`, `vcl`, `vclie`, `designide`, `ToolsAPI`, `FireDAC`, …) | Proprietary (Embarcadero EULA) | **Linked.** A design-time `.bpl` cannot exist without `designide`. | ✅ Resolved by the **linking exception** — `ADDITIONAL-PERMISSIONS.md` §2 |
+| **Microsoft Edge WebView2 Runtime** | Proprietary (Microsoft) | Hosted/called; detected, never redistributed | ✅ Resolved by the same exception; also arguably a GPLv3 §1 **System Library** |
+| **Lazarus / Free Pascal (LCL, RTL)** — Lazarus edition | **modified LGPL** / LGPL with static-linking exception | Linked | ✅ Compatible — designed to be linkable from any licence |
+| **User-supplied AI CLIs** (Claude Code, Codex, Copilot CLI, Gemini) | Each vendor's own | Spawned as a **separate process** over stdin/stdout | ✅ Separate programs at arm's length — no combined work, no GPL reach |
+
+## 5. Shipped by the installer as separate programs
+
+The Windows installer may stage independent CLI executables next to Aefos. They
+are **aggregation on a distribution medium** (GPLv3 §5, final paragraph), not a
+combined work — each stays under its own licence and none of them place any
+obligation on Aefos, nor Aefos on them.
+
+| Component | Licence | GPLv3 |
+|-----------|---------|-------|
+| **Codex CLI** (`openai/codex`) | **Apache-2.0** | ✅ Compatible with GPLv3 (one-way, Apache-2.0 → GPLv3) |
+| **Gemini CLI** (`google-gemini/gemini-cli`) | **Apache-2.0** | ✅ Compatible with GPLv3 |
+| **Claude Code** | Proprietary | Not bundled — detect-only, by design |
+| **GitHub Copilot CLI** | Proprietary | Not bundled — its licence forbids repackaging |
+
+Attribution for whatever is actually staged is generated at build time into
+`redist/cli/THIRD-PARTY-LICENSES.txt` by `installer/fetch-clis.ps1`.
+
+---
+
+## 6. What was checked for, and not found
+
+The following licence families are **incompatible with GPLv3**. Every vendored
+component above was checked against this list. **None matched:**
+
+- ❌ **4-clause BSD** (the "advertising clause" — the original BSD) — not present;
+  both BSD notices in the tree are the 3-clause form.
+- ❌ **CDDL** — not present.
+- ❌ **EPL** (1.0 or 2.0) — not present.
+- ❌ **SSPL** — not present.
+- ❌ **"Non-commercial use only" / "no derivatives" / research-only** — not present.
+- ❌ **Code with no licence file and no traceable provenance** — not present. The
+  only vendored directory without a `LICENSE` file is SQLite, whose public-domain
+  status and exact upstream artefact are documented and hash-pinned in
+  `source/data/ThirdParty/sqlite/UPSTREAM.txt`.
+
+Also worth recording, though outside the shipped product:
+`poc/WebViewDock/Windows10Dark.vsf` is an **Embarcadero VCL style** file living
+in the proof-of-concept tree. It is not part of any shipped package, but it is
+an Embarcadero asset sitting in a repository that is about to become public.
+Removing it, or confirming it may be redistributed, is a small follow-up.
+
+---
+
+## 7. Limits of this assessment
+
+This inventory was produced by reading the licence files present in the tree and
+the provenance metadata beside each vendored component. It is **not a legal
+opinion**, and it was not written by a lawyer. It covers the components **that
+are in the tracked tree**; a build machine may pull further dependencies at
+build time (see `installer/fetch-clis.ps1`) that are outside its scope. Before
+the relicense is announced publicly, it is worth having counsel confirm §3 and
+skim §4.
+
+To report an omission or correction, contact tecsisinfo.com.br@gmail.com.


### PR DESCRIPTION
Until today this repository told the world **the opposite of what it now is**: the file called `LICENSE` was the proprietary EULA, and the README said in six places that the source code is private.

## The licence is replaced, not amended

`LICENSE` is now the **GNU GPL v3**, verbatim — byte-identical to the copy in the source tree.

Beside it, `ADDITIONAL-PERMISSIONS.md` carries the two grants under **GPLv3 §7** that make this workable at all:

- **the code Aefos writes for you is yours**, under any licence you choose, including a proprietary one. A tool that *compiles* your code must not make your code unfree; the same goes for a tool that *writes* it.
- **linking with Embarcadero's RAD Studio libraries is expressly permitted.** A design-time `.bpl` cannot exist without `designide`, which is not GPL-compatible — without this permission every build ever shipped would violate its own licence.

## The history is kept

The old EULA lives on as **`EULA-historical.md`**, with a header stating exactly what it is: the agreement that governed the software **until 2026-08-05**, and nothing more. History, not a second licence.

> Named that way on purpose: GitHub matches `LICENSE*` and would open a second "License" tab for it.

## The vitrine follows

A storefront that contradicts its own `LICENSE` is worse than one that says nothing. Updated: the badge, the *"source code is private"* sentences in **both** READMEs, and the licence section — which now separates the **software** (GPL, free) from the **service** (a licence key buys the hosted backend and support, not the software).

## And the Portuguese README was two sections short

Not a feeling — a count: 12 sections in English, 10 in Portuguese. The two missing were **License & activation** and **Updating, reinstalling & moving to another machine** — exactly where support questions come from. Both are translated now; 12 each.

The rule this settles: the **storefront and the user manual stay bilingual**, because the audience that installs this is Brazilian; the **technical docs and the source tree are English only**, because contributors are not.

## What did not change

The hosted services are **not** covered by the GPL, and **releases keep coming from this repository**. The CHANGELOG says so under `[Unreleased] → Licence`.

---

Next, in a separate change: the source tree itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)