### PR TITLE
Retire the last four documents that still speak as an EULA

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,9 @@
+# Renders the "Sponsor" button at the top of the repository page.
+#
+# `custom` takes a list, so more destinations can be added later WITHOUT
+# replacing this one -- a Pix key for Brazilian donors (no intermediary fee) and
+# `github: [isaquepinheiro]` once GitHub Sponsors is enabled on the account.
+# Sponsors is the one that matters for companies: it invoices them, and a company
+# cannot put a personal payment link through its accounts payable.
+custom:
+  - https://link.mercadopago.com.br/aefosai

--- a/ADDITIONAL-PERMISSIONS.md
+++ b/ADDITIONAL-PERMISSIONS.md
@@ -129,10 +129,6 @@ backups, and validating any generated output before you rely on it.**
 
 * **Third-party components** bundled with or vendored into Aefos keep their own
   licences. See [`THIRD-PARTY-NOTICES.md`](THIRD-PARTY-NOTICES.md).
-* **The hosted commercial services** — the licence-key backend, activation, the
-  Pro and Enterprise subscriptions, and paid support — are *services*, not the
-  software. They have their own terms, provided with the service. Nothing in them
-  restricts your rights in the GPL-licensed software.
 * This document is not legal advice and its authors are not lawyers. If you need
   certainty for a commercial deployment, have your own counsel read it.
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ not.
 
 ## Privacy & license
 
-- 📄 [EULA](LICENSE) — proprietary; Community edition free (incl. internal business use).
+- 📜 [License](LICENSE) — GNU GPL v3, with [additional permissions](ADDITIONAL-PERMISSIONS.md).
 - 🔐 [Privacy Policy](PRIVACY.md) ([PT-BR](PRIVACY.pt-BR.md)) — LGPD-aligned.
 
 ---

--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ transfer.
 
 Full walkthrough in the [User Manual](https://moderndelphiworks.github.io/Aefos/).
 
+## Supporting the project
+
+Aefos is free software and stays that way — there is no paid tier to upgrade to.
+What keeps it moving is the AI subscriptions its own development runs on, and
+those are paid by one person.
+
+If Aefos saves you time, the **Sponsor** button at the top of this page is the way
+to help. Companies: sponsorship is invoiceable, a personal payment link usually is
+not.
+
 ## Reporting bugs & requests
 
 - 🐛 **[Open an issue](../../issues/new/choose)** — please read the

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -99,6 +99,15 @@ preso a uma máquina, então não há o que desativar ou transferir.
 
 Passo a passo completo no [Manual do Usuário](https://moderndelphiworks.github.io/Aefos/).
 
+## Apoiando o projeto
+
+O Aefos é software livre e continua assim — não existe versão paga para onde
+migrar. O que mantém ele andando são as assinaturas de IA que o próprio
+desenvolvimento consome, e elas saem do bolso de uma pessoa só.
+
+Se o Aefos te poupa tempo, o botão **Sponsor** no topo desta página é o caminho.
+Empresas: patrocínio é faturável; link de pagamento pessoal, em geral, não.
+
 ## Reportar bugs e pedidos
 
 - 🐛 **[Abrir uma issue](../../issues/new/choose)** — leia antes os

--- a/TERMS-ISSUES.md
+++ b/TERMS-ISSUES.md
@@ -2,8 +2,8 @@
 
 These Submission Terms apply to everything you post in this repository — issues,
 comments, discussions, and pull requests (collectively, "Submissions"). They are
-separate from, and in addition to, the [Aefos AI EULA](LICENSE). **By posting a
-Submission, you accept these terms.**
+separate from, and in addition to, the [licence](LICENSE) the software is distributed
+under. **By posting a Submission, you accept these terms.**
 
 This repository is **public**. Anything you post is visible to everyone, is indexed by
 search engines, and may be cached or archived **permanently**, even if later edited or
@@ -35,8 +35,7 @@ By posting a Submission, you represent and warrant that:
 For any non-code Feedback (ideas, suggestions, bug reports, feature requests), you
 grant Aefos a worldwide, perpetual, irrevocable, royalty-free, transferable, and
 sublicensable license to use, reproduce, modify, and incorporate it into the Software
-and documentation, consistent with Section 16 (Feedback) of the [EULA](LICENSE),
-without obligation or compensation to you.
+and documentation, without obligation or compensation to you.
 
 For any code you contribute via pull request to this **public** repository (for
 example, documentation fixes), you license that contribution under the same terms as
@@ -51,8 +50,7 @@ any obligation to act on any request.
 ## 5. Indemnification
 
 To the maximum extent permitted by applicable law, you agree to hold Aefos harmless
-from claims arising out of your Submissions or your breach of these terms, consistent
-with Section 13 (Indemnification) of the [EULA](LICENSE).
+from claims arising out of your Submissions or your breach of these terms.
 
 ## 6. Security issues
 

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -2,11 +2,11 @@
  AEFOS AI — THIRD-PARTY NOTICES
 ===============================================================================
 
-The Aefos AI software ("Software") is proprietary and distributed in binary
-form. It includes, embeds, statically links, or otherwise incorporates the
-third-party components listed below. Each such component remains subject to its
-own license, reproduced in full in this file. Nothing in the Aefos AI End User
-License Agreement (EULA) limits the rights granted to you under these
+The Aefos AI software ("Software") is free software under the GNU General
+Public License version 3. It includes, embeds, statically links, or otherwise
+incorporates the third-party components listed below. Each such component
+remains subject to its own license, reproduced in full in this file. Nothing
+in Aefos AI's own licence limits the rights granted to you under these
 third-party licenses.
 
 Components NOT bundled (external dependencies the Software detects or invokes but
@@ -272,7 +272,7 @@ redistributed by Aefos AI. They remain governed solely by their own terms.
  * User-supplied AI command-line tools (e.g. Claude Code, Codex, GitHub Copilot
    CLI, Gemini) — bring-your-own. Not bundled; not credentialed. Your use of any
    such tool, and any content you send to it, is governed by that tool/provider's
-   own terms and privacy policy. See the Aefos AI EULA, Section 6.
+   own terms and privacy policy.
 
 -------------------------------------------------------------------------------
  To report an omission or correction in these notices, contact


### PR DESCRIPTION
The licence changed and the gate came out of the code, but four files at the root were never revisited — and they are the ones a visitor reads first.

| File | What it said |
|---|---|
| `README.md` | closing section still advertised **"EULA — proprietary; Community edition free"**, contradicting the License section eight lines above it |
| `TERMS-ISSUES.md` | drew its force from **EULA sections 13 and 16**, which no longer exist — the obligations now stand on their own wording instead of a dead cross-reference |
| `THIRD-PARTY-NOTICES.txt` | opened by declaring the Software **"proprietary and distributed in binary form"** — the opposite of what this repository is. It is the file the distributed product carries. |
| `ADDITIONAL-PERMISSIONS.md` | carved out **"hosted commercial services — the licence-key backend, activation, the Pro and Enterprise subscriptions, and paid support"**. None of those exist, and listing them invited the reader to go hunting for a paid tier. |

The EULA references that remain are deliberate: they point at `EULA-historical.md` and say the software **was** proprietary until 5 August 2026.

I swept every file at the root, not only these four. What the sweep still matches is correct: the "no key, no activation" statements in `PRIVACY.md` and `README.md`, the historical pointers, and Embarcadero's and Microsoft's own licences in the third-party notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)