### PR TITLE
Put the donation where someone would actually see it

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ already use (Claude Code, Codex, GitHub Copilot CLI, Gemini).
 [![Platform](https://img.shields.io/badge/platform-Windows-0078D6)](#requirements)
 [![License](https://img.shields.io/badge/license-GPL%20v3-blue)](LICENSE)
 [![CRA-ready](https://img.shields.io/badge/CRA--ready-SBOM%20%2B%20Security%20policy-success)](https://www.pubpascal.dev/packages/aefos)
+[![Support](https://img.shields.io/badge/support-donate-ff69b4)](https://link.mercadopago.com.br/aefosai)
 
-[⬇️ Download](../../releases) · [📖 User Manual](https://moderndelphiworks.github.io/Aefos/) · [🐛 Report a bug](../../issues/new/choose) · [🔒 Security](SECURITY.md)
+[⬇️ Download](../../releases) · [📖 User Manual](https://moderndelphiworks.github.io/Aefos/) · [🐛 Report a bug](../../issues/new/choose) · [🔒 Security](SECURITY.md) · [💙 Support Aefos](https://link.mercadopago.com.br/aefosai)
 
 **English** · [Português (PT-BR)](README.pt-BR.md)
 
@@ -132,13 +133,15 @@ Full walkthrough in the [User Manual](https://moderndelphiworks.github.io/Aefos/
 
 ## Supporting the project
 
-Aefos is free software and stays that way — there is no paid tier to upgrade to.
-What keeps it moving is the AI subscriptions its own development runs on, and
-those are paid by one person.
+Aefos is free software and stays that way — there is no paid tier to
+upgrade to. What keeps it moving is the AI subscriptions its own development
+runs on, and those are paid by one person.
 
-If Aefos saves you time, the **Sponsor** button at the top of this page is the way
-to help. Companies: sponsorship is invoiceable, a personal payment link usually is
-not.
+If Aefos saves you time, **[you can contribute here](https://link.mercadopago.com.br/aefosai)** — or use the
+**Sponsor** button at the top of this page.
+
+Companies: sponsorship is invoiceable, a personal payment link usually is not
+— if your accounts payable needs an invoice, say so and it will be sorted.
 
 ## Reporting bugs & requests
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -13,8 +13,9 @@ que você já usa (Claude Code, Codex, GitHub Copilot CLI, Gemini).
 [![Plataforma](https://img.shields.io/badge/plataforma-Windows-0078D6)](#requisitos)
 [![Licença](https://img.shields.io/badge/licen%C3%A7a-GPL%20v3-blue)](LICENSE)
 [![CRA-ready](https://img.shields.io/badge/CRA--ready-SBOM%20%2B%20Pol%C3%ADtica%20de%20Seguran%C3%A7a-success)](https://www.pubpascal.dev/packages/aefos)
+[![Support](https://img.shields.io/badge/support-donate-ff69b4)](https://link.mercadopago.com.br/aefosai)
 
-[⬇️ Download](../../releases) · [📖 Manual do Usuário](https://moderndelphiworks.github.io/Aefos/) · [🐛 Reportar bug](../../issues/new/choose) · [🔒 Segurança](SECURITY.md)
+[⬇️ Download](../../releases) · [📖 Manual do Usuário](https://moderndelphiworks.github.io/Aefos/) · [🐛 Reportar bug](../../issues/new/choose) · [🔒 Segurança](SECURITY.md) · [💙 Apoie o Aefos](https://link.mercadopago.com.br/aefosai)
 
 [English](README.md) · **Português (PT-BR)**
 
@@ -101,12 +102,15 @@ Passo a passo completo no [Manual do Usuário](https://moderndelphiworks.github.
 
 ## Apoiando o projeto
 
-O Aefos é software livre e continua assim — não existe versão paga para onde
-migrar. O que mantém ele andando são as assinaturas de IA que o próprio
+O Aefos é software livre e continua assim — não existe versão paga para
+onde migrar. O que mantém ele andando são as assinaturas de IA que o próprio
 desenvolvimento consome, e elas saem do bolso de uma pessoa só.
 
-Se o Aefos te poupa tempo, o botão **Sponsor** no topo desta página é o caminho.
-Empresas: patrocínio é faturável; link de pagamento pessoal, em geral, não.
+Se o Aefos te poupa tempo, **[você pode contribuir aqui](https://link.mercadopago.com.br/aefosai)** — ou usar o
+botão **Sponsor** no topo desta página.
+
+Empresas: patrocínio é faturável; link de pagamento pessoal, em geral, não
+— se o financeiro aí precisa de nota, é só pedir que a gente resolve.
 
 ## Reportar bugs e pedidos
 


### PR DESCRIPTION
The section from #5 is on `main` — and it is invisible. **Two independent reasons, and fixing one alone changes nothing:**

1. It sits at **line 133 of 168** — below Install, License and Updating. Nobody scrolls that far to give money.
2. Its only call to action was *"the **Sponsor** button at the top of this page"* — and that button **does not render** until `Settings → General → Features → ☑ Sponsorships` is ticked. So the one line asking for support pointed at nothing.

This adds two things that are visible on arrival and depend on neither the scroll nor the checkbox:

- a `support | donate` badge next to the existing four
- `💙 Support Aefos` / `💙 Apoie o Aefos` in the header nav row

The section keeps its reasoning, but stops being the only door — it now carries the payment link directly, and the Sponsor button becomes the alternative rather than the requirement.

The invoice line is also spelled out: a company whose accounts payable needs a *nota* should ask, rather than assume there is no way.

⚠️ Still worth ticking that Sponsorships checkbox — the GitHub button is what companies recognise. This just means the ask works without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)