### PR TITLE
Bring the Pix donation across from the README we curated

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,17 +131,37 @@ transfer.
 
 Full walkthrough in the [User Manual](https://moderndelphiworks.github.io/Aefos/).
 
-## Supporting the project
+<div align="center">
 
-Aefos is free software and stays that way — there is no paid tier to
-upgrade to. What keeps it moving is the AI subscriptions its own development
-runs on, and those are paid by one person.
+## ❤️ Support Aefos
 
-If Aefos saves you time, **[you can contribute here](https://link.mercadopago.com.br/aefosai)** — or use the
-**Sponsor** button at the top of this page.
+**Aefos AI is free software (GPL v3) — built and maintained by one developer.**
 
-Companies: sponsorship is invoiceable, a personal payment link usually is not
-— if your accounts payable needs an invoice, say so and it will be sorted.
+### **[→ Donate / Sponsor Aefos AI ←](https://link.mercadopago.com.br/aefosai)**
+
+*Any amount, any payment method — you choose both. Card, Pix or boleto.*
+
+**In Brazil? Pix goes further** — it reaches the project with no processor fee.
+
+<img src="assets/pix-qr.png" alt="Pix QR code — Aefos AI" width="220">
+
+**Pix key (random):** `4b155305-2671-4c39-8d58-7b9b5c428e18`
+
+</div>
+
+If Aefos saves you or your team time, **please consider donating.** There is no
+paywall and no paid tier to upgrade to: every feature is in the build you
+download. What keeps it maintained, keeps it working across new RAD Studio
+releases and keeps the roadmap moving are donations and the AI subscriptions its
+own development runs on, which one person pays for.
+
+**Companies:** using Aefos internally costs you nothing and obliges you to
+nothing. If it is part of your toolchain, sponsoring it is the cheapest way to
+keep it alive, and sponsorship is invoiceable where a personal payment link is
+not — ask and it will be sorted. Contributions in code are just as welcome as
+money; see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
 
 ## Reporting bugs & requests
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -100,17 +100,37 @@ preso a uma máquina, então não há o que desativar ou transferir.
 
 Passo a passo completo no [Manual do Usuário](https://moderndelphiworks.github.io/Aefos/).
 
-## Apoiando o projeto
+<div align="center">
 
-O Aefos é software livre e continua assim — não existe versão paga para
-onde migrar. O que mantém ele andando são as assinaturas de IA que o próprio
-desenvolvimento consome, e elas saem do bolso de uma pessoa só.
+## ❤️ Apoie o Aefos
 
-Se o Aefos te poupa tempo, **[você pode contribuir aqui](https://link.mercadopago.com.br/aefosai)** — ou usar o
-botão **Sponsor** no topo desta página.
+**O Aefos AI é software livre (GPL v3) — feito e mantido por um desenvolvedor só.**
 
-Empresas: patrocínio é faturável; link de pagamento pessoal, em geral, não
-— se o financeiro aí precisa de nota, é só pedir que a gente resolve.
+### **[→ Doar / Apoiar o Aefos AI ←](https://link.mercadopago.com.br/aefosai)**
+
+*Qualquer valor, qualquer forma de pagamento — você escolhe as duas. Cartão, Pix ou boleto.*
+
+**Prefere Pix?** Chega inteiro ao projeto, sem taxa de processadora.
+
+<img src="assets/pix-qr.png" alt="QR Code Pix — Aefos AI" width="220">
+
+**Chave Pix (aleatória):** `4b155305-2671-4c39-8d58-7b9b5c428e18`
+
+</div>
+
+Se o Aefos poupa tempo seu ou do seu time, **considere doar.** Não há paywall
+nem versão paga para onde migrar: todo recurso está no build que você baixa. O
+que mantém o projeto vivo, funcionando a cada nova versão do RAD Studio e com o
+roadmap andando são as doações e as assinaturas de IA que o próprio
+desenvolvimento consome, pagas por uma pessoa só.
+
+**Empresas:** usar o Aefos internamente não custa nada e não obriga a nada. Se
+ele faz parte da sua toolchain, patrociná-lo é a forma mais barata de mantê-lo
+de pé — e patrocínio é faturável, onde um link de pagamento pessoal em geral
+não é: é só pedir que a gente resolve. Contribuição em código vale tanto
+quanto dinheiro; veja [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
 
 ## Reportar bugs e pedidos
 


### PR DESCRIPTION
The private README has carried a proper donation block for months — **the Pix key, the QR code**, and the line that matters to a Brazilian donor: *Pix reaches the project with no processor fee.*

**None of it crossed over.** The public repo got a paragraph pointing at a payment processor instead — so the one payment method that costs the project nothing was the one nobody could find. The QR image was already published under `assets/pix-qr.png`; only the text was missing.

Carried across as written, in both languages, minus the single clause that no longer applies: donations *"and optional Pro/Enterprise subscriptions"* keeping it alive. Those do not exist any more, and the sentence now says what actually pays for development.

---

⚠️ **This is one symptom of a bigger miss, and it is mine.**

We curated a copy of the README for publication — **401 lines**. What is on `main` is the old storefront — **191 lines**. During the overlay I preserved the published version of several files instead of the curated one, and never diffed their *contents*, only their names. The Pix block is simply the most expensive thing that fell in that gap.

I am auditing the rest now and will report every file where the curated version never landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)