### PR TITLE
Fix what publication broke, found by auditing all 593 files

### DIFF
--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -34,9 +34,9 @@ be incorporated into a GPL work without any conflict.
 
 | # | Component | Version | Licence | Where | GPLv3 |
 |---|-----------|---------|---------|-------|-------|
-| 3 | **marked** | 14.1.4 | **MIT** | `meta/chat/vendor/marked/` (`LICENSE` present) | ✅ Compatible |
-| 4 | **Markdown** (John Gruber, syntax description shipped inside marked's `LICENSE`) | — | **BSD 3-Clause** | `meta/chat/vendor/marked/LICENSE` | ✅ Compatible — **3**-clause, no advertising clause |
-| 5 | **highlight.js** | 11.11.1 | **BSD 3-Clause** | `meta/chat/vendor/highlight/` (`LICENSE` present) | ✅ Compatible — **3**-clause, no advertising clause |
+| 3 | **marked** | 14.1.4 | **MIT** | embedded in `source/chat/UI/Aefos.OTA.Chat.UI.OutputPanel.Assets.pas`; licence verbatim in `THIRD-PARTY-NOTICES.txt` | ✅ Compatible |
+| 4 | **Markdown** (John Gruber, syntax description shipped inside marked's `LICENSE`) | — | **BSD 3-Clause** | licence verbatim in `THIRD-PARTY-NOTICES.txt` | ✅ Compatible — **3**-clause, no advertising clause |
+| 5 | **highlight.js** | 11.11.1 | **BSD 3-Clause** | embedded in `source/chat/UI/Aefos.OTA.Chat.UI.OutputPanel.Assets.pas`; licence verbatim in `THIRD-PARTY-NOTICES.txt` | ✅ Compatible — **3**-clause, no advertising clause |
 
 Both BSD notices were read in full and confirmed to be the **3-clause** form.
 Neither contains the GPL-incompatible **4-clause "advertising"** term ("All
@@ -120,12 +120,6 @@ component above was checked against this list. **None matched:**
   only vendored directory without a `LICENSE` file is SQLite, whose public-domain
   status and exact upstream artefact are documented and hash-pinned in
   `source/data/ThirdParty/sqlite/UPSTREAM.txt`.
-
-Also worth recording, though outside the shipped product:
-`poc/WebViewDock/Windows10Dark.vsf` is an **Embarcadero VCL style** file living
-in the proof-of-concept tree. It is not part of any shipped package, but it is
-an Embarcadero asset sitting in a repository that is about to become public.
-Removing it, or confirming it may be redistributed, is a small follow-up.
 
 ---
 

--- a/docs/components/chat.md
+++ b/docs/components/chat.md
@@ -1,7 +1,8 @@
 # Component — Chat
 
-**BPL:** `Aefos.OTA.Chat` · **Source:** `source/chat` · **Vendored web assets:**
-`third-party/` (embedded into `Assets.pas` by `scripts/embed-webview-assets.ps1`).
+**BPL:** `Aefos.OTA.Chat` · **Source:** `source/chat` · **Vendored web assets:** marked and
+highlight.js ship already embedded in `Aefos.OTA.Chat.UI.OutputPanel.Assets.pas`; their
+licences are reproduced verbatim in `THIRD-PARTY-NOTICES.txt`.
 
 ## What it is
 

--- a/packages/Delphi/Aefos.OTA.Chat.dpk
+++ b/packages/Delphi/Aefos.OTA.Chat.dpk
@@ -108,8 +108,6 @@ contains
   Aefos.OTA.Chat.UI.AboutForm in '..\..\source\chat\UI\Aefos.OTA.Chat.UI.AboutForm.pas',
   Aefos.OTA.UI.MCPToolInspector.Assets in '..\..\source\mcp\OTA\Aefos.OTA.UI.MCPToolInspector.Assets.pas',
   Aefos.OTA.UI.MCPToolInspector in '..\..\source\mcp\OTA\Aefos.OTA.UI.MCPToolInspector.pas',
-  Aefos.OTA.Chat.UI.Branding in '..\..\source\chat\UI\Aefos.OTA.Chat.UI.Branding.pas' {$IFDEF DEBUG},
-  Aefos.Test.Artifact in '..\..\meta\chat\tests\Aefos.Test.Artifact.pas',
-  Aefos.Smoke.Matcher in '..\..\meta\chat\tests\Smoke\Aefos.Smoke.Matcher.pas' {$ENDIF};
+  Aefos.OTA.Chat.UI.Branding in '..\..\source\chat\UI\Aefos.OTA.Chat.UI.Branding.pas';
 
 end.

--- a/packages/Delphi/Aefos.OTA.Terminal.dproj
+++ b/packages/Delphi/Aefos.OTA.Terminal.dproj
@@ -82,7 +82,7 @@
         <DelphiCompile Include="$(MainSource)">
             <MainSource>MainSource</MainSource>
         </DelphiCompile>
-        <DCCReference Include="Aefos.OTA.TerminalFont.res"/>
+        <DCCReference Include="Aefos.OTA.TerminalFont.RES"/>
         <DCCReference Include="rtl.dcp"/>
         <DCCReference Include="vcl.dcp"/>
         <DCCReference Include="vclie.dcp"/>

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -1,8 +1,7 @@
 <#
   bump-version.ps1 — single-command version bump across EVERY place the Aefos
   version is hardcoded, so a release never drifts again (the 0.18.0 release shipped
-  Chat 0.17.0 because OTA_PLUGIN_VERSION was a separate manual const — see
-  meta/install-feedback-friend-2026-06-20.md #4).
+  Chat 0.17.0 because OTA_PLUGIN_VERSION was a separate manual const).
 
   The version lives in, and this script rewrites, all of:
     - installer/Aefos.iss                          (#define AppVer "x.y.z")

--- a/source/lazarus/ide/Aefos.Lazarus.Register.pas
+++ b/source/lazarus/ide/Aefos.Lazarus.Register.pas
@@ -207,11 +207,6 @@ const
   cSecChatReviewName = 'secAefosAIChatReview';
   cMenuApproveAllName = 'itmAefosAIApproveAll';
   cMenuRejectAllName  = 'itmAefosAIRejectAll';
-  cMenuLicenseName   = 'itmAefosAILicense';
-  { Fallback caption used only before the first StatusText read (the live status
-    replaces it at registration). }
-  cLicenseCaption    = 'License...';
-
   { Environment override: when AEFOS_LAZ_MCP_AUTOSTART=1, Register starts the MCP
     server at package load. This is how the headless runtime proof drives the
     server without a mouse click (the IDE cannot be clicked in a smoke run); it
@@ -596,7 +591,6 @@ var
   LToggleMcp: TNotifyEvent;
   LApproveAll: TNotifyEvent;
   LRejectAll: TNotifyEvent;
-  LLicense: TNotifyEvent;
   LCmdCategory: TIDECommandCategory;
   LAboutCommand: TIDECommand;
 begin
@@ -689,11 +683,8 @@ begin
   { The LCL chat window: windowed WebView2 host + bridge. }
   RegisterIDEMenuCommand(LSecOpen, cMenuChatName, cOpenChatCaption, LChat);
 
-  { Group 2 -- settings + product info (Options / About / web / License), the
-    block the Delphi submenu places below the separator. The live "License:
-    <state>" item mirrors the Delphi Chat submenu (Aefos.OTA.Chat.Register): the
-    shared cross-compiler gate (Aefos.License.Gate) now backs both editions, so
-    the state is REAL (trial/active/expired), not faked. }
+  { Group 2 -- settings + product info (Options / About / web), the block the
+    Delphi submenu places below the separator. }
   LSecInfo := RegisterIDEMenuSection(LChatRoot, cSecChatInfoName);
   { Deep-link into Tools > Options at the Aefos AI executor page. }
   RegisterIDEMenuCommand(LSecInfo, cMenuOptionsName, cOptionsCaption, LOptions);
@@ -755,14 +746,13 @@ begin
                  Open Terminal
                  Action Center
                  --------------------------
-                 License: <live state>
                  About Aefos AI...
 
     "Open Terminal" shows/docks the native terminal panel
     (Aefos.Lazarus.TerminalWindow); "Action Center" opens the saved-actions catalog
     window (Aefos.Lazarus.ActionCenterWindow), matching the Delphi terminal group
-    order. The info block reuses the SAME shared License gate + About dialog the
-    Chat submenu uses, so parity is real, not faked. }
+    order. The info block reuses the SAME About dialog the Chat submenu uses,
+    so parity is real, not faked. }
   LTerminalRoot := RegisterIDESubMenu(mnuView, cMenuTerminalRootName,
     cTerminalMenuCaption);
   LSecTerminalOpen := RegisterIDEMenuSection(LTerminalRoot, cSecTerminalOpenName);
@@ -772,9 +762,8 @@ begin
     cActionCenterCaption, LActionCenter);
 
   { Info block -- its own section so a divider separates it from "Open Terminal".
-    The live "License: <state>" item is a DISTINCT command from the Chat one; both
-    are refreshed together by _RefreshLicenseCaptions. About reuses the same handler
-    (no shortcut here -- the Chat/About item already owns the rebindable command). }
+    About reuses the same handler as the Chat submenu (no shortcut here -- the
+    Chat/About item already owns the rebindable command). }
   LSecTerminalInfo := RegisterIDEMenuSection(LTerminalRoot, cSecTerminalInfoName);
   RegisterIDEMenuCommand(LSecTerminalInfo, cMenuTerminalAboutName, cAboutCaption,
     LAbout);


### PR DESCRIPTION
I audited every file in the published tree — does each reference resolve inside the tree the public actually gets? **593 files.** Five things did not, and **none of them show up in a Release build**, which is why they survived.

| # | Where | What breaks |
|---|---|---|
| **A** | `packages/Delphi/Aefos.OTA.Chat.dpk` | still lists `Aefos.Test.Artifact` and `Aefos.Smoke.Matcher` under `meta/chat/tests/` — **`meta/` was never published.** Release skips them behind `{$IFDEF DEBUG}`; a **DEBUG build cannot find them at all**. Anyone who clones and builds the way a contributor builds hits this immediately. |
| **B** | `source/lazarus/ide/Aefos.Lazarus.Register.pas` | still declared `cMenuLicenseName`, `cLicenseCaption = 'License...'` and `LLicense: TNotifyEvent`, and **four comment blocks** described a `License: <live state>` menu item and `Aefos.License.Gate` backing it. The code is dead — but comments are what a reader believes, and these said the feature is there. |
| **C** | `THIRD-PARTY-NOTICES.md` | named `meta/chat/vendor/marked/` and `.../highlight/` as the home of those components. They ship **embedded in `Assets.pas`**, and their licences are verbatim in `THIRD-PARTY-NOTICES.txt`. It also recorded a `poc/WebViewDock/*.vsf` file **that is not in this repository** — that note was written *because* the repo was about to go public, and it has. |
| **C** | `docs/components/chat.md` | pointed at `third-party/` and `scripts/embed-webview-assets.ps1` — neither is published. |
| **D** | `packages/Delphi/Aefos.OTA.Terminal.dproj` | referenced `Aefos.OTA.TerminalFont.res`; the file on disk is `.RES`. Windows does not care, **a case-sensitive checkout does**. |

**What I checked and found clean:** every `DCCReference` and `contains` entry resolves; no `uses` names a deleted unit; no markdown link or `<img src>` 404s inside the tree; no installer `Source:` names a tracked file that is missing; nothing else still references the removed licence feature.

**What the audit still reports, correctly:** `.dcp` entries (RTL packages, resolved by the compiler), installer payloads that are build outputs (`cli/bin/aefos.exe`, `redist/`), the `{{Name}}.dpk` template placeholder, and the CHANGELOG line that *describes* the licence removal.

⚠️ **I have not compiled this.** The two package changes (A, D) want your build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)