### PR TITLE
The README never mentioned the source

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,52 @@ annotate it right in the editor gutter:
 
 ![Change review: stacked before/after diff with gutter accept/reject/annotate controls](assets/change-review.png)
 
+## Build from source
+
+Everything Aefos ships is in this repository, and it builds with no absolute
+paths — package files use repo-relative sources.
+
+```powershell
+scripts\build-packages.ps1 -Version all   # 22.0 = D11, 23.0 = D12, 37.0 = D13
+installer\build-installer.ps1
+```
+
+Or open `packages/Delphi/AefosGroup.groupproj` in the IDE and build the group —
+the group already carries the dependency order. Only **Chat** and **Terminal**
+register UI in the IDE; the other packages are runtime dependencies.
+
+Touched `source/lazarus/`? Run `scripts/build-lazarus.ps1` — **no other
+script compiles that tree.**
+
+```
+Aefos/
+├─ source/          all product source code
+│  ├─ chat/         Chat BPL (Core, UI, Register)
+│  ├─ terminal/     Terminal BPL (Core, UI, ThirdParty/libvterm)
+│  ├─ providers/    one driver per AI CLI (Claude/Codex/Copilot/Gemini)
+│  ├─ harness/      Design/Code seam (WithLiveForm, EnsureCode/DesignView)
+│  ├─ webview/      composition-hosted WebView2 (TAefosWebView)
+│  ├─ completion/   inline completion (ghost text)
+│  ├─ data/         SQLite/FireDAC persistence
+│  ├─ lazarus/      the Lazarus/FPC edition
+│  ├─ compat/       shims that let units compile under both compilers
+│  └─ mcp/          MCP protocol + OTA tool facade + the tool suite
+├─ packages/         .dpk/.dproj (Delphi) and .lpk (Lazarus)
+├─ mcps/desktop/     the out-of-process desktop MCP server
+├─ cli/              the `aefos` command-line tool
+├─ installer/        Inno Setup installers
+├─ scripts/          build scripts
+└─ docs/             technical docs + the user manual
+```
+
+| Read this | For |
+|---|---|
+| [`docs/architecture.md`](docs/architecture.md) | how the pieces fit, and why the MCP engine is decoupled from `ToolsAPI` |
+| [`docs/build-install.md`](docs/build-install.md) | build prerequisites, package order, installing the BPLs into an IDE |
+| [`docs/intent-view.md`](docs/intent-view.md) | the Design/Code rule every mutating tool enforces — the thing that makes Aefos a Delphi tool rather than a text editor |
+| [`docs/mcp-tools.md`](docs/mcp-tools.md) | every MCP tool the IDE exposes to the agent |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | house style, and how to open a PR that lands |
+
 ## Documentation
 
 📖 **[User Manual](https://moderndelphiworks.github.io/Aefos/)** (PT-BR / EN) — install, first steps, Chat, Terminal,

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -53,6 +53,52 @@ depurador), opera o Form Designer e mais.
 |:---:|:---:|
 | ![Aefos Chat](assets/chat.png) | ![Aefos Terminal](assets/terminal.png) |
 
+## Buildar do fonte
+
+Tudo que o Aefos distribui está neste repositório, e builda sem nenhum caminho
+absoluto — os arquivos de pacote usam caminhos relativos ao repo.
+
+```powershell
+scripts\build-packages.ps1 -Version all   # 22.0 = D11, 23.0 = D12, 37.0 = D13
+installer\build-installer.ps1
+```
+
+Ou abra `packages/Delphi/AefosGroup.groupproj` na IDE e builde o grupo — ele já
+carrega a ordem de dependência. Só **Chat** e **Terminal** registram UI na IDE;
+os outros pacotes são dependências de runtime.
+
+Mexeu em `source/lazarus/`? Rode `scripts/build-lazarus.ps1` — **nenhum outro
+script compila essa árvore.**
+
+```
+Aefos/
+├─ source/          all product source code
+│  ├─ chat/         Chat BPL (Core, UI, Register)
+│  ├─ terminal/     Terminal BPL (Core, UI, ThirdParty/libvterm)
+│  ├─ providers/    one driver per AI CLI (Claude/Codex/Copilot/Gemini)
+│  ├─ harness/      Design/Code seam (WithLiveForm, EnsureCode/DesignView)
+│  ├─ webview/      composition-hosted WebView2 (TAefosWebView)
+│  ├─ completion/   inline completion (ghost text)
+│  ├─ data/         SQLite/FireDAC persistence
+│  ├─ lazarus/      the Lazarus/FPC edition
+│  ├─ compat/       shims that let units compile under both compilers
+│  └─ mcp/          MCP protocol + OTA tool facade + the tool suite
+├─ packages/         .dpk/.dproj (Delphi) and .lpk (Lazarus)
+├─ mcps/desktop/     the out-of-process desktop MCP server
+├─ cli/              the `aefos` command-line tool
+├─ installer/        Inno Setup installers
+├─ scripts/          build scripts
+└─ docs/             technical docs + the user manual
+```
+
+| Leia | Para |
+|---|---|
+| [`docs/architecture.md`](docs/architecture.md) | como as peças se encaixam, e por que o motor MCP é desacoplado do `ToolsAPI` |
+| [`docs/build-install.md`](docs/build-install.md) | pré-requisitos de build, ordem dos pacotes, instalar as BPLs numa IDE |
+| [`docs/intent-view.md`](docs/intent-view.md) | a regra Design/Código que toda ferramenta de mutação impõe — o que faz do Aefos uma ferramenta Delphi, e não um editor de texto |
+| [`docs/mcp-tools.md`](docs/mcp-tools.md) | cada ferramenta MCP que a IDE expõe ao agente |
+| [`CONTRIBUTING.md`](CONTRIBUTING.md) | estilo da casa, e como abrir um PR que entra |
+
 ## Documentação
 
 📖 **[Manual do Usuário](https://moderndelphiworks.github.io/Aefos/)** (PT-BR / EN) — instalação, primeiros passos,


### PR DESCRIPTION
This closes the audit I owed you. I compared the curated copy against the published repo **by content**, in the direction that matters: what does the curated copy have that the public lacks?

Almost everything it flagged was the old text correctly replaced — the proprietary header, `1.0.x` version tables, the pre-bilingual `build-html.py`. **One finding was real, and it is the big one.**

### The README is still a storefront

Download, install, licence, support — and **no path from the front page into the code**. No repository layout. No build instructions. No link to `docs/architecture.md`, `docs/build-install.md`, `docs/intent-view.md` or `docs/mcp-tools.md`, all of which have existed all along.

A developer who came *because* the project went open source arrived and found nothing to do.

### What this adds

A **Build from source** section in both languages, adapted from the README we curated, corrected for what shipped since — the licence package is gone, `source/` gained `compat`, `completion` and `lazarus`, and the supported IDEs are three rather than one:

- the two commands that actually build it (`build-packages.ps1 -Version all`, `build-installer.ps1`)
- the repository layout
- the warning that costs the most time when missed: **nothing but `build-lazarus.ps1` compiles the Lazarus tree**
- a table pointing at the four docs worth reading first, plus `CONTRIBUTING.md`

---

### The rest of the drift, for the record

The curated copy is now **stale in every remaining respect** — the licence removal and every fix since #5 happened in the git clone, not in it. Its unique files are the English-only manual variant from that stage, the licence files already deleted, and build artifacts.

Once this merges, `D:\Ecossistema-Delphi\Aefos-AI-Public` has nothing left that the repository does not have, and can go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)