### PR TITLE
Record that the installer stopped bundling an AI CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ Dates are in `YYYY-MM-DD`.
 and every feature ships enabled. **Delphi 12 Athens (BDS 23.0)** and **Delphi 13
 (BDS 37.0)**; the installer detects what you have and lets you pick.
 
+### Changed
+
+**The installer no longer bundles an AI CLI.** 1.1.0 shipped Codex and Gemini
+beside the agent so a fresh install was productive immediately. With the source
+public that trade stopped being worth it: redistributing third-party binaries
+adds licence surface and ships versions that go stale between releases, and the
+installer drops from 109 MB to about 5 MB. Aefos is, and is documented as,
+**bring your own CLI** — install the one you already use and point Aefos at it,
+or leave the path empty and let it be found on PATH.
+
+Nothing is taken away from anyone: the bundled binaries were installed with
+`uninsneveruninstall`, so a 1.1.0 user keeps the copy already in
+`%APPDATA%\Aefos\bin`. New installs simply do not get one.
+
 ### Removed
 
 **The licence gate is gone.** There is no key, no activation, no trial and no


### PR DESCRIPTION
I nearly shipped this as an unannounced regression.

The 1.2.0 installer I built came out at **5.5 MB**; 1.1.0 was **109 MB**. The difference is that 1.1.0 bundled Codex and Gemini, and the `.iss` omits them silently (`skipifsourcedoesntexist`) when they are not staged. I had fetched them to restore parity — then you said not to embed them now that the source is public, which is the better call:

- redistributing third-party binaries adds licence surface a GPL repo does not need
- bundled binaries go stale between releases
- **109 MB → ~5 MB**

**Every other document already says "bring your own CLI — no CLI is bundled."** The changelog was the only place where 1.1.0 and 1.2.0 disagreed, and it is the page someone reads before upgrading. This adds the entry.

**Nobody loses anything.** The bundled binaries were installed with `uninsneveruninstall`, so a 1.1.0 user keeps the copy already in `%APPDATA%\Aefos\bin`. New installs simply do not get one, and Aefos still finds a CLI on `PATH` with the executor path left empty.

> The WebView2 offline runtime is a separate matter and was never the problem: it is behind `-DBundleWebView2`, opt-in, and without it the installer downloads the runtime when the machine lacks it. That is the intended behaviour, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)