### PR TITLE
Record the shipped hash in the Lazarus release notes

### DIFF
--- a/installer/lazarus/RELEASE-NOTES-0.25.1-beta.md
+++ b/installer/lazarus/RELEASE-NOTES-0.25.1-beta.md
@@ -44,7 +44,7 @@ Portuguese.
 ## Verify your download
 
 ```
-sha256  98553307f63c9d725d5a21c027e93b851731740bb88bf9acecff9b8475778f67
+sha256  6c61e378bdf8630b1462a52a2352fcd851aff7d673b7da923d849de970284b45
 ```
 
 ```powershell


### PR DESCRIPTION
The notes carried the hash of the **0.25.0-beta** build they were copied from — worse than carrying none, since a reader who checks it concludes the download was tampered with.

Now the hash of the 0.25.1-beta installer actually being published:

```
6c61e378bdf8630b1462a52a2352fcd851aff7d673b7da923d849de970284b45
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)