### PR TITLE
Point the installer at the folder the 64-bit IDE actually searches

### DIFF
--- a/installer/Aefos.iss
+++ b/installer/Aefos.iss
@@ -13,8 +13,8 @@
 ;
 ;  Delphi 13 counts as TWO targets, not one: it ships a second IDE executable
 ;  (bin64\bds.exe), and a design-time package is loaded into the IDE PROCESS -- so
-;  a Win32 BPL is invisible to the 64-bit IDE and vice-versa. The Win64x set is
-;  built separately, installed into Bpl\Win64x, and registered under its own
+;  a Win32 BPL is invisible to the 64-bit IDE and vice-versa. The Win64 set is
+;  built separately, installed into Bpl\Win64, and registered under its own
 ;  "Known Packages x64" key.
 ;
 ;  Per-version BPLs are RTL-version-specific and CANNOT be shared - a Delphi 12
@@ -57,8 +57,8 @@
 #define HaveD12  FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD12 + "\Aefos.OTA.Chat.bpl")
 #define HaveD13  FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD13 + "\Aefos.OTA.Chat.bpl")
 ; The 64-bit IDE payload is independent: -Platform Win32 (the default) stages
-; nothing under Win64x and the whole block below vanishes at compile time.
-#define HaveD13x FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD13 + "\Win64x\Aefos.OTA.Chat.bpl")
+; nothing under Win64 and the whole block below vanishes at compile time.
+#define HaveD13x FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD13 + "\Win64\Aefos.OTA.Chat.bpl")
 #if !HaveD11 && !HaveD12 && !HaveD13
   #error No staged BPLs found under .\bpl\<ver>. Run scripts\build-packages.ps1 then installer\build-installer.ps1.
 #endif
@@ -88,7 +88,7 @@ SolidCompression=yes
 WizardStyle=modern
 ShowLanguageDialog=yes
 ; The SETUP itself stays a 32-bit process. This says nothing about the packages:
-; Delphi 13 gained a 64-bit IDE and we now ship Win64x BPLs for it (see HaveD13x).
+; Delphi 13 gained a 64-bit IDE and we now ship Win64 BPLs for it (see HaveD13x).
 ; What this setting controls is where {pf} and the registry redirector point, and
 ; every path here is written literally, so 32-bit mode is both correct and the
 ; safer default on a machine with no 64-bit IDE at all.
@@ -231,7 +231,7 @@ Source: "{#BplSrc}\{#VerD13}\dclAefosWebView.bpl";     DestDir: "{commondocs}\Em
 ; --- Delphi 13, 64-bit IDE (bin64\bds.exe) - a SEPARATE set of packages --------
 ; Delphi 13 ships two IDE executables, and a design-time BPL is loaded into the
 ; IDE PROCESS: a Win32 package simply does not appear in the 64-bit IDE, and vice
-; versa. So this is a second build (Platform=Win64x), installed into the Win64x
+; versa. So this is a second build (Platform=Win64), installed into the Win64
 ; subfolder the IDE itself writes to, and registered under its OWN registry key --
 ; "Known Packages x64", which is a different key from the 32-bit one (verified: 80
 ; entries there, all under $(BDS)\bin64).
@@ -239,22 +239,22 @@ Source: "{#BplSrc}\{#VerD13}\dclAefosWebView.bpl";     DestDir: "{commondocs}\Em
 ; Optional exactly like a version payload: build-packages.ps1 -Platform Win32 (the
 ; default) stages nothing here, and this whole block disappears at compile time.
 #if HaveD13x
-Source: "{#BplSrc}\{#VerD13}\Win64x\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64x\Aefos.Providers.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64x\Aefos.Tools.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64x\Aefos.MCP.Core.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64x\Aefos.MCP.Tools.OTA.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64x\Aefos.Data.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64x\Aefos.WebView.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64x\Aefos.OTA.Chat.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64x\Aefos.OTA.Terminal.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64x\dclAefosWebView.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.Providers.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.Tools.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.MCP.Core.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.MCP.Tools.OTA.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.Data.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.WebView.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.OTA.Chat.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.OTA.Terminal.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\dclAefosWebView.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
 ; A 64-bit IDE process cannot bind the 32-bit loader RAD Studio ships, so this is
 ; the x64 one -- staged by build-installer.ps1 from the same place the Lazarus
 ; installer gets it. Without it the chat would fall back to plain text in the
 ; 64-bit IDE only, which is exactly the kind of difference nobody would think to
 ; look for.
-Source: "{#BplSrc}\{#VerD13}\Win64x\WebView2Loader.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\WebView2Loader.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
 #endif
 
 ; --- WebView2 Evergreen STANDALONE (offline) - OPTIONAL embed (-DBundleWebView2) -
@@ -297,9 +297,9 @@ Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages";    Valu
 ; installs nothing visible in the 64-bit IDE -- it reads "Known Packages x64",
 ; and the two lists never see each other.
 #if HaveD13x
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages x64";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x\Aefos.OTA.Chat.bpl";     ValueData: "Aefos AI - Chat";              Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages x64";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x\Aefos.OTA.Terminal.bpl"; ValueData: "Aefos AI - Terminal";          Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages x64";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64x\dclAefosWebView.bpl";       ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages x64";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64\Aefos.OTA.Chat.bpl";     ValueData: "Aefos AI - Chat";              Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages x64";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64\Aefos.OTA.Terminal.bpl"; ValueData: "Aefos AI - Terminal";          Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages x64";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64\dclAefosWebView.bpl";       ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
 #endif
 #endif
 

--- a/installer/build-installer.ps1
+++ b/installer/build-installer.ps1
@@ -79,15 +79,15 @@ foreach ($v in $staged) {
   Copy-Item $wv2 $dir -Force   # ensure the loader is present (VM build may lack it)
   Write-Host "  ok  Delphi $v  ($($Bpls.Count) BPLs + WebView2Loader.dll)" -ForegroundColor Green
 
-  # Delphi 13's 64-bit IDE, when its packages were built (-Platform Win64x). It is
+  # Delphi 13's 64-bit IDE, when its packages were built (-Platform Win64). It is
   # a separate set: a design-time BPL loads into the IDE PROCESS, so the Win32 ones
   # above are invisible to bin64\bds.exe.
-  $x64Dir = Join-Path $dir 'Win64x'
+  $x64Dir = Join-Path $dir 'Win64'
   if (Test-Path (Join-Path $x64Dir 'Aefos.OTA.Chat.bpl')) {
     $missing64 = $Bpls | Where-Object { -not (Test-Path (Join-Path $x64Dir $_)) }
     if ($missing64) {
-      throw "Delphi $v/Win64x: staged folder is missing $($missing64.Count) BPL(s): " +
-            "$($missing64 -join ', '). Re-run build-packages.ps1 -Version $v -Platform Win64x."
+      throw "Delphi $v/Win64: staged folder is missing $($missing64.Count) BPL(s): " +
+            "$($missing64 -join ', '). Re-run build-packages.ps1 -Version $v -Platform Win64."
     }
     # A 64-bit IDE process cannot bind the 32-bit loader RAD Studio ships, and RAD
     # Studio has no x64 one (verified: nothing under any bin64). It comes from the
@@ -100,9 +100,9 @@ foreach ($v in $staged) {
     }
     if (Test-Path $loader64) {
       Copy-Item $loader64 $x64Dir -Force
-      Write-Host "  ok  Delphi $v/Win64x  ($($Bpls.Count) BPLs + x64 WebView2Loader.dll)" -ForegroundColor Green
+      Write-Host "  ok  Delphi $v/Win64  ($($Bpls.Count) BPLs + x64 WebView2Loader.dll)" -ForegroundColor Green
     } else {
-      throw "Delphi $v/Win64x: no x64 WebView2Loader.dll. See " +
+      throw "Delphi $v/Win64: no x64 WebView2Loader.dll. See " +
             "installer\lazarus\redist\x86_64\README.md."
     }
   }

--- a/scripts/build-packages.ps1
+++ b/scripts/build-packages.ps1
@@ -33,10 +33,10 @@ param(
   [string]$Version = 'all',
   [ValidateSet('Release', 'Debug')]
   [string]$Config = 'Release',
-  # Win32 is the classic IDE. Win64x is Delphi 13's separate 64-bit IDE
+  # Win32 is the classic IDE. Win64 is Delphi 13's separate 64-bit IDE
   # (bin64\bds.exe) -- a design-time BPL must match the process bitness, so
   # the two are different builds, not one build installed twice.
-  [ValidateSet('Win32', 'Win64x', 'all')]
+  [ValidateSet('Win32', 'Win64', 'all')]
   [string]$Platform = 'Win32'
 )
 
@@ -81,13 +81,13 @@ function Ensure-LibVTerm([string]$Rsvars, [string]$Plat) {
   $vtermDir = Join-Path $root 'source\terminal\ThirdParty\libvterm'
   # The one artefact that matters: Core.LibVTerm.pas links exactly this via {$L}
   # (a unity object -- the per-file .obj's alone don't satisfy the single-pass linker).
-  # bcc32c emits 32-bit OMF into obj\; bcc64x emits COFF x64 into obj\Win64x\.
+  # bcc32c emits 32-bit OMF into obj\; bcc64 emits ELF x64 into obj\Win64\.
   # Each linker rejects the other's output with E2045, which reads like a
   # corrupt file and is really the wrong architecture -- hence two folders.
   if ($Plat -eq 'Win32') {
     $unity = Join-Path $vtermDir 'obj\libvterm_unity.obj'
   } else {
-    $unity = Join-Path $vtermDir 'obj\Win64x\libvterm_unity.o'
+    $unity = Join-Path $vtermDir 'obj\Win64\libvterm_unity.o'
   }
   if (Test-Path $unity) { return }
   Write-Host "  libvterm objects missing -- building them (fresh checkout)." -ForegroundColor Yellow
@@ -99,7 +99,7 @@ function Ensure-LibVTerm([string]$Rsvars, [string]$Plat) {
   }
 }
 
-$plats = if ($Platform -eq 'all') { @('Win32', 'Win64x') } else { @($Platform) }
+$plats = if ($Platform -eq 'all') { @('Win32', 'Win64') } else { @($Platform) }
 
 $built = @()
 foreach ($v in $targets) {
@@ -109,9 +109,9 @@ foreach ($v in $targets) {
     continue
   }
   foreach ($plat in $plats) {
-    # Only Delphi 13 has a 64-bit IDE to load a Win64x package.
-    if ($plat -eq 'Win64x' -and $v -ne '37.0') {
-      Write-Host "  --  Delphi $v has no 64-bit IDE -- skipping Win64x." -ForegroundColor DarkGray
+    # Only Delphi 13 has a 64-bit IDE to load a Win64 package.
+    if ($plat -eq 'Win64' -and $v -ne '37.0') {
+      Write-Host "  --  Delphi $v has no 64-bit IDE -- skipping Win64." -ForegroundColor DarkGray
       continue
     }
     Ensure-LibVTerm $rsvars $plat
@@ -121,7 +121,7 @@ foreach ($v in $targets) {
     cmd /c $cmd
     if ($LASTEXITCODE -ne 0) { throw "Build FAILED for Delphi $v/$plat (exit $LASTEXITCODE)." }
 
-    # Stage into installer\bpl\<ver>\ for Win32, <ver>\Win64x\ for the 64-bit
+    # Stage into installer\bpl\<ver>\ for Win32, <ver>\Win64\ for the 64-bit
     # IDE -- the installer copies each set to the directory its IDE reads.
     $src = Get-PublicBplDir $v $plat
     $dst = Join-Path $stage $v

--- a/source/terminal/ThirdParty/libvterm/build-objs.bat
+++ b/source/terminal/ThirdParty/libvterm/build-objs.bat
@@ -8,7 +8,7 @@ rem
 rem  TWO PLATFORMS, TWO COMPILERS, AND THEY ARE NOT INTERCHANGEABLE.
 rem
 rem    Win32   bcc32c.exe  (bin)    -> 32-bit OMF   -> obj\*.obj
-rem    Win64x  bcc64x.exe  (bin64)  -> COFF x64     -> obj\Win64x\*.o
+rem    Win64   bcc64.exe   (bin)    -> ELF x64      -> obj\Win64\*.o
 rem
 rem  Each platform's Delphi linker REJECTS the other's object outright, with
 rem  "E2045 Bad object file format" - which reads like a corrupt file and is
@@ -16,11 +16,11 @@ rem  really the wrong architecture. Hence separate output folders: a build can
 rem  never pick up the wrong one, whoever ran last.
 rem
 rem  The legacy bcc32.exe is C89/C++03 and CANNOT compile libvterm (C99
-rem  designated initializers + mixed declarations). bcc32c and bcc64x are the
+rem  designated initializers + mixed declarations). bcc32c and bcc64 are the
 rem  Clang-based compilers and both handle it.
 rem
 rem  Usage:  build-objs.bat            (Win32, the default)
-rem          build-objs.bat Win64x     (Win64 Modern, for the 64-bit IDE)
+rem          build-objs.bat Win64      (classic Win64, for the 64-bit IDE)
 rem    Requires the compiler on PATH, or the BDS environment variable pointing
 rem    at the RAD Studio root (set by rsvars.bat / inside the IDE).
 rem
@@ -35,9 +35,9 @@ set PLATFORM=%~1
 if "%PLATFORM%"=="" set PLATFORM=Win32
 
 rem -- Locate the compiler and decide where the objects land -------------------
-if /I "%PLATFORM%"=="Win64x" goto :win64
+if /I "%PLATFORM%"=="Win64" goto :win64
 if /I "%PLATFORM%"=="Win32" goto :win32
-echo *** Unknown platform "%PLATFORM%" - expected Win32 or Win64x ***
+echo *** Unknown platform "%PLATFORM%" - expected Win32 or Win64 ***
 endlocal & exit /b 1
 
 :win32
@@ -48,10 +48,10 @@ if defined BDS if exist "%BDS%\bin\bcc32c.exe" set BCC="%BDS%\bin\bcc32c.exe"
 goto :compile
 
 :win64
-set OUTDIR=%HERE%obj\Win64x
+set OUTDIR=%HERE%obj\Win64
 set OBJEXT=o
-set BCC=bcc64x.exe
-if defined BDS if exist "%BDS%\bin64\bcc64x.exe" set BCC="%BDS%\bin64\bcc64x.exe"
+set BCC=bcc64.exe
+if defined BDS if exist "%BDS%\bin\bcc64.exe" set BCC="%BDS%\bin\bcc64.exe"
 goto :compile
 
 :compile


### PR DESCRIPTION
Closes the item that parked #18.

The packages were already built for the right platform. **The plumbing that feeds them was not:** `build-objs.bat` still reached for `bcc64x` in `bin64`, `build-packages.ps1` still passed `Platform=Win64x`, and the installer still staged, copied and registered `Bpl\Win64x` — the folder the live test proved is **not** on the 64-bit IDE's search path.

Everything now targets **classic Win64**:

| | |
|---|---|
| Objects | `bcc64` from `bin` — **ELF**, not the COFF `bcc64x` emits → `obj\Win64\` |
| Build | `msbuild /p:Platform=Win64` |
| Staged | `installer\bpl\<ver>\Win64\` |
| Installed | `Studio\<ver>\Bpl\Win64` — **the folder the IDE already searches** |
| Registered | the three design packages, under `Known Packages x64` |

## Proven from nothing

Objects deleted, both platforms built from a clean tree:

```
libvterm objects missing -- building them (fresh checkout).
libvterm objects built into ...\libvterm\obj
  OK  Delphi 37.0/Win32  (10 BPLs)
libvterm objects missing -- building them (fresh checkout).
libvterm objects built into ...\libvterm\obj\Win64
  OK  Delphi 37.0/Win64  (10 BPLs)
```

Then an installer carrying **four payloads**:

```
ok  Delphi 22.0        (10 BPLs + WebView2Loader.dll)
ok  Delphi 23.0        (10 BPLs + WebView2Loader.dll)
ok  Delphi 37.0        (10 BPLs + WebView2Loader.dll)
ok  Delphi 37.0/Win64  (10 BPLs + x64 WebView2Loader.dll)
-> Aefos-Setup-1.3.0.exe   8.4 MB
```

## Still to verify by installing

The 64-bit IDE was proven to **load and run** Aefos when the packages were placed and registered by hand. What this PR changes is that the **installer** does it — and that has not been through a setup run. The Terminal in the 64-bit IDE also remains unopened: it links libvterm, but nothing yet shows the recompiled C drawing a screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)