### PR TITLE
Reconnect the Desktop MCP to the build, and the CLI to the version

### DIFF
--- a/cli/aefos.dpr
+++ b/cli/aefos.dpr
@@ -37,11 +37,17 @@ uses
   Aefos.Addons.Args in 'Aefos.Addons.Args.pas';
 
 const
-  // The manager's own version. The Aefos-plugin version used for the
-  // requirements gate is read from %AEFOS_VERSION% (the installer sets it), and
-  // falls back to this baseline so a fresh install is never wrongly blocked.
-  CManagerVersion = '1.0.0';
-  CAefosBaseline = '1.0.0';
+  // The manager's own version, printed by `aefos --version`.
+  //
+  // CAefosBaseline is the Aefos version an addon's requirements.aefos_version is
+  // gated against. %AEFOS_VERSION% overrides it when set, but no installer sets
+  // that variable today, so in practice the baseline IS the answer - which is
+  // why it has to move with the release: a stale baseline refuses addons that
+  // the running Aefos actually satisfies.
+  //
+  // Both are rewritten by scripts/bump-version.ps1. Do not edit by hand.
+  CManagerVersion = '1.4.0';
+  CAefosBaseline = '1.4.0';
 
 var
   GArgv: TArray<string>;

--- a/installer/Aefos.iss
+++ b/installer/Aefos.iss
@@ -147,13 +147,19 @@ Source: "..\cli\bin\AefosAgent.exe"; DestDir: "{userappdata}\Aefos\bin"; Flags: 
 ; aefos.exe: the shared state outlives either edition's uninstall.
 Source: "..\cli\bin\aefos.exe"; DestDir: "{userappdata}\Aefos\bin"; Flags: ignoreversion skipifsourcedoesntexist uninsneveruninstall
 
-; Bundled Desktop MCP addon (offline), when a packed dist is present. The Desktop
-; MCP is an ADDON: it is published in the addons repository and normally obtained
-; with `aefos install desktop` (binary included). Only the source of its server
-; executable lives in this repo, so nothing here produces the dist.
-; If a dist IS staged under mcps\desktop\dist, it rides along verbatim into
-; {app}\addons and the [Run] step seeds it with no download.
-; skipifsourcedoesntexist: without it, the installer simply ships online-only.
+; Bundled Desktop MCP addon (offline). The Desktop MCP is an ADDON: it is
+; published in the addons repository and updated with `aefos update desktop`.
+; The copy bundled here is what a machine with NO network gets - the [Run] step
+; below seeds it with no download.
+;
+; scripts\pack-desktop-addon.ps1 produces this dist (from the exe THIS tree
+; built), and build-packages.ps1 runs it as part of the standard build. That
+; wiring was missing once and the failure was silent: skipifsourcedoesntexist
+; means a tree with no dist ships online-only WITHOUT complaining, so the desktop
+; tools were simply absent offline and nothing said why. The flags stay - an
+; installer must still build when the dist was deliberately not staged - but the
+; dist is now produced by default, so the quiet path is the exception, not the
+; norm.
 Source: "..\mcps\desktop\dist\registry.json"; DestDir: "{app}\addons"; Flags: ignoreversion skipifsourcedoesntexist
 Source: "..\mcps\desktop\dist\addons\*"; DestDir: "{app}\addons\addons"; Flags: recursesubdirs createallsubdirs ignoreversion skipifsourcedoesntexist
 

--- a/installer/build-installer.ps1
+++ b/installer/build-installer.ps1
@@ -128,11 +128,25 @@ if ($cliStaged.Count -gt 0) {
   Write-Host "Bundled CLIs: none staged (installer ships without them). Pass -FetchClis to bundle." -ForegroundColor DarkYellow
 }
 
-# The Desktop MCP is an ADDON: it is published in the addons repository and
-# obtained with `aefos install desktop`, binary included. Only the source of its
-# server executable lives here (mcps\desktop), so this installer does not bundle
-# it offline. The .iss staging lines are skipifsourcedoesntexist, so a build
-# without a packed dist simply ships online-only.
+# The Desktop MCP is an ADDON: its binary travels INSIDE the addon zip, never as
+# a loose file of this installer, so it arrives only when the addon is installed.
+# scripts\pack-desktop-addon.ps1 packs the offline copy and build-packages.ps1
+# runs it, so a normal build has one staged and the installer seeds it with no
+# download.
+#
+# Report what is actually staged. The .iss lines are skipifsourcedoesntexist, so
+# a missing dist still builds - it just silently ships online-only, and "silently"
+# is exactly how this went unnoticed once. Say it out loud instead.
+$desktopDist = Join-Path (Split-Path -Parent $here) 'mcps\desktop\dist\registry.json'
+if (Test-Path $desktopDist) {
+  $desktopEntry = (Get-Content -LiteralPath $desktopDist -Raw | ConvertFrom-Json).addons |
+                  Where-Object { $_.slug -eq 'desktop' } | Select-Object -First 1
+  Write-Host "Bundled Desktop MCP addon: v$($desktopEntry.version) (installs offline)" -ForegroundColor Green
+} else {
+  Write-Host "Bundled Desktop MCP addon: NONE staged - the installer will ship ONLINE-ONLY," -ForegroundColor Yellow
+  Write-Host "  so a machine with no network gets no desktop tools. Run scripts\build-desktop-mcp.ps1" -ForegroundColor Yellow
+  Write-Host "  then scripts\pack-desktop-addon.ps1 (build-packages.ps1 does both)." -ForegroundColor Yellow
+}
 
 # Locate ISCC.
 if (-not $Iscc) {

--- a/scripts/build-packages.ps1
+++ b/scripts/build-packages.ps1
@@ -166,4 +166,23 @@ foreach ($v in $built) { Copy-Item $aefosExe (Join-Path $stage $v) -Force }
 Copy-Item $aefosExe $binDir -Force
 Write-Host "  OK  aefos.exe -> installer\bpl\<ver>\ + $binDir" -ForegroundColor Green
 
+# Build the out-of-process Desktop MCP server and pack it as the OFFLINE addon
+# dist the installer seeds from. This belongs in the standard build: it was not
+# here, and the consequence was silent - installer\Aefos.iss stages the dist with
+# skipifsourcedoesntexist, so a tree that never produced one shipped online-only
+# WITHOUT saying so, and the desktop tools were simply absent on a machine with
+# no network.
+#
+# One binary serves every IDE version (no ToolsAPI, no VCL, no designide), so it
+# is built once rather than per RAD Studio version like the BPLs.
+& (Join-Path $PSScriptRoot 'build-desktop-mcp.ps1') | Out-Host
+$desktopExe = Join-Path $root 'mcps\desktop\bin\AefosDesktopMcp.exe'
+if (-not (Test-Path $desktopExe)) { throw "Desktop MCP not produced: $desktopExe" }
+Write-Host "  OK  AefosDesktopMcp.exe" -ForegroundColor Green
+
+& (Join-Path $PSScriptRoot 'pack-desktop-addon.ps1') -CheckGallery | Out-Host
+$desktopRegistry = Join-Path $root 'mcps\desktop\dist\registry.json'
+if (-not (Test-Path $desktopRegistry)) { throw "Desktop MCP offline dist not produced: $desktopRegistry" }
+Write-Host "  OK  desktop addon offline dist -> mcps\desktop\dist" -ForegroundColor Green
+
 Write-Host "Next: installer\build-installer.ps1 (compiles the installer from installer\bpl\<ver>)." -ForegroundColor DarkGray

--- a/scripts/bump-version.ps1
+++ b/scripts/bump-version.ps1
@@ -73,6 +73,24 @@ Edit-File 'source/mcp/OTA/Aefos.OTA.MCP.IssueReport.pas' {
   param($t) $t -replace "(CPluginVersionFallback\s*=\s*')[0-9][0-9.]*(')", "`${1}$Version`${2}"
 } 'CPluginVersionFallback'
 
+# 3c) The addon manager's two version constants (cli/aefos.dpr).
+#
+#     CManagerVersion is what `aefos --version` prints - it read 1.0.0 on a 1.4.0
+#     product because this script only ever rewrote .dproj VerInfo, and these are
+#     plain Pascal consts no VerInfo touches.
+#
+#     CAefosBaseline is NOT cosmetic. It is the Aefos version the requirements
+#     gate compares an addon's `requirements.aefos_version` against (see
+#     AefosVersion in cli/aefos.dpr). %AEFOS_VERSION% overrides it, but nothing
+#     actually sets that variable, so the baseline IS the answer in practice: an
+#     addon requiring >=1.1.0 would be refused on a 1.4.0 install. Bumping it with
+#     the release keeps the gate honest.
+Edit-File 'cli/aefos.dpr' {
+  param($t)
+  ($t -replace "(CManagerVersion\s*=\s*')[0-9][0-9.]*(')", "`${1}$Version`${2}") `
+      -replace "(CAefosBaseline\s*=\s*')[0-9][0-9.]*(')", "`${1}$Version`${2}"
+} 'CManagerVersion + CAefosBaseline'
+
 # 4) Every Aefos .dproj VerInfo (ONLY lines tagged com.moderndelphiworks.aefos, so
 #    the generic 1.0.0.0 base-config VerInfo is left untouched).
 Get-ChildItem (Join-Path $root 'packages/Delphi') -Filter *.dproj | ForEach-Object {

--- a/scripts/pack-desktop-addon.ps1
+++ b/scripts/pack-desktop-addon.ps1
@@ -1,0 +1,168 @@
+<#
+.SYNOPSIS
+  Packs the Desktop MCP into the OFFLINE dist the installer seeds from.
+
+.DESCRIPTION
+  The Desktop MCP is an addon: it is published in the addons repository and
+  normally obtained with `aefos install desktop`. This script produces the
+  offline copy that rides inside the installer, so a fresh machine gets the
+  desktop tools with no download at all:
+
+      mcps\desktop\dist\registry.json                        -> {app}\addons\
+      mcps\desktop\dist\addons\desktop\desktop-<ver>.zip      -> {app}\addons\addons\
+
+  The registry it writes uses a RELATIVE url ("addons/desktop/desktop-<ver>.zip").
+  aefos.exe anchors a non-http url on the registry's own directory
+  (Aefos.Addons.Net.pas:128), so the whole thing resolves locally.
+
+  Two things are deliberate:
+
+  It packs the exe THIS tree built (mcps\desktop\bin), not one downloaded from
+  the gallery. Anyone building from source ships their own binary - a build that
+  quietly embedded someone else's would make the source meaningless.
+
+  It derives the version from the source of truth - DESKTOP_SERVER_VERSION in
+  Aefos.Desktop.Tools.pas - so the dist can never claim a version the binary
+  does not report over the wire.
+
+  The manifest is GENERATED here rather than kept as a second copy of the
+  bundle: the published bundle lives in the addons repository, and a duplicate
+  in this tree would drift the moment either side changed. -CheckGallery
+  compares this build against what the gallery currently serves and warns on a
+  mismatch (it never fails the build - an offline build must still work).
+
+.PARAMETER CheckGallery
+  Fetch the published registry and warn if the local version differs from it.
+
+.EXAMPLE
+  pwsh -NoProfile -File scripts/pack-desktop-addon.ps1
+
+.EXAMPLE
+  pwsh -NoProfile -File scripts/pack-desktop-addon.ps1 -CheckGallery
+#>
+[CmdletBinding()]
+param(
+  [switch] $CheckGallery
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$Repo    = Split-Path -Parent $PSScriptRoot
+$McpDir  = Join-Path $Repo 'mcps\desktop'
+$Exe     = Join-Path $McpDir 'bin\AefosDesktopMcp.exe'
+$DistDir = Join-Path $McpDir 'dist'
+$Slug    = 'desktop'
+$Registry = 'https://raw.githubusercontent.com/ModernDelphiWorks/Aefos-Addons/main/registry.json'
+
+# --- version, from the binary's own source of truth --------------------------
+$ToolsPas = Join-Path $McpDir 'Aefos.Desktop.Tools.pas'
+if (-not (Test-Path $ToolsPas)) { throw "Not found: $ToolsPas" }
+
+$VersionMatch = Select-String -Path $ToolsPas -Pattern "DESKTOP_SERVER_VERSION\s*=\s*'([0-9]+\.[0-9]+\.[0-9]+)'" |
+                Select-Object -First 1
+if (-not $VersionMatch) {
+  throw "Could not read DESKTOP_SERVER_VERSION from $ToolsPas - the dist would claim a version the server does not report."
+}
+$Version = $VersionMatch.Matches[0].Groups[1].Value
+
+Write-Host "Desktop MCP addon $Version" -ForegroundColor Cyan
+
+if (-not (Test-Path $Exe)) {
+  throw @"
+Desktop MCP binary not built: $Exe
+Run scripts\build-desktop-mcp.ps1 first (build-packages.ps1 does this for you).
+"@
+}
+
+# --- stage -------------------------------------------------------------------
+if (Test-Path $DistDir) { Remove-Item -LiteralPath $DistDir -Recurse -Force }
+$Payload = Join-Path $DistDir "staging\$Slug"
+New-Item -ItemType Directory -Force -Path (Join-Path $Payload 'mcp')   | Out-Null
+New-Item -ItemType Directory -Force -Path (Join-Path $Payload 'tools') | Out-Null
+
+$Description = 'Desktop automation MCP for the AI agent: enumerate and inspect windows and ' +
+               'UI-Automation element trees, per-window screenshots, and guarded write actions ' +
+               '- all behind an exe-path scope allow-list and off-LLM human consent. ' +
+               'Ships its own AefosDesktopMcp.exe.'
+
+$Manifest = [ordered]@{
+  slug        = $Slug
+  version     = $Version
+  name        = 'Desktop MCP'
+  description = $Description
+  trust       = 'official'
+  requirements = [ordered]@{ aefos_version = '>=0.30.0' }
+  artifacts   = [ordered]@{ command = $false; skill = $false; mcp = $true; tools = $true }
+}
+$Manifest | ConvertTo-Json -Depth 10 |
+  Set-Content -Path (Join-Path $Payload 'addon.json') -Encoding UTF8
+
+# ${ADDON_ROOT} is expanded by the installer to the absolute addon folder, so a
+# raw MCP spawn (no shell, no cwd) still finds the server.
+$Server = [ordered]@{
+  'aefos-desktop' = [ordered]@{
+    command = '${ADDON_ROOT}\tools\AefosDesktopMcp.exe'
+    args    = @()
+    env     = [ordered]@{}
+  }
+}
+$Server | ConvertTo-Json -Depth 10 |
+  Set-Content -Path (Join-Path $Payload 'mcp\server.json') -Encoding UTF8
+
+Copy-Item -LiteralPath $Exe -Destination (Join-Path $Payload 'tools') -Force
+
+# --- zip ---------------------------------------------------------------------
+$ZipName = "$Slug-$Version.zip"
+$ZipDir  = Join-Path $DistDir "addons\$Slug"
+New-Item -ItemType Directory -Force -Path $ZipDir | Out-Null
+$ZipPath = Join-Path $ZipDir $ZipName
+
+Compress-Archive -Path $Payload -DestinationPath $ZipPath -CompressionLevel Optimal
+Remove-Item -LiteralPath (Join-Path $DistDir 'staging') -Recurse -Force
+
+$Sha = (Get-FileHash -LiteralPath $ZipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+
+# --- local registry (relative url) -------------------------------------------
+$LocalRegistry = [ordered]@{
+  schema = 1
+  addons = @(
+    [ordered]@{
+      slug         = $Slug
+      name         = $Manifest.name
+      version      = $Version
+      description  = $Description
+      type         = 'mcp'
+      trust        = 'official'
+      url          = "addons/$Slug/$ZipName"
+      sha256       = $Sha
+      requirements = [ordered]@{ aefos_version = '>=0.30.0' }
+    }
+  )
+}
+$Json = $LocalRegistry | ConvertTo-Json -Depth 10
+$Json = $Json.Replace('\/', '/')
+Set-Content -Path (Join-Path $DistDir 'registry.json') -Value $Json -Encoding UTF8
+
+Write-Host "  OK  $ZipPath" -ForegroundColor Green
+Write-Host "      sha256 $Sha"
+Write-Host "  OK  $(Join-Path $DistDir 'registry.json') (relative url)" -ForegroundColor Green
+
+# --- optional drift check against the published gallery ----------------------
+if ($CheckGallery) {
+  try {
+    $Published = (Invoke-WebRequest -Uri $Registry -UseBasicParsing -TimeoutSec 20).Content | ConvertFrom-Json
+    $Entry = $Published.addons | Where-Object { $_.slug -eq $Slug }
+    if (-not $Entry) {
+      Write-Host "  ??  the gallery has no '$Slug' entry" -ForegroundColor Yellow
+    } elseif ($Entry.version -eq $Version) {
+      Write-Host "  OK  the gallery serves the same version ($Version)" -ForegroundColor Green
+    } else {
+      Write-Host "  !!  DRIFT: this tree builds $Version, the gallery serves $($Entry.version)." -ForegroundColor Yellow
+      Write-Host "      The installer will seed $Version offline; `aefos update desktop` then moves" -ForegroundColor Yellow
+      Write-Host "      the user to whatever the gallery serves. Publish first if $Version is the newer one." -ForegroundColor Yellow
+    }
+  } catch {
+    Write-Host "  --  gallery check skipped (offline): $($_.Exception.Message)" -ForegroundColor DarkYellow
+  }
+}


### PR DESCRIPTION
Three things had come loose. Each failed **quietly** — which is why none of them
ever surfaced as a bug report.

| # | What | How it failed |
|---|---|---|
| 1 | `build-desktop-mcp.ps1` had **no caller** | `build-packages.ps1` runs the agent CLI and `aefos.exe` builds, not this one — so `mcps\desktop\bin` never existed in a normal build |
| 2 | The **offline addon dist** was never packed | its packer left with the bundle when the addon moved to the gallery repo |
| 3 | `cli/aefos.dpr` was **unreachable** by `bump-version.ps1` | `aefos --version` answered `1.0.0` on a 1.4.0 product |

## The one that actually hurt users

`installer/Aefos.iss` stages the dist with `skipifsourcedoesntexist`. An
installer built without one ships **online-only without saying so** — a machine
behind a corporate proxy or with no network simply had no desktop tools, and
nothing anywhere explained why. The `.iss` comment even documented the gap
(*"nothing here produces the dist"*) as though it were the design.

The binary still travels **inside the addon zip**, never as a loose installer
file — it arrives when the addon is installed, exactly as before. What changed
is that the offline copy exists again.

## `pack-desktop-addon.ps1`

Two choices worth stating:

- **It packs the exe THIS tree built**, not one downloaded from the gallery.
  Anyone building from source ships their own binary; a build that quietly
  embedded ours would make the source meaningless.
- **The version comes from `DESKTOP_SERVER_VERSION`** in
  `Aefos.Desktop.Tools.pas`, so the dist cannot claim a version the binary does
  not report over the wire. The manifest is generated rather than kept as a
  second copy of the published bundle, and `-CheckGallery` warns (never fails)
  when this tree and the gallery disagree.

## The version constant that wasn't cosmetic

`CManagerVersion` is what `--version` prints. `CAefosBaseline` is what an addon's
`requirements.aefos_version` is **gated against**. The comment claimed the
installer sets `%AEFOS_VERSION%` to override it — `grep` says no installer sets
that variable at all, so the baseline *is* the answer in practice: an addon
requiring `>=1.1.0` would have been refused on a 1.4.0 install. Both now move
with the release, and the comment says what is true.

## Proof

Offline install run end to end against an **isolated `%USERPROFILE%`** — no
network, and the real `~/.aefos` untouched:

```
Resolving desktop ...
Downloading desktop v0.4.1 ...
Verifying integrity (sha256) ...
  + mcp      ...\.aefos\addons\desktop\mcp.json
  + tools    ...\.aefos\addons\desktop\tools
  * MCP server registered
Installed desktop v0.4.1.
```

`mcp.json` came out with `${ADDON_ROOT}` resolved to an absolute path, and the
`mcp-servers.json` aggregate was updated. The bump was run for real to `1.5.0`,
both constants confirmed rewritten, then reverted.

**Not covered here:** the Delphi build of the exe is the maintainer's to run. The
dist in this proof was packed from the already-shipped 0.4.1 binary.