### PR TITLE
Open the build to Delphi 10 Seattle and up, from one list

### DIFF
--- a/installer/build-installer.ps1
+++ b/installer/build-installer.ps1
@@ -10,7 +10,9 @@
   drops the WebView2 loader beside each version's BPLs, and runs ISCC.
 
   Supported design-time versions:
-    22.0 = Delphi 11 Alexandria   23.0 = Delphi 12 Athens   37.0 = Delphi 13
+    17.0 = 10 Seattle  18.0 = 10.1 Berlin  19.0 = 10.2 Tokyo  20.0 = 10.3 Rio
+    21.0 = 10.4 Sydney  22.0 = Delphi 11    23.0 = Delphi 12    37.0 = Delphi 13
+    (the one list: scripts\aefos-ide-versions.ps1)
 
   Usage:
     pwsh -File build-installer.ps1
@@ -30,7 +32,8 @@ $here  = Split-Path -Parent $MyInvocation.MyCommand.Path
 $stage = Join-Path $here 'bpl'
 $iss   = Join-Path $here 'Aefos.iss'
 
-$Supported = @('22.0', '23.0', '37.0')
+. (Join-Path (Split-Path -Parent $here) 'scripts\aefos-ide-versions.ps1')
+$Supported = $script:AefosIdeSupported
 $Bpls = @(
   'Aefos.Harness.bpl', 'Aefos.Providers.bpl',
   'Aefos.WebView.bpl', 'Aefos.Tools.bpl', 'Aefos.MCP.Core.bpl',
@@ -42,8 +45,8 @@ $Bpls = @(
 # it beside our BPLs and point the RTL at it by full path (SetWebView2Path). Source
 # it from any installed RAD Studio bin (Delphi 12's bin lacks it; Delphi 13 has it).
 function Get-WebView2Loader {
-  foreach ($v in @('37.0', '23.0', '22.0')) {
-    $p = "C:\Program Files (x86)\Embarcadero\Studio\$v\bin\WebView2Loader.dll"
+  foreach ($v in $script:AefosIdeVersionsNewestFirst) {
+    $p = Join-Path ${env:ProgramFiles(x86)} "Embarcadero\Studio\$v\bin\WebView2Loader.dll"
     if (Test-Path $p) { return $p }
   }
   if ($env:BDS) {
@@ -63,7 +66,29 @@ $staged = $Supported | Where-Object {
 }
 if (-not $staged) {
   throw "No version is staged under $stage. Run scripts\build-packages.ps1 (and, for " +
-        "Delphi 11, copy the VM's installer\bpl\22.0 folder here)."
+        "an IDE that lives in a VM, copy that machine's installer\bpl\<ver> folder here)."
+}
+
+# The build scripts accept every version in aefos-ide-versions.ps1, but Aefos.iss
+# carries a hand-written payload block per version (#define Ver...). So a version
+# can be built and staged while the .iss knows nothing about it - and the
+# installer would compile happily, just without those BPLs. Refuse to be quiet
+# about it: that is the same shape of silence that lost the Desktop MCP.
+$issText  = Get-Content -LiteralPath $iss -Raw
+$issKnows = @([regex]::Matches($issText, '(?m)^#define\s+Ver\w+\s+"([\d.]+)"') |
+              ForEach-Object { $_.Groups[1].Value })
+$orphans  = @($staged | Where-Object { $issKnows -notcontains $_ })
+if ($orphans.Count -gt 0) {
+  Write-Host ""
+  Write-Host "STAGED BUT NOT PACKAGED: $($orphans -join ', ')" -ForegroundColor Yellow
+  foreach ($o in $orphans) {
+    Write-Host "  $o ($(Get-AefosIdeProductName $o)) has BPLs in installer\bpl\$o, but Aefos.iss" -ForegroundColor Yellow
+    Write-Host "  has no payload block for it - those BPLs will NOT ship." -ForegroundColor Yellow
+  }
+  Write-Host "  Add a #define Ver.. plus its [Files]/[Components] block to Aefos.iss." -ForegroundColor Yellow
+  Write-Host ""
+  $staged = @($staged | Where-Object { $issKnows -contains $_ })
+  if (-not $staged) { throw "Nothing left to package: every staged version is unknown to Aefos.iss." }
 }
 
 $wv2 = Get-WebView2Loader

--- a/scripts/aefos-ide-versions.ps1
+++ b/scripts/aefos-ide-versions.ps1
@@ -1,0 +1,65 @@
+<#
+  The one list of RAD Studio versions Aefos builds for.
+
+  Dot-source this; do not copy the array. It was copied into six scripts, and a
+  copied list drifts in the worst possible way: the build accepts a version the
+  installer has never heard of, produces BPLs for it, and the payload silently
+  never ships.
+
+      . (Join-Path $PSScriptRoot 'aefos-ide-versions.ps1')
+
+  Two numbers per release and they are NOT the same. $(BDS) - the product/registry
+  version, which is what rsvars.bat and the install path use - and CompilerVersion,
+  which is what {$IF} guards in the source test. Delphi 13 is the odd one: product
+  37.0 AND compiler 37.0, after Embarcadero jumped the product numbering.
+
+  Adding a version is one row here. Everything that enumerates versions reads it.
+#>
+
+$script:AefosIdeVersions = @(
+  [pscustomobject]@{ Bds = '17.0'; Product = 'Delphi 10 Seattle';    Compiler = '30.0'; Year = 2015 }
+  [pscustomobject]@{ Bds = '18.0'; Product = 'Delphi 10.1 Berlin';   Compiler = '31.0'; Year = 2016 }
+  [pscustomobject]@{ Bds = '19.0'; Product = 'Delphi 10.2 Tokyo';    Compiler = '32.0'; Year = 2017 }
+  [pscustomobject]@{ Bds = '20.0'; Product = 'Delphi 10.3 Rio';      Compiler = '33.0'; Year = 2018 }
+  [pscustomobject]@{ Bds = '21.0'; Product = 'Delphi 10.4 Sydney';   Compiler = '34.0'; Year = 2020 }
+  [pscustomobject]@{ Bds = '22.0'; Product = 'Delphi 11 Alexandria'; Compiler = '35.0'; Year = 2021 }
+  [pscustomobject]@{ Bds = '23.0'; Product = 'Delphi 12 Athens';     Compiler = '36.0'; Year = 2023 }
+  [pscustomobject]@{ Bds = '37.0'; Product = 'Delphi 13';            Compiler = '37.0'; Year = 2025 }
+)
+
+# Newest first: every "pick whichever is installed" loop wants the newest that is
+# actually there, not the oldest.
+$script:AefosIdeVersionsNewestFirst = @(
+  $script:AefosIdeVersions | Sort-Object { [double] $_.Bds } -Descending | ForEach-Object { $_.Bds }
+)
+
+$script:AefosIdeSupported = @($script:AefosIdeVersions | ForEach-Object { $_.Bds })
+
+function Get-AefosIdeProductName {
+  param([Parameter(Mandatory = $true)][string] $Bds)
+  $row = $script:AefosIdeVersions | Where-Object { $_.Bds -eq $Bds } | Select-Object -First 1
+  if ($row) { $row.Product } else { "BDS $Bds" }
+}
+
+function Get-AefosInstalledIdeVersions {
+  <#
+    .SYNOPSIS
+      The supported versions whose RAD Studio is actually installed, newest first.
+
+    .DESCRIPTION
+      Presence is decided by rsvars.bat, not by the registry: rsvars is what a
+      command-line build actually needs, and an installed-but-unregistered
+      product has it while a registry entry can outlive an uninstall.
+  #>
+  param()
+  $found = @()
+  foreach ($v in $script:AefosIdeVersionsNewestFirst) {
+    if (Test-Path (Get-AefosRsVarsPath $v)) { $found += $v }
+  }
+  return $found
+}
+
+function Get-AefosRsVarsPath {
+  param([Parameter(Mandatory = $true)][string] $Bds)
+  Join-Path ${env:ProgramFiles(x86)} "Embarcadero\Studio\$Bds\bin\rsvars.bat"
+}

--- a/scripts/build-aefos-cli.ps1
+++ b/scripts/build-aefos-cli.ps1
@@ -6,7 +6,7 @@
   A plain Win32 console EXE (RTL + the Aefos.Compat.* shims in source\compat for
   HTTP/SHA-256/ZIP/JSON/IO - no ToolsAPI, no VCL). ONE binary serves every IDE
   version; compiled once with whichever RAD Studio command line is installed
-  (D13/37.0 preferred, then D12/23.0, then D11/22.0). No IDE needs to be open. The same sources
+  (newest installed first, back to 10 Seattle/17.0). No IDE needs to be open. The same sources
   build under FPC 3.2.2 (see scripts\build-fpc.ps1 -Clis).
 
 .EXAMPLE
@@ -14,7 +14,7 @@
 #>
 [CmdletBinding()]
 param(
-  [string] $Version  # optional: '37.0' or '23.0'; auto-detected when omitted
+  [string] $Version  # optional: any supported BDS, e.g. '37.0' or '17.0'; auto-detected when omitted
 )
 
 $ErrorActionPreference = 'Stop'
@@ -25,10 +25,13 @@ $dcu  = Join-Path $repo 'cli\.build-aefos'
 
 if (-not (Test-Path $dpr)) { throw "CLI program not found: $dpr" }
 
-$candidates = if ($Version) { @($Version) } else { @('37.0', '23.0', '22.0') }
+# One binary serves every IDE version, so ANY installed RAD Studio can build it -
+# newest first. The list is scripts\aefos-ide-versions.ps1; never a copy.
+. (Join-Path $PSScriptRoot 'aefos-ide-versions.ps1')
+$candidates = if ($Version) { @($Version) } else { $script:AefosIdeVersionsNewestFirst }
 $rsvars = $null
 foreach ($v in $candidates) {
-  $p = "C:\Program Files (x86)\Embarcadero\Studio\$v\bin\rsvars.bat"
+  $p = Get-AefosRsVarsPath $v
   if (Test-Path $p) { $rsvars = $p; break }
 }
 if (-not $rsvars) { throw "No installed RAD Studio (looked for: $($candidates -join ', '))." }

--- a/scripts/build-agent-cli.ps1
+++ b/scripts/build-agent-cli.ps1
@@ -6,14 +6,14 @@
   The CLI is a plain Win32 console EXE (RTL-only: System.Net + threading, no
   ToolsAPI, no VCL) - ONE binary serves every supported IDE version, so it is
   compiled once with whichever RAD Studio command line is installed (D13/37.0
-  preferred, then D12/23.0, then D11/22.0). No IDE needs to be open.
+  preferred, down to 10 Seattle/17.0). No IDE needs to be open.
 
 .EXAMPLE
   pwsh -NoProfile -File scripts/build-agent-cli.ps1
 #>
 [CmdletBinding()]
 param(
-  [string] $Version  # optional: '37.0' or '23.0'; auto-detected when omitted
+  [string] $Version  # optional: any supported BDS, e.g. '37.0' or '17.0'; auto-detected when omitted
 )
 
 $ErrorActionPreference = 'Stop'
@@ -25,10 +25,13 @@ $dcu  = Join-Path $repo 'cli\.build'
 if (-not (Test-Path $dpr)) { throw "CLI program not found: $dpr" }
 
 # Resolve a RAD Studio rsvars.bat.
-$candidates = if ($Version) { @($Version) } else { @('37.0', '23.0', '22.0') }
+# One binary serves every IDE version, so ANY installed RAD Studio can build it -
+# newest first. The list is scripts\aefos-ide-versions.ps1; never a copy.
+. (Join-Path $PSScriptRoot 'aefos-ide-versions.ps1')
+$candidates = if ($Version) { @($Version) } else { $script:AefosIdeVersionsNewestFirst }
 $rsvars = $null
 foreach ($v in $candidates) {
-  $p = "C:\Program Files (x86)\Embarcadero\Studio\$v\bin\rsvars.bat"
+  $p = Get-AefosRsVarsPath $v
   if (Test-Path $p) { $rsvars = $p; break }
 }
 if (-not $rsvars) { throw "No installed RAD Studio (looked for: $($candidates -join ', '))." }

--- a/scripts/build-desktop-mcp.ps1
+++ b/scripts/build-desktop-mcp.ps1
@@ -14,7 +14,7 @@
   which closes the D11/D12 gap (those IDEs do not ship Winapi.UIAutomation).
 
   Compiled with whichever RAD Studio command line is installed (D13/37.0
-  preferred, then D12/23.0, then D11/22.0). No IDE needs to be open. Pass -Version
+  preferred, down to 10 Seattle/17.0). No IDE needs to be open. Pass -Version
   to force one.
 
   -Test also stands the freshly built .exe up as a real MCP server and drives a
@@ -27,7 +27,7 @@
 #>
 [CmdletBinding()]
 param(
-  [string] $Version,   # optional: '37.0' or '23.0'; auto-detected when omitted
+  [string] $Version,   # optional: any supported BDS, e.g. '37.0' or '17.0'; auto-detected when omitted
   [switch] $Test
 )
 
@@ -39,10 +39,13 @@ $dcu  = Join-Path $repo 'mcps\desktop\.build'
 
 if (-not (Test-Path $dpr)) { throw "Desktop MCP program not found: $dpr" }
 
-$candidates = if ($Version) { @($Version) } else { @('37.0', '23.0', '22.0') }
+# One binary serves every IDE version, so ANY installed RAD Studio can build it -
+# newest first. The list is scripts\aefos-ide-versions.ps1; never a copy.
+. (Join-Path $PSScriptRoot 'aefos-ide-versions.ps1')
+$candidates = if ($Version) { @($Version) } else { $script:AefosIdeVersionsNewestFirst }
 $rsvars = $null
 foreach ($v in $candidates) {
-  $p = "C:\Program Files (x86)\Embarcadero\Studio\$v\bin\rsvars.bat"
+  $p = Get-AefosRsVarsPath $v
   if (Test-Path $p) { $rsvars = $p; break }
 }
 if (-not $rsvars) { throw "No installed RAD Studio (looked for: $($candidates -join ', '))." }

--- a/scripts/build-packages.ps1
+++ b/scripts/build-packages.ps1
@@ -7,10 +7,18 @@
   (the design-time BPLs load into the 32-bit IDE) and stage the built BPLs into
   installer\bpl\<ver>\ so installer\build-installer.ps1 can package them.
 
-  Supported design-time versions (the only ones that ship a plugin):
-    22.0 = Delphi 11 Alexandria (compiler 35.0)
-    23.0 = Delphi 12 Athens     (compiler 36.0)
-    37.0 = Delphi 13            (compiler 37.0)
+  Supported design-time versions (the only ones that ship a plugin) live in ONE
+  place -- scripts\aefos-ide-versions.ps1 -- which this script dot-sources. Adding
+  a Delphi is a row there, not an edit here. Today: 10 Seattle (17.0) through 13
+  (37.0).
+
+  Reaching back to Seattle is deliberate and cheap: nothing in the RTL Aefos uses
+  is newer than 2015 (System.Net.HttpClient and System.Hash arrived in XE8, which
+  Seattle ships), the WebView2 layer is our own COM import rather than Vcl.Edge
+  (which only exists from 10.4), and the source is free of inline var by house
+  rule. The one unit that is newer -- ToolsAPI.Editor, Delphi 12 -- is gated by
+  {$IF CompilerVersion >= 36} around the WHOLE unit, because gating just the call
+  is not enough when the .dpk still lists it in `contains`.
 
   Cross-machine note: a version builds only where its RAD Studio is installed AND
   registered (command-line dcc needs the per-user product registry). Build each
@@ -29,7 +37,10 @@
 #>
 [CmdletBinding()]
 param(
-  [ValidateSet('22.0', '23.0', '37.0', 'all')]
+  # Keep in step with scripts\aefos-ide-versions.ps1 -- ValidateSet needs literals
+  # (it is evaluated at parse time), so this is the one list that cannot be
+  # computed. The check right after the dot-source fails loudly if the two drift.
+  [ValidateSet('17.0', '18.0', '19.0', '20.0', '21.0', '22.0', '23.0', '37.0', 'all')]
   [string]$Version = 'all',
   [ValidateSet('Release', 'Debug')]
   [string]$Config = 'Release',
@@ -42,11 +53,23 @@ param(
 
 $ErrorActionPreference = 'Stop'
 $root  = Split-Path -Parent $PSScriptRoot
-$grp   = Join-Path $root 'Packages\Delphi\AefosGroup.groupproj'
+# Lower-case 'packages': the tree was renamed and git tracks it that way. Windows
+# would not care; a case-sensitive checkout would fail to find the group project.
+$grp   = Join-Path $root 'packages\Delphi\AefosGroup.groupproj'
 $stage = Join-Path $root 'installer\bpl'
 if (-not (Test-Path $grp)) { throw "Group project not found: $grp" }
 
-$Supported = @('22.0', '23.0', '37.0')   # 22.0 = D11, 23.0 = D12, 37.0 = D13
+. (Join-Path $PSScriptRoot 'aefos-ide-versions.ps1')
+$Supported = $script:AefosIdeSupported
+
+# The ValidateSet above is literal by necessity. Prove it still matches the one
+# list, so a version added there can never be silently rejected here.
+$declared = @('17.0', '18.0', '19.0', '20.0', '21.0', '22.0', '23.0', '37.0')
+$drift = @(Compare-Object -ReferenceObject $declared -DifferenceObject $Supported)
+if ($drift.Count -gt 0) {
+  throw ("-Version's ValidateSet and aefos-ide-versions.ps1 disagree: {0}. Update the ValidateSet literal." -f
+         (($drift | ForEach-Object { "$($_.InputObject) ($($_.SideIndicator))" }) -join ', '))
+}
 $Bpls = @(
   'Aefos.Harness.bpl', 'Aefos.Providers.bpl',
   'Aefos.WebView.bpl', 'Aefos.Tools.bpl', 'Aefos.MCP.Core.bpl',
@@ -62,10 +85,9 @@ function Get-PublicBplDir([string]$Ver, [string]$Plat) {
 # Resolve the version list. 'all' = every supported version installed on THIS
 # machine (rsvars present); explicit version is taken as-is.
 if ($Version -eq 'all') {
-  $targets = $Supported | Where-Object {
-    Test-Path "C:\Program Files (x86)\Embarcadero\Studio\$_\bin\rsvars.bat"
-  }
+  $targets = Get-AefosInstalledIdeVersions
   if (-not $targets) { throw "No supported RAD Studio version is installed on this machine." }
+  Write-Host ("Installed: " + (($targets | ForEach-Object { "$_ ($(Get-AefosIdeProductName $_))" }) -join ', ')) -ForegroundColor DarkGray
 } else {
   $targets = @($Version)
 }
@@ -103,7 +125,7 @@ $plats = if ($Platform -eq 'all') { @('Win32', 'Win64') } else { @($Platform) }
 
 $built = @()
 foreach ($v in $targets) {
-  $rsvars = "C:\Program Files (x86)\Embarcadero\Studio\$v\bin\rsvars.bat"
+  $rsvars = Get-AefosRsVarsPath $v
   if (-not (Test-Path $rsvars)) {
     Write-Warning "Delphi $v not installed (no rsvars at $rsvars) -- skipping."
     continue


### PR DESCRIPTION
The Seattle test needs a build that accepts `17.0`. Today `build-packages.ps1`
rejects it at the parameter.

## One list instead of six copies

Six scripts each carried their own supported-version array, so "support a new
Delphi" meant finding all six — and a copied list drifts in the worst direction:
the build accepts a version the installer has never heard of, produces BPLs for
it, and the payload **silently never ships**.

`scripts/aefos-ide-versions.ps1` is now the only list — **17.0 (10 Seattle)
through 37.0 (13)** — each row carrying both numbers that get confused:

| $(BDS) | Product | CompilerVersion |
|---|---|---|
| 17.0 | 10 Seattle | 30.0 |
| 18.0 | 10.1 Berlin | 31.0 |
| 19.0 | 10.2 Tokyo | 32.0 |
| 20.0 | 10.3 Rio | 33.0 |
| 21.0 | 10.4 Sydney | 34.0 |
| 22.0 | 11 Alexandria | 35.0 |
| 23.0 | 12 Athens | 36.0 |
| 37.0 | 13 | 37.0 |

`-Version`'s ValidateSet can't be computed (parse-time), so it stays literal —
and a check right after the dot-source **throws if the two disagree**. Verified
by adding a version to the list alone: the script refuses before building
anything.

## Why Seattle is cheap to reach

Nothing in the RTL Aefos touches is newer than 2015 — `System.Net.HttpClient`
and `System.Hash` are XE8, which Seattle ships. The WebView2 layer is our own COM
import rather than `Vcl.Edge` (10.4+). The source is free of inline `var` by
house rule. The one newer unit, `ToolsAPI.Editor`, is already gated whole.

## Two silences closed

**`build-installer` now reports what it is NOT packaging.** `Aefos.iss` carries a
hand-written payload block per version, so a freshly supported `17.0` can be built
and staged while the `.iss` knows nothing about it — the installer would compile
happily, minus those BPLs. Verified with a fake `installer\bpl\17.0`:

```
STAGED BUT NOT PACKAGED: 17.0
  17.0 (Delphi 10 Seattle) has BPLs in installer\bpl\17.0, but Aefos.iss
  has no payload block for it - those BPLs will NOT ship.
```

**Two path bugs.** The rsvars/WebView2 lookups hardcoded `C:\Program Files (x86)`;
they go through `${env:ProgramFiles(x86)}` now. And `build-packages` pointed at
`Packages\Delphi` with a capital P — the tree was renamed to lower case and git
tracks it that way, so Windows forgave it and a case-sensitive checkout would not.

## Deliberately not here

`Aefos.iss` is untouched. Adding five payload blocks for versions nobody has
compiled would be guessing; they go in as each version proves it builds — Seattle
first. Until then the new warning makes the gap loud instead of silent.