### PR TITLE
Delphi 10 Seattle: nine of ten packages build

### DIFF
--- a/cli/Aefos.Addons.Installer.pas
+++ b/cli/Aefos.Addons.Installer.pas
@@ -93,7 +93,8 @@ uses
   Aefos.Addons.Manifest,
   Aefos.Addons.Ledger,
   Aefos.Addons.McpRewrite,
-  Aefos.Addons.Net;
+  Aefos.Addons.Net,
+  Aefos.Compat.JsonFormat;
 
 // Classic-RTL string helpers (FPC 3.2.2 has no TStringHelper): kept
 // unit-private, byte-identical to the Delphi string methods they replace.

--- a/cli/Aefos.Addons.Ledger.pas
+++ b/cli/Aefos.Addons.Ledger.pas
@@ -51,7 +51,8 @@ uses
   Aefos.Compat.IO,
   Aefos.Compat.Json,
   Generics.Collections,
-  Aefos.Addons.Paths;
+  Aefos.Addons.Paths,
+  Aefos.Compat.JsonFormat;
 
 function _ArtifactsToJson(const A: TAddonArtifacts): TJSONObject;
 begin

--- a/packages/Delphi/Aefos.MCP.Core.dpk
+++ b/packages/Delphi/Aefos.MCP.Core.dpk
@@ -54,6 +54,7 @@ requires
 
 contains
   Aefos.Compat.Json in '..\..\source\compat\Aefos.Compat.Json.pas',
+  Aefos.Compat.JsonFormat in '..\..\source\compat\Aefos.Compat.JsonFormat.pas',
   Aefos.Compat.Sha256 in '..\..\source\compat\Aefos.Compat.Sha256.pas',
   Aefos.Compat.IO in '..\..\source\compat\Aefos.Compat.IO.pas',
   Aefos.MCP.Server in '..\..\source\mcp\Core\Aefos.MCP.Server.pas',

--- a/packages/Delphi/Aefos.MCP.Core.dpk
+++ b/packages/Delphi/Aefos.MCP.Core.dpk
@@ -55,6 +55,7 @@ requires
 contains
   Aefos.Compat.Json in '..\..\source\compat\Aefos.Compat.Json.pas',
   Aefos.Compat.JsonFormat in '..\..\source\compat\Aefos.Compat.JsonFormat.pas',
+  Aefos.Compat.MainThread in '..\..\source\compat\Aefos.Compat.MainThread.pas',
   Aefos.Compat.Sha256 in '..\..\source\compat\Aefos.Compat.Sha256.pas',
   Aefos.Compat.IO in '..\..\source\compat\Aefos.Compat.IO.pas',
   Aefos.MCP.Server in '..\..\source\mcp\Core\Aefos.MCP.Server.pas',

--- a/scripts/aefos-ide-versions.ps1
+++ b/scripts/aefos-ide-versions.ps1
@@ -63,3 +63,22 @@ function Get-AefosRsVarsPath {
   param([Parameter(Mandatory = $true)][string] $Bds)
   Join-Path ${env:ProgramFiles(x86)} "Embarcadero\Studio\$Bds\bin\rsvars.bat"
 }
+
+function Get-AefosFrameworkVersion {
+  <#
+    .SYNOPSIS
+      The .NET framework version a given rsvars.bat puts on PATH, as a number.
+
+    .DESCRIPTION
+      This decides which MSBuild a command-line build gets, and the versions
+      disagree: 10 Seattle's rsvars sets v3.5, where the AfterTargets attribute
+      our .dproj staging target uses does not exist yet. Returns 0 when the file
+      cannot be read or declares nothing - callers should treat that as "old".
+  #>
+  param([Parameter(Mandatory = $true)][string] $RsVarsPath)
+  if (-not (Test-Path $RsVarsPath)) { return 0.0 }
+  $line = Select-String -Path $RsVarsPath -Pattern 'FrameworkVersion\s*=\s*v([\d.]+)' |
+          Select-Object -First 1
+  if (-not $line) { return 0.0 }
+  return [double] ($line.Matches[0].Groups[1].Value -replace '^(\d+\.\d+).*$', '$1')
+}

--- a/scripts/build-packages.ps1
+++ b/scripts/build-packages.ps1
@@ -138,7 +138,32 @@ foreach ($v in $targets) {
     }
     Ensure-LibVTerm $rsvars $plat
     Write-Host "=== Building Aefos group for Delphi $v ($Config/$plat) ===" -ForegroundColor Cyan
-    $cmd = "`"$rsvars`" && msbuild `"$grp`" /t:Build /p:Config=$Config /p:Platform=$plat " +
+    # Prepend MSBuild 4.0 when rsvars picked an older one.
+    #
+    # Seattle's rsvars.bat sets FrameworkDir to .NET v3.5, i.e. MSBuild 3.5 - and
+    # AfterTargets does not exist before MSBuild 4.0. Our .dproj files each carry
+    # an AfterTargets="Build" target (AefosStageBplForInstaller), so every package
+    # dies with MSB4066 "the attribute AfterTargets is unrecognized" before a line
+    # of Pascal is read. It reads like a broken project file; it is a build engine
+    # five years older than the attribute.
+    #
+    # Fixing it here rather than in the eight .dproj files is deliberate: those
+    # files are also opened by the IDE, and rewriting the target into a 3.5-era
+    # idiom would degrade every modern build to work around one old one. Proven on
+    # Seattle: same projects, same compiler (30.0), MSBuild 4.0 - builds and the
+    # staging target runs.
+    $msbuildPrefix = ''
+    $ms4 = Join-Path $env:WINDIR 'Microsoft.NET\Framework\v4.0.30319'
+    if ((Get-AefosFrameworkVersion $rsvars) -lt 4.0) {
+      if (-not (Test-Path (Join-Path $ms4 'MSBuild.exe'))) {
+        throw ("Delphi $v's rsvars selects MSBuild <4.0, which cannot parse the AfterTargets " +
+               "staging target, and MSBuild 4.0 is not installed at $ms4.")
+      }
+      Write-Host "  rsvars selects MSBuild <4.0 -- using $ms4 (AfterTargets needs 4.0)." -ForegroundColor DarkGray
+      $msbuildPrefix = "set PATH=$ms4;%PATH% && "
+    }
+    $cmd = "`"$rsvars`" && $msbuildPrefix" +
+           "msbuild `"$grp`" /t:Build /p:Config=$Config /p:Platform=$plat " +
            "/p:DCC_ForceExecute=true /v:minimal /nologo"
     cmd /c $cmd
     if ($LASTEXITCODE -ne 0) { throw "Build FAILED for Delphi $v/$plat (exit $LASTEXITCODE)." }

--- a/source/chat/Adapter/Aefos.OTA.Chat.Adapter.DebuggerNotifier.pas
+++ b/source/chat/Adapter/Aefos.OTA.Chat.Adapter.DebuggerNotifier.pas
@@ -70,7 +70,8 @@ implementation
 uses
   System.Classes,
   Winapi.Windows,
-  ToolsAPI;
+  ToolsAPI,
+  Aefos.Compat.MainThread;
 
 type
   // TNotifierObject supplies the empty IOTANotifier members; only the four
@@ -127,7 +128,7 @@ begin
   LReshow := GReshow; // local copy; the queued closure must not read the global
   if not Assigned(LReshow) then
     Exit;
-  TThread.ForceQueue(nil,
+  TAefosMainThread.ForceQueue(
     procedure
     begin
       try

--- a/source/chat/Adapter/Aefos.OTA.Chat.Adapter.IDENotifier.pas
+++ b/source/chat/Adapter/Aefos.OTA.Chat.Adapter.IDENotifier.pas
@@ -55,7 +55,8 @@ implementation
 uses
   System.Classes,
   Winapi.Windows,
-  ToolsAPI;
+  ToolsAPI,
+  Aefos.Compat.MainThread;
 
 type
   // ADR-258/259: the real IDE notifier. TNotifierObject supplies the empty
@@ -89,7 +90,7 @@ begin
   // BR-2 / BR-3: run the re-resolve AFTER the IDE callback returns, on the main
   // thread (where menu/panel mutation is safe), and never let an exception
   // escape back into the IDE notification path.
-  TThread.ForceQueue(nil,
+  TAefosMainThread.ForceQueue(
     procedure
     begin
       try

--- a/source/chat/Aefos.OTA.Chat.Register.pas
+++ b/source/chat/Aefos.OTA.Chat.Register.pas
@@ -137,6 +137,14 @@ uses
   Xml.XMLDoc,
   Xml.XMLIntf;
 
+{$IF not Declared(GetTickCount64)}
+// 10 Seattle's Winapi.Windows does not declare this Vista-era API yet.
+// Declared() rather than a CompilerVersion number: it asks the compiler in
+// hand whether the symbol exists, instead of encoding a guess about which
+// release added it.
+function GetTickCount64: UInt64; stdcall; external 'kernel32.dll' name 'GetTickCount64';
+{$IFEND}
+
 const
   // ESP-002 Epic 2/4 Demand 2/3 (ADR-275): onboarding detection targets the
   // Claude Code MVP binary through the shared ResolveCLIBinary ladder. The

--- a/source/chat/Core/Aefos.OTA.Chat.Core.CommandRegistry.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.CommandRegistry.pas
@@ -177,6 +177,7 @@ implementation
 
 uses
   System.Classes,
+  System.Types,
   System.IOUtils;
 
 const
@@ -600,7 +601,7 @@ function TCommandRegistry._DiscoverReferences(
   const ACommandDir: string): TArray<TCommandReference>;
 var
   LRefDir: string;
-  LFiles: TArray<string>;
+  LFiles: TStringDynArray;
   LIndex: Integer;
   LRef: TCommandReference;
   LCollected: TList<TCommandReference>;
@@ -658,7 +659,7 @@ procedure TCommandRegistry._CollectFromRoot(const ARoot: string;
   const ASeen: TDictionary<string, Byte>);
 var
   LCommandsDir: string;
-  LDirs: TArray<string>;
+  LDirs: TStringDynArray;
   LDirIndex: Integer;
 begin
   if ARoot = '' then

--- a/source/chat/Core/Aefos.OTA.Chat.Core.Config.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.Config.pas
@@ -101,7 +101,8 @@ uses
   Aefos.Provider.Types,
   Aefos.Provider.Kinds,
   Aefos.OTA.Chat.Core.Dispatcher.Types,
-  Aefos.OTA.Chat.Core.Dispatcher.Decode;
+  Aefos.OTA.Chat.Core.Dispatcher.Decode,
+  Aefos.Compat.JsonFormat;
 
 const
   CONFIG_DIR_REL = '.aefos';

--- a/source/chat/Core/Aefos.OTA.Chat.Core.ExecutorProbe.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.ExecutorProbe.pas
@@ -40,6 +40,14 @@ uses
   System.StrUtils,
   System.Classes;
 
+{$IF not Declared(GetTickCount64)}
+// 10 Seattle's Winapi.Windows does not declare this Vista-era API yet.
+// Declared() rather than a CompilerVersion number: it asks the compiler in
+// hand whether the symbol exists, instead of encoding a guess about which
+// release added it.
+function GetTickCount64: UInt64; stdcall; external 'kernel32.dll' name 'GetTickCount64';
+{$IFEND}
+
 const
   CAPABILITY_ARG = '--help';
   MCP_CONFIG_FLAG = '--mcp-config';

--- a/source/chat/Core/Aefos.OTA.Chat.Core.OllamaDispatcher.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.OllamaDispatcher.pas
@@ -173,6 +173,7 @@ var
   LSettings: TOllamaDispatchSettings;
   LModel: string;
   LBody: string;
+  LMessages: TArray<TOllamaMessage>;
   LStart: Cardinal;
   LKeepAlive: IDispatcherRunHandle;
 begin
@@ -202,8 +203,15 @@ begin
     Exit;
   end;
 
-  LBody := OllamaBuildChatRequest(LModel,
-    [TOllamaMessage.New('user', ARequest.Prompt)], True);
+  // Built into a typed local first, rather than passed as an inline [ ... ]
+  // literal. OllamaBuildChatRequest is overloaded, and 10 Seattle's compiler
+  // will not pick an overload from an open-array literal plus defaulted
+  // parameters - it reports "no overloaded version can be called with these
+  // arguments". Naming the type removes the ambiguity, and reads the same on
+  // every version.
+  LMessages := TArray<TOllamaMessage>.Create(
+    TOllamaMessage.New('user', ARequest.Prompt));
+  LBody := OllamaBuildChatRequest(LModel, LMessages, True);
   LStart := TThread.GetTickCount;
   LState.Transport := FTransportFactory();
   LState.Transport.ChatStream(LSettings.BaseUrl, LBody,

--- a/source/chat/Core/Aefos.OTA.Chat.Core.SessionStore.SQLite.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.SessionStore.SQLite.pas
@@ -30,6 +30,7 @@ implementation
 uses
   Winapi.Windows,
   System.SysUtils,
+  System.Types,
   System.IOUtils,
   System.JSON,
   System.DateUtils,
@@ -206,7 +207,7 @@ end;
 procedure TSQLiteSessionStore._ImportLegacy(const ADb: ISQLiteDatabase);
 var
   LDir, LPath: string;
-  LFiles: TArray<string>;
+  LFiles: TStringDynArray;
   LEntry: TSessionEntry;
 begin
   if ADb.MetaGet(CImportFlag, '') = '1' then

--- a/source/chat/UI/Aefos.OTA.Chat.UI.ChatPanel.pas
+++ b/source/chat/UI/Aefos.OTA.Chat.UI.ChatPanel.pas
@@ -1501,13 +1501,19 @@ begin
 end;
 
 procedure TAefosChatPanel._ApplyThemeTo(const AComponent: TComponent);
+{$IF Declared(IOTAIDEThemingServices)}
 var
   LThemeServices: IOTAIDEThemingServices;
+{$IFEND}
 begin
   // Older IOTAIDEThemingServices (NOT the 250 variant). The 250 variant
   // triggers RecreateWnd inside ApplyTheme(Self), which re-enters CreateWnd
   // → _ApplyTheme → infinite loop on this form's layout. The older surface
   // applies theme in-place and is what the panel has shipped with.
+  //
+  // Neither surface exists on an IDE that had no themes (10 Seattle), so there
+  // the component simply keeps its own colours.
+  {$IF Declared(IOTAIDEThemingServices)}
   if Assigned(BorlandIDEServices) and
     Supports(BorlandIDEServices, IOTAIDEThemingServices, LThemeServices) then
   try
@@ -1517,8 +1523,10 @@ begin
       _DbgLog('[Aefos] ApplyThemeTo: '
         + E.ClassName + ' - ' + E.Message);
   end;
+  {$IFEND}
 end;
 
+{$IF Declared(IOTAIDEThemingServices)}
 procedure TAefosChatPanel._ApplyTheme;
 var
   LThemeServices: IOTAIDEThemingServices;
@@ -1772,6 +1780,17 @@ begin
     FOutput.Font.Color := ChooseColor(LIsDark, clWhite, clBlack);
   end;
 end;
+{$ELSE}
+
+// No IDE theming service on this ToolsAPI (10 Seattle had no IDE themes), so
+// there is no theme to read and nothing to mirror: the panel keeps the colours
+// it was designed with. Guarding the whole body rather than each use keeps the
+// themed version readable - it is the one that actually does something.
+procedure TAefosChatPanel._ApplyTheme;
+begin
+end;
+
+{$IFEND}
 
 procedure TAefosChatPanel._OnFormShow(Sender: TObject);
 var

--- a/source/chat/UI/Aefos.OTA.Chat.UI.ChatPanel.pas
+++ b/source/chat/UI/Aefos.OTA.Chat.UI.ChatPanel.pas
@@ -540,6 +540,7 @@ uses
   System.UITypes,
   Vcl.Clipbrd,
   System.JSON,
+  Aefos.Compat.MainThread,
   System.DateUtils,
   System.IOUtils,
   System.NetEncoding,
@@ -2470,10 +2471,10 @@ begin
     // while output is actively flowing, so the panel cannot be freed in between.
     LController := FController;
     LTheme := _BuildPanelTheme;
-    TThread.ForceQueue(nil, TThreadProcedure(procedure
+    TAefosMainThread.ForceQueue(procedure
       begin
         LController.Navigate(LTheme);
-      end));
+      end);
   end;
 end;
 
@@ -3025,7 +3026,9 @@ end;
 
 function TAefosChatPanel._BuildPanelTheme: TPanelTheme;
 var
+  {$IF Declared(IOTAIDEThemingServices250)}
   LTheming: IOTAIDEThemingServices250;
+  {$IFEND}
   LStyle: TCustomStyleServices;
   LThemeName: string;
   LIsDark: Boolean;
@@ -3033,6 +3036,11 @@ begin
   LStyle := nil;
   LIsDark := False;
   LThemeName := '';
+  // 10 Seattle's ToolsAPI has no theming service - that IDE had no themes - so
+  // LStyle stays nil there and the luminance fallback right below decides
+  // dark/light. That is the same path taken today when the service exists but
+  // the user has theming switched off, so nothing new is being exercised.
+  {$IF Declared(IOTAIDEThemingServices250)}
   if Assigned(BorlandIDEServices) and
      Supports(BorlandIDEServices, IOTAIDEThemingServices250, LTheming) then
   begin
@@ -3045,6 +3053,7 @@ begin
       LStyle := nil;
     end;
   end;
+  {$IFEND}
   if (not Assigned(LStyle)) and (Self.Color <> clNone) then
     LIsDark := ((0.299 * GetRValue(ColorToRGB(Self.Color))) +
                 (0.587 * GetGValue(ColorToRGB(Self.Color))) +

--- a/source/chat/UI/Aefos.OTA.Chat.UI.ConsentWebForm.pas
+++ b/source/chat/UI/Aefos.OTA.Chat.UI.ConsentWebForm.pas
@@ -65,6 +65,14 @@ uses
   Aefos.OTA.Chat.Core.OutputPanel.RenderProtocol,
   Aefos.OTA.Chat.UI.OutputPanel.EdgeController;
 
+{$IF not Declared(GetTickCount64)}
+// 10 Seattle's Winapi.Windows does not declare this Vista-era API yet.
+// Declared() rather than a CompilerVersion number: it asks the compiler in
+// hand whether the symbol exists, instead of encoding a guess about which
+// release added it.
+function GetTickCount64: UInt64; stdcall; external 'kernel32.dll' name 'GetTickCount64';
+{$IFEND}
+
 type
   { Private shell. Nothing about it is visible: no border, no caption, no taskbar
     button -- the HTML inside is the entire window as far as the user can tell. }

--- a/source/chat/UI/Aefos.OTA.UI.ThemeHelper.pas
+++ b/source/chat/UI/Aefos.OTA.UI.ThemeHelper.pas
@@ -118,7 +118,9 @@ class procedure TThemeHelper.ApplyPremiumTheme(AForm: TCustomForm);
 var
   LIsDark: Boolean;
   LBgColor, LTextColor, LSecondaryColor: TColor;
+  {$IF Declared(IOTAIDEThemingServices250)}
   LTheming: IOTAIDEThemingServices250;
+  {$IFEND}
   LStyle: TCustomStyleServices;
   LThemeName: string;
   LIndex: Integer;
@@ -134,6 +136,15 @@ begin
   LSecondaryColor := 0;
 
   // ── Step 1: try to get the native IDE StyleServices ─────────────────────
+  //
+  // IDE theming is not universal: IOTAIDEThemingServices250 does not exist in
+  // 10 Seattle's ToolsAPI, because that IDE had no themes to expose. Declared()
+  // asks the ToolsAPI in hand instead of encoding which release introduced it.
+  //
+  // Nothing is lost where it is absent - Step 2 below already derives dark/light
+  // from the form's own luminance, which is exactly the path taken today when
+  // the service exists but theming is switched off.
+  {$IF Declared(IOTAIDEThemingServices250)}
   if Assigned(BorlandIDEServices) and
      Supports(BorlandIDEServices, IOTAIDEThemingServices250, LTheming) then
   begin
@@ -146,6 +157,7 @@ begin
       LStyle := nil;
     end;
   end;
+  {$IFEND}
 
   // ── Step 2: derive luminance fallback when StyleServices unavailable ─────
   if (not Assigned(LStyle)) and (AForm.Color <> clNone) then

--- a/source/compat/Aefos.Compat.Http.pas
+++ b/source/compat/Aefos.Compat.Http.pas
@@ -115,6 +115,34 @@ uses
 
 {$IFNDEF FPC}
 
+// Applies whichever THTTPClient timeouts the compiler in hand actually has.
+//
+// ConnectionTimeout and ResponseTimeout arrived in 10.1 Berlin (CompilerVersion
+// 31); on 10 Seattle they do not exist, and naming them is a COMPILE error, not
+// a runtime no-op. SendTimeout came later, so it carries its own guard.
+//
+// Every call site funnels through here on purpose: the same properties were set
+// in three places, and three copies of a version guard is three chances to fix
+// one and forget the others. Degrading is safe - a client with no explicit
+// timeout uses the RTL default instead of hanging forever.
+//
+// A value <= 0 means "leave the default alone", which is what the call sites
+// already expressed with their own `if X > 0 then`.
+procedure _ApplyTimeouts(const AClient: THTTPClient;
+  const AConnectMs, ASendMs, AResponseMs: Integer);
+begin
+  {$IF CompilerVersion >= 31}   // 10.1 Berlin
+  if AConnectMs > 0 then
+    AClient.ConnectionTimeout := AConnectMs;
+  if AResponseMs > 0 then
+    AClient.ResponseTimeout := AResponseMs;
+  {$IFEND}
+  {$IF CompilerVersion >= 34}   // 10.4 Sydney
+  if ASendMs > 0 then
+    AClient.SendTimeout := ASendMs;
+  {$IFEND}
+end;
+
 class function TAefosHttp.TryGetToFile(const AUrl, ADestFile: string;
   out AStatusCode: Integer; out AError: string): Boolean;
 var
@@ -157,11 +185,7 @@ begin
   AError := '';
   LClient := THTTPClient.Create;
   try
-    if ATimeoutMs > 0 then
-    begin
-      LClient.ConnectionTimeout := ATimeoutMs;
-      LClient.ResponseTimeout := ATimeoutMs;
-    end;
+    _ApplyTimeouts(LClient, ATimeoutMs, 0, ATimeoutMs);
     try
       LResp := LClient.Get(AUrl);
       AStatusCode := LResp.StatusCode;
@@ -240,12 +264,7 @@ begin
   AError := '';
   LClient := THTTPClient.Create;
   try
-    if AConnectTimeoutMs > 0 then
-      LClient.ConnectionTimeout := AConnectTimeoutMs;
-    if ASendTimeoutMs > 0 then
-      LClient.SendTimeout := ASendTimeoutMs;
-    if AResponseTimeoutMs > 0 then
-      LClient.ResponseTimeout := AResponseTimeoutMs;
+    _ApplyTimeouts(LClient, AConnectTimeoutMs, ASendTimeoutMs, AResponseTimeoutMs);
     LClient.ContentType := AContentType;
     LClient.AcceptCharSet := 'utf-8';
     LSource := TStringStream.Create(ARequestBody, TEncoding.UTF8);
@@ -315,11 +334,7 @@ begin
   AError := '';
   LClient := THTTPClient.Create;
   try
-    if ATimeoutMs > 0 then
-    begin
-      LClient.ConnectionTimeout := ATimeoutMs;
-      LClient.ResponseTimeout := ATimeoutMs;
-    end;
+    _ApplyTimeouts(LClient, ATimeoutMs, 0, ATimeoutMs);
     LClient.ContentType := AContentType;
     if AExtraHeaders <> '' then
       _ApplyHeaders(LClient, AExtraHeaders);

--- a/source/compat/Aefos.Compat.JsonFormat.pas
+++ b/source/compat/Aefos.Compat.JsonFormat.pas
@@ -1,0 +1,172 @@
+unit Aefos.Compat.JsonFormat;
+{$IFDEF FPC}{$mode delphiunicode}{$ENDIF}
+
+(*
+  TJSONValue.Format compatibility (Aefos -> Delphi 10 Seattle).
+
+  System.JSON only grew Format(indent) - the pretty-printing serializer - in a
+  release after 10 Seattle. Aefos calls it in fifteen places across seven units,
+  and every one of them writes a file a HUMAN opens: .mcp.json, the chat config,
+  a PyTools manifest, the AI-flow store, an addon ledger. Emitting those on one
+  long line would be a real downgrade, not a cosmetic one.
+
+  Fifteen version-guard blocks would be fifteen chances to fix one and miss the
+  others. A CLASS HELPER puts it in exactly one place and leaves every call site
+  untouched: on a compiler that has Format, this unit adds nothing and the RTL
+  method is used; on Seattle the helper supplies it with the same name and
+  signature, so a call reads and means the same thing either way.
+
+  It helps TJSONAncestor rather than TJSONValue so one declaration reaches
+  TJSONObject, TJSONArray and every other descendant.
+
+  FPC: nothing here. Aefos.Compat.Json's own wrapper already implements Format,
+  so this unit exists - harmless in a uses clause on both compilers - and is
+  empty.
+
+  ONE CAVEAT worth knowing: only ONE class helper for a type is active at a given
+  point in the source, so another helper on TJSONAncestor in scope with this one
+  would silently win. Nothing else in the tree helps that type today.
+
+  (This header is a parenthesis-star comment on purpose: it needs to mention
+  compiler directives, and a brace comment ends at the first closing brace -
+  which a directive carries. That mistake cost a build round trip.)
+*)
+
+interface
+
+{$IFNDEF FPC}
+{$IF CompilerVersion < 31}   // < 10.1 Berlin: System.JSON has no Format
+
+uses
+  System.JSON;
+
+type
+  TAefosJsonFormatHelper = class helper for TJSONAncestor
+  public
+    // Pretty-prints this value, indenting each nested level by AIndent spaces -
+    // the signature System.JSON adopted later.
+    function Format(const AIndent: Integer = 2): string;
+  end;
+
+{$IFEND}
+{$ENDIF}
+
+implementation
+
+{$IFNDEF FPC}
+{$IF CompilerVersion < 31}
+
+uses
+  System.SysUtils;
+
+(*
+  Re-indents compact JSON text.
+
+  Deliberately a pass over the SERIALIZED form rather than a walk of the object
+  tree: ToJSON is the one method every System.JSON version has and agrees on, so
+  this cannot drift with the class API.
+
+  The whole job is knowing when a brace is structure and when it is merely a
+  character inside a string - hence LInString/LEscaped. Without them a Windows
+  path holding brace characters would be read as an object and wreck the layout.
+  LEscaped toggles rather than latching, because a backslash can escape another
+  backslash - and a value ending in one would otherwise swallow its closing quote.
+*)
+function TAefosJsonFormatHelper.Format(const AIndent: Integer): string;
+var
+  LCompact: string;
+  LBuilder: TStringBuilder;
+  LIndex, LLevel: Integer;
+  LChar, LNext, LPrev: Char;
+  LInString, LEscaped: Boolean;
+
+  procedure NewLineAt(const ALevel: Integer);
+  begin
+    LBuilder.Append(sLineBreak);
+    if (AIndent > 0) and (ALevel > 0) then
+      LBuilder.Append(StringOfChar(' ', AIndent * ALevel));
+  end;
+
+begin
+  LCompact := Self.ToJSON;
+  LLevel := 0;
+  LInString := False;
+  LEscaped := False;
+  LBuilder := TStringBuilder.Create;
+  try
+    for LIndex := 1 to Length(LCompact) do
+    begin
+      LChar := LCompact[LIndex];
+
+      if LInString then
+      begin
+        LBuilder.Append(LChar);
+        if LEscaped then
+          LEscaped := False
+        else if LChar = '\' then
+          LEscaped := True
+        else if LChar = '"' then
+          LInString := False;
+        Continue;
+      end;
+
+      if LIndex < Length(LCompact) then
+        LNext := LCompact[LIndex + 1]
+      else
+        LNext := #0;
+      if LIndex > 1 then
+        LPrev := LCompact[LIndex - 1]
+      else
+        LPrev := #0;
+
+      case LChar of
+        '"':
+          begin
+            LInString := True;
+            LBuilder.Append(LChar);
+          end;
+        '{', '[':
+          begin
+            LBuilder.Append(LChar);
+            // An empty container stays on one line, which is what the RTL does.
+            // An indented blank line opened for nothing is the tell-tale of a
+            // hand-rolled formatter.
+            if ((LChar = '{') and (LNext = '}')) or ((LChar = '[') and (LNext = ']')) then
+              Continue;
+            Inc(LLevel);
+            NewLineAt(LLevel);
+          end;
+        '}', ']':
+          begin
+            // Closing an empty container: its opener already declined to indent,
+            // so this must not dedent either.
+            if ((LChar = '}') and (LPrev = '{')) or ((LChar = ']') and (LPrev = '[')) then
+            begin
+              LBuilder.Append(LChar);
+              Continue;
+            end;
+            Dec(LLevel);
+            NewLineAt(LLevel);
+            LBuilder.Append(LChar);
+          end;
+        ',':
+          begin
+            LBuilder.Append(LChar);
+            NewLineAt(LLevel);
+          end;
+        ':':
+          LBuilder.Append(': ');
+      else
+        LBuilder.Append(LChar);
+      end;
+    end;
+    Result := LBuilder.ToString;
+  finally
+    LBuilder.Free;
+  end;
+end;
+
+{$IFEND}
+{$ENDIF}
+
+end.

--- a/source/compat/Aefos.Compat.MainThread.pas
+++ b/source/compat/Aefos.Compat.MainThread.pas
@@ -1,0 +1,175 @@
+unit Aefos.Compat.MainThread;
+
+(*
+  Deferred main-thread execution (Aefos -> Delphi 10 Seattle).
+
+  TThread.ForceQueue is the RTL method that runs a closure on the main thread
+  LATER - always later, even when the caller is already the main thread. Aefos
+  depends on that "always" in the gutter-review notifiers: a view or module
+  notifier must never unregister itself from inside its own callback, so the save
+  paths defer the tidy-up. TThread.Queue is NOT a substitute: called from the main
+  thread it runs the closure immediately, which is precisely the reentrancy the
+  deferral exists to avoid - and the failure mode is an access violation inside
+  the IDE, the exact class of bug this codebase has already paid for once.
+
+  10 Seattle has no ForceQueue, so this unit supplies the same guarantee the way
+  it was done before the RTL offered it: post a message to a hidden window and
+  run the closure when the message loop gets to it. The current call stack is
+  guaranteed to have unwound by then, because a posted message is not dispatched
+  until the thread next pumps.
+
+  Everything here is ours - the Win32 message queue is the platform's, and the
+  window/closure plumbing is written for this unit.
+
+  BPL UNLOAD (house rule, non-negotiable): the hidden window's WndProc points
+  INTO this package. A window outliving the BPL means the IDE dispatches into an
+  unmapped address. Finalization therefore destroys the window and drops any
+  closures still queued - see the finalization block, and do not "simplify" it.
+*)
+
+interface
+
+type
+  TAefosMainThreadProc = reference to procedure;
+
+  { Static namespace for main-thread scheduling. Never instantiated. }
+  TAefosMainThread = class sealed
+  public
+    // Runs AProc on the main thread AFTER the current call stack unwinds -
+    // never inline, even when called from the main thread itself.
+    class procedure ForceQueue(const AProc: TAefosMainThreadProc); static;
+  end;
+
+implementation
+
+uses
+  {$IF CompilerVersion > 30}   // > 10 Seattle: the RTL has ForceQueue
+  System.Classes,
+  {$ELSE}
+  Winapi.Windows,
+  Winapi.Messages,
+  // System.Classes, NOT Vcl.Forms: AllocateHWnd lives in Classes, and
+  // Aefos.MCP.Core is an RTL-only package that does not require vcl. Pulling
+  // Vcl.Forms in here makes the compiler try to absorb it into MCP.Core and the
+  // build dies with "Packages 'Aefos.MCP.Core' and 'vcl' both contain unit
+  // 'Vcl.Forms'". The layering is deliberate - do not reach for the VCL here.
+  System.Classes,
+  System.SysUtils,
+  System.Generics.Collections,
+  {$IFEND}
+  System.SyncObjs;
+
+{$IF CompilerVersion > 30}
+
+class procedure TAefosMainThread.ForceQueue(const AProc: TAefosMainThreadProc);
+begin
+  // The RTL already guarantees the semantics; just forward.
+  TThread.ForceQueue(nil, TThreadProcedure(AProc));
+end;
+
+{$ELSE}
+
+const
+  // Private to this window - no other code sees this HWND.
+  WM_AEFOS_RUN_QUEUED = WM_USER + 4711;
+
+type
+  // AllocateHWnd wants a method pointer, not a plain procedure, so the pump owns
+  // its handler. One instance, created on first use, destroyed at finalization.
+  TAefosQueuePump = class
+  public
+    procedure WndProc(var AMessage: TMessage);
+  end;
+
+var
+  GWindow: HWND = 0;
+  GPump: TAefosQueuePump = nil;
+  GLock: TCriticalSection = nil;
+  GPending: TList<TAefosMainThreadProc> = nil;
+
+// Runs one queued closure per message. Failures are swallowed on purpose: this
+// is a message handler inside the IDE, and letting an exception escape a WndProc
+// is how a plugin takes the host down with it.
+procedure TAefosQueuePump.WndProc(var AMessage: TMessage);
+var
+  LProc: TAefosMainThreadProc;
+begin
+  if AMessage.Msg <> WM_AEFOS_RUN_QUEUED then
+  begin
+    AMessage.Result := DefWindowProc(GWindow, AMessage.Msg, AMessage.WParam,
+      AMessage.LParam);
+    Exit;
+  end;
+
+  LProc := nil;
+  GLock.Enter;
+  try
+    if (GPending <> nil) and (GPending.Count > 0) then
+    begin
+      LProc := GPending[0];
+      GPending.Delete(0);
+    end;
+  finally
+    GLock.Leave;
+  end;
+
+  if Assigned(LProc) then
+    try
+      LProc();
+    except
+      // Deliberately silent - see the comment above.
+    end;
+end;
+
+class procedure TAefosMainThread.ForceQueue(const AProc: TAefosMainThreadProc);
+begin
+  if not Assigned(AProc) then
+    Exit;
+  GLock.Enter;
+  try
+    if GPending = nil then
+      Exit;                         // finalization already ran
+    if GWindow = 0 then
+    begin
+      GPump := TAefosQueuePump.Create;
+      GWindow := AllocateHWnd(GPump.WndProc);
+    end;
+    GPending.Add(AProc);
+  finally
+    GLock.Leave;
+  end;
+  // PostMessage, never SendMessage: posting is what makes this deferred. One
+  // message per closure keeps the pairing exact.
+  PostMessage(GWindow, WM_AEFOS_RUN_QUEUED, 0, 0);
+end;
+
+{$IFEND}
+
+initialization
+{$IF CompilerVersion <= 30}
+  GLock := TCriticalSection.Create;
+  GPending := TList<TAefosMainThreadProc>.Create;
+{$IFEND}
+
+finalization
+{$IF CompilerVersion <= 30}
+  // Order matters. Take the window down FIRST so nothing can be dispatched into
+  // this package once the closures are gone, then release the queue. A closure
+  // still pending at unload is DROPPED, not run: its captured state belongs to a
+  // package that is going away.
+  GLock.Enter;
+  try
+    if GWindow <> 0 then
+    begin
+      DeallocateHWnd(GWindow);
+      GWindow := 0;
+    end;
+    FreeAndNil(GPump);
+    FreeAndNil(GPending);
+  finally
+    GLock.Leave;
+  end;
+  FreeAndNil(GLock);
+{$IFEND}
+
+end.

--- a/source/compat/Aefos.Compat.Sha256.pas
+++ b/source/compat/Aefos.Compat.Sha256.pas
@@ -50,6 +50,7 @@ implementation
 {$IFNDEF FPC}
 
 uses
+  System.Classes,
   System.Hash;
 
 class function TAefosSha256.HexDigest(const AText: string): string;
@@ -67,9 +68,31 @@ begin
 end;
 
 class function TAefosSha256.HexDigestFile(const APath: string): string;
+var
+  LHash: THashSHA2;
+  LStream: TFileStream;
+  LBuffer: TBytes;
+  LRead: Integer;
 begin
-  Result := LowerCase(THashSHA2.GetHashStringFromFile(APath,
-    THashSHA2.TSHA2Version.SHA256));
+  // Streamed rather than THashSHA2.GetHashStringFromFile, which 10 Seattle's
+  // System.Hash does not have (the unit arrived in XE8; that helper came later).
+  // Feeding the hash in blocks costs nothing and works on every version - and it
+  // is strictly better than reading the whole file into memory, which is what the
+  // obvious workaround (HexDigest of TFile.ReadAllBytes) would have done to a
+  // multi-megabyte addon zip.
+  LHash := THashSHA2.Create(THashSHA2.TSHA2Version.SHA256);
+  SetLength(LBuffer, 64 * 1024);
+  LStream := TFileStream.Create(APath, fmOpenRead or fmShareDenyWrite);
+  try
+    repeat
+      LRead := LStream.Read(LBuffer[0], Length(LBuffer));
+      if LRead > 0 then
+        LHash.Update(LBuffer[0], LRead);
+    until LRead <= 0;
+  finally
+    LStream.Free;
+  end;
+  Result := LowerCase(LHash.HashAsString);
 end;
 
 {$ELSE}

--- a/source/data/Aefos.Data.SQLite.pas
+++ b/source/data/Aefos.Data.SQLite.pas
@@ -59,8 +59,26 @@ uses
   FireDAC.DApt,
   FireDAC.Phys,
   FireDAC.Phys.SQLite,
-  FireDAC.Phys.SQLiteDef,
-  FireDAC.Phys.SQLiteWrapper.Stat;
+  FireDAC.Phys.SQLiteDef
+  // Static SQLite: pulling this unit in is what links the engine into the BPL,
+  // so no sqlite3.dll has to travel beside it.
+  //
+  // It is not in every FireDAC. MEASURED, not assumed: absent from 10 Seattle
+  // (lib\win32\release carries FireDAC.Phys.SQLiteWrapper.dcu with no .Stat
+  // sibling), present in Delphi 11. The exact release that added it is NOT
+  // established - Embarcadero documents the unit without dating it - so this
+  // guard says "anything above Seattle", the simplest reading consistent with
+  // both measurements.
+  //
+  // If a 10.1/10.2/10.3 build ever fails on this line, that is this guard being
+  // wrong rather than the tree: raise the number to the first version that has
+  // the unit. Where it is absent FireDAC falls back to loading sqlite3.dll at
+  // run time, so the breakage moves from compile time to first database open -
+  // which is exactly why this note is here and not in a commit message.
+  {$IF CompilerVersion > 30}   // > 10 Seattle
+  , FireDAC.Phys.SQLiteWrapper.Stat
+  {$IFEND}
+  ;
 
 type
   TSQLiteDatabase = class(TInterfacedObject, ISQLiteDatabase)

--- a/source/mcp/Core/Aefos.MCP.AddonGateway.pas
+++ b/source/mcp/Core/Aefos.MCP.AddonGateway.pas
@@ -132,6 +132,14 @@ type
 
 implementation
 
+{$IF not Declared(GetTickCount64)}
+// 10 Seattle's Winapi.Windows does not declare this Vista-era API yet.
+// Declared() rather than a CompilerVersion number: it asks the compiler in
+// hand whether the symbol exists, instead of encoding a guess about which
+// release added it.
+function GetTickCount64: UInt64; stdcall; external 'kernel32.dll' name 'GetTickCount64';
+{$IFEND}
+
 const
   CGatewayProtocolVersion = '2025-06-18';
   CGatewayClientName      = 'aefos-gateway';

--- a/source/mcp/Core/Aefos.MCP.GitFacade.pas
+++ b/source/mcp/Core/Aefos.MCP.GitFacade.pas
@@ -122,6 +122,14 @@ uses
   Winapi.Windows,
   System.IOUtils;
 
+{$IF not Declared(GetTickCount64)}
+// 10 Seattle's Winapi.Windows does not declare this Vista-era API yet.
+// Declared() rather than a CompilerVersion number: it asks the compiler in
+// hand whether the symbol exists, instead of encoding a guess about which
+// release added it.
+function GetTickCount64: UInt64; stdcall; external 'kernel32.dll' name 'GetTickCount64';
+{$IFEND}
+
 const
   GIT_DEFAULT_TIMEOUT_MS = 5000;
   GIT_MAX_OUTPUT_BYTES   = 8 * 1024 * 1024;

--- a/source/mcp/Core/Aefos.MCP.InspectorBridge.pas
+++ b/source/mcp/Core/Aefos.MCP.InspectorBridge.pas
@@ -160,6 +160,8 @@ begin
 end;
 
 function TMCPInspectorBridge._AuditLogSize: Int64;
+var
+  LStream: TFileStream;
 begin
   // Missing file is the normal first-call state - return 0 so the delta
   // computation harvests the entire post-call body.
@@ -169,7 +171,16 @@ begin
   if not TFile.Exists(FAuditLogPath) then
     Exit;
   try
-    Result := TFile.GetSize(FAuditLogPath);
+    // Not TFile.GetSize: 10 Seattle's System.IOUtils has no such helper (it came
+    // later). Opening read-only and asking the stream is the portable route to
+    // the same number, with the same sharing mode - fmShareDenyNone matters,
+    // because the audit log is being appended to while we measure it.
+    LStream := TFileStream.Create(FAuditLogPath, fmOpenRead or fmShareDenyNone);
+    try
+      Result := LStream.Size;
+    finally
+      LStream.Free;
+    end;
   except
     on E: Exception do
       // BR-9 (mirrors AuditLog write policy): observability noise is never

--- a/source/mcp/Core/Aefos.MCP.Provision.pas
+++ b/source/mcp/Core/Aefos.MCP.Provision.pas
@@ -101,7 +101,8 @@ uses
   System.Classes,
   System.IOUtils,
   System.JSON,
-  Aefos.MCP.ServerMerge;
+  Aefos.MCP.ServerMerge,
+  Aefos.Compat.JsonFormat;
 
 {$R 'Aefos.MCP.Provision.res'}
 

--- a/source/mcp/Core/Aefos.MCP.Tools.AuditQuery.pas
+++ b/source/mcp/Core/Aefos.MCP.Tools.AuditQuery.pas
@@ -58,6 +58,7 @@ implementation
 uses
   System.SysUtils,
   System.JSON,
+  System.Types,
   System.IOUtils,
   System.Generics.Collections,
   System.Generics.Defaults,
@@ -318,7 +319,7 @@ procedure _ScanFile(const AFile: string; const AQuery: TAuditQuery;
   const AMatches: TList<TAuditMatch>; var AScanned, AMalformed: Integer);
 var
   LFileDate: string;
-  LLines: TArray<string>;
+  LLines: TStringDynArray;
   LFor: Integer;
 begin
   LFileDate := _FileDate(AFile);
@@ -486,7 +487,7 @@ var
   LMatches: TList<TAuditMatch>;
   LScanned, LMalformed, LFor: Integer;
   LDir: string;
-  LFiles: TArray<string>;
+  LFiles: TStringDynArray;
 begin
   LQuery := _ReadParams(AParams);            // raises -32602 on bad input
   LMatches := TList<TAuditMatch>.Create;

--- a/source/mcp/Core/Aefos.MCP.Tools.PyTools.pas
+++ b/source/mcp/Core/Aefos.MCP.Tools.PyTools.pas
@@ -44,6 +44,7 @@ implementation
 
 uses
   System.SysUtils,
+  System.Types,
   System.IOUtils,
   System.JSON,
   Aefos.Tools.Process,
@@ -266,7 +267,7 @@ end;
 
 function TMCPPyToolsRegistrar.RegisterAll(const AServer: IMCPServer): Integer;
 var
-  LDirs: TArray<string>;
+  LDirs: TStringDynArray;
   LDir, LManifest, LRaw: string;
   LJson: TJSONObject;
   LSpec: TPyToolSpec;

--- a/source/mcp/Core/Aefos.MCP.Transport.NamedPipe.pas
+++ b/source/mcp/Core/Aefos.MCP.Transport.NamedPipe.pas
@@ -97,6 +97,23 @@ type
 
 implementation
 
+{$IF not Declared(GetTickCount64)}
+// 10 Seattle's Winapi.Windows does not declare this Vista-era API yet.
+// Declared() rather than a CompilerVersion number: it asks the compiler in
+// hand whether the symbol exists, instead of encoding a guess about which
+// release added it.
+function GetTickCount64: UInt64; stdcall; external 'kernel32.dll' name 'GetTickCount64';
+{$IFEND}
+
+{$IF not Declared(CancelIoEx)}
+// Same story as GetTickCount64: a Vista-era API 10 Seattle's Winapi.Windows
+// does not declare. This one cannot degrade - it is what unblocks a pending
+// overlapped read on a handle from another thread, so the shutdown path needs
+// it to exist at all.
+function CancelIoEx(hFile: THandle; lpOverlapped: POverlapped): BOOL; stdcall;
+  external 'kernel32.dll' name 'CancelIoEx';
+{$IFEND}
+
 // Thread-local routing slot — set by _RunAcceptLoop before every _DispatchFrame
 // so Send (called synchronously on the same worker thread by the dispatcher)
 // knows which client handle and send-synchronisation objects to use.

--- a/source/mcp/OTA/Aefos.MCP.OTA.BuildService.pas
+++ b/source/mcp/OTA/Aefos.MCP.OTA.BuildService.pas
@@ -355,6 +355,14 @@ var
   LOk: Boolean;
 begin
   LOk := False;
+  // The clean compile mode is not offered by every ToolsAPI - 10 Seattle's has
+  // no such member. Declared() asks the ToolsAPI in hand.
+  //
+  // Where it is missing the answer is a plain False: the tool reports that it
+  // could not clean, which is TRUE, rather than pretending success or silently
+  // doing a normal build in its place. An agent told "cleaned" when nothing was
+  // cleaned would go on to trust stale output.
+  {$IF Declared(cmOTAClean)}
   try
     TThread.Synchronize(nil, procedure
     var
@@ -369,6 +377,7 @@ begin
   except
     LOk := False;
   end;
+  {$IFEND}
   Result := LOk;
 end;
 

--- a/source/mcp/OTA/Aefos.MCP.OTA.DebugService.pas
+++ b/source/mcp/OTA/Aefos.MCP.OTA.DebugService.pas
@@ -228,6 +228,20 @@ type
     procedure EvaluateComplete(const ExprStr, ResultStr: string;
       CanModify: Boolean; ResultAddress, ResultSize: LongWord;
       ReturnCode: Integer); overload;
+    // "Evalute" is not our typo - it is Embarcadero's, and it is IN the
+    // interface: 10 Seattle's ToolsAPI.pas declares
+    // IOTAThreadNotifier.EvaluteComplete, while IOTAThreadNotifier160 right
+    // below it spells EvaluateComplete correctly. The name was fixed in a later
+    // release, so WHICH spelling satisfies the interface depends on the IDE
+    // being compiled against.
+    //
+    // Both are declared, unconditionally, instead of guessing which release
+    // corrected it: on an IDE that wants the misspelling this satisfies the
+    // interface; on one that does not, it is an extra protected method nobody
+    // calls. A version guard here would encode a guess - this does not.
+    procedure EvaluteComplete(const ExprStr, ResultStr: string;
+      CanModify: Boolean; ResultAddress, ResultSize: LongWord;
+      ReturnCode: Integer);
     procedure ModifyComplete(const ExprStr, ResultStr: string;
       ReturnCode: Integer);
     { IOTAThreadNotifier160 }
@@ -291,6 +305,16 @@ begin
   // Legacy 32-bit shape: upcast the address and forward (CnPack idiom).
   EvaluateComplete(ExprStr, ResultStr, CanModify, TOTAAddress(ResultAddress),
     ResultSize, ReturnCode);
+end;
+
+procedure TDebugEvalNotifier.EvaluteComplete(const ExprStr,
+  ResultStr: string; CanModify: Boolean; ResultAddress, ResultSize: LongWord;
+  ReturnCode: Integer);
+begin
+  // Embarcadero's spelling (see the declaration): forward to the real one so
+  // the completion path is identical whichever name the IDE calls.
+  EvaluateComplete(ExprStr, ResultStr, CanModify, ResultAddress, ResultSize,
+    ReturnCode);
 end;
 
 procedure TDebugEvalNotifier.ModifyComplete(const ExprStr, ResultStr: string;

--- a/source/mcp/OTA/Aefos.MCP.OTA.IDEReadService.pas
+++ b/source/mcp/OTA/Aefos.MCP.OTA.IDEReadService.pas
@@ -113,10 +113,16 @@ begin
   try
     TThread.Synchronize(nil, procedure
     var
+      {$IF Declared(IOTAIDEThemingServices250)}
       LTheming: IOTAIDEThemingServices250;
+      {$IFEND}
       LName: string;
     begin
       if not Assigned(BorlandIDEServices) then Exit;
+      // An IDE with no theming service (10 Seattle) answers 'system', which is
+      // the honest answer: it has no theme to report. Declared() asks the
+      // ToolsAPI in hand rather than encoding which release added the service.
+      {$IF Declared(IOTAIDEThemingServices250)}
       if not Supports(BorlandIDEServices, IOTAIDEThemingServices250, LTheming) then Exit;
       try
         LName := LTheming.GetActiveThemeName;
@@ -127,6 +133,7 @@ begin
       except
         LResult := 'system';
       end;
+      {$IFEND}
     end);
   except
     LResult := 'system';

--- a/source/mcp/OTA/Aefos.OTA.IDE.GutterReview.pas
+++ b/source/mcp/OTA/Aefos.OTA.IDE.GutterReview.pas
@@ -107,6 +107,7 @@ uses
   Aefos.MCP.Types,
   Aefos.OTA.Options.AIFlow,
   Aefos.OTA.UI.ThemeHelper,
+  Aefos.Compat.MainThread,  // deferred main-thread run (see the ForceQueue calls)
   Aefos.MCP.OTA.ReviewGate; // review seams hoisted out of the facade (SOLID split)
 
 type
@@ -1681,7 +1682,7 @@ begin
     LUnits.Free;
   end;
   // Defer notifier/hook teardown to the next main-loop turn (out of any save callback).
-  TThread.ForceQueue(nil,
+  TAefosMainThread.ForceQueue(
     procedure
     begin
       _CleanupResolvedModuleNotifiers;
@@ -1723,7 +1724,7 @@ begin
     end;
   if Assigned(LView) then
     _ForceFullRepaint(LView); // repaint so stripped red / dropped markers refresh
-  TThread.ForceQueue(nil,
+  TAefosMainThread.ForceQueue(
     procedure
     begin
       _CleanupResolvedModuleNotifiers;
@@ -1829,7 +1830,7 @@ end;
 // the agent when the change is later approved or rejected.
 procedure _DeferNoteDialog(AChangeId: Integer);
 begin
-  TThread.ForceQueue(nil,
+  TAefosMainThread.ForceQueue(
     procedure
     var
       LChange: TReviewChange;

--- a/source/mcp/OTA/Aefos.OTA.MCP.PyToolsManager.pas
+++ b/source/mcp/OTA/Aefos.OTA.MCP.PyToolsManager.pas
@@ -44,7 +44,8 @@ uses
   Vcl.Menus,
   ToolsAPI,
   Aefos.MCP.Provision,
-  Aefos.OTA.UI.ThemeHelper;
+  Aefos.OTA.UI.ThemeHelper,
+  Aefos.Compat.JsonFormat;
 
 const
   CEntryDefault = 'main.py';

--- a/source/mcp/OTA/Aefos.OTA.Options.AIFlow.Store.pas
+++ b/source/mcp/OTA/Aefos.OTA.Options.AIFlow.Store.pas
@@ -151,7 +151,8 @@ type
 implementation
 
 uses
-  Winapi.Windows;
+  Winapi.Windows,
+  Aefos.Compat.JsonFormat;
 
 const
   CONFIG_DIR_REL = '.aefos';

--- a/source/mcp/OTA/Aefos.OTA.UI.MCPConsentDialog.pas
+++ b/source/mcp/OTA/Aefos.OTA.UI.MCPConsentDialog.pas
@@ -81,7 +81,9 @@ class function TMCPConsentDialog.Execute(const AToolName, ASummary,
   ADetail: string): TMCPConsentDecision;
 var
   LForm: TMCPConsentDialog;
+  {$IF Declared(IOTAIDEThemingServices)}
   LTheming: IOTAIDEThemingServices;
+  {$IFEND}
   LView: TAefosConsentView;
   LDrop: Integer;
 begin
@@ -133,9 +135,14 @@ begin
     // the user works in the external terminal. Keep the prompt above the IDE
     // windows so an alt-tab back lands on a visible, answerable modal.
     LForm.FormStyle := fsStayOnTop;
+    // No theming service to ask on an older ToolsAPI (10 Seattle's IDE had no
+    // themes): the dialog keeps stock VCL colours, which is what the rest of
+    // that IDE looks like. The dark-form patching below still runs.
+    {$IF Declared(IOTAIDEThemingServices)}
     if Assigned(BorlandIDEServices) and
        Supports(BorlandIDEServices, IOTAIDEThemingServices, LTheming) then
       LTheming.ApplyTheme(LForm);
+    {$IFEND}
     // The IDE's own ApplyTheme leaves a bsDialog form light even on a dark
     // theme -- which is why this dialog stayed grey next to a dark chat card,
     // the single biggest thing making the two read as different products. The

--- a/source/mcp/Tools/Aefos.Tools.Batch.pas
+++ b/source/mcp/Tools/Aefos.Tools.Batch.pas
@@ -67,12 +67,15 @@ type
 implementation
 
 uses
+  System.Types,      // TStringDynArray - what TDirectory.GetFiles actually returns
   System.IOUtils;
 
 class function TFileBatch.ListFiles(const ARoot, AMask: string;
   const ARecursive: Boolean): TArray<string>;
 var
   LOption: TSearchOption;
+  LFiles: TStringDynArray;
+  LIndex: Integer;
 begin
   SetLength(Result, 0);
   if not TDirectory.Exists(ARoot) then
@@ -81,7 +84,15 @@ begin
     LOption := TSearchOption.soAllDirectories
   else
     LOption := TSearchOption.soTopDirectoryOnly;
-  Result := TDirectory.GetFiles(ARoot, AMask, LOption);
+  // TDirectory.GetFiles returns TStringDynArray. Modern Delphi treats that as
+  // the same type as TArray<string> and lets the assignment through; 10 Seattle
+  // does not, and rejects it as incompatible. Copying element by element is
+  // understood by every version, so this needs no version guard at all - and it
+  // is a handful of file names, not a hot path.
+  LFiles := TDirectory.GetFiles(ARoot, AMask, LOption);
+  SetLength(Result, Length(LFiles));
+  for LIndex := 0 to High(LFiles) do
+    Result[LIndex] := LFiles[LIndex];
 end;
 
 // Tallies an item into a result accumulator.

--- a/source/mcp/Tools/Aefos.Tools.Process.pas
+++ b/source/mcp/Tools/Aefos.Tools.Process.pas
@@ -58,6 +58,19 @@ uses
   System.Classes,
   Winapi.Windows;
 
+{$IF not Declared(GetTickCount64)}
+// GetTickCount64 is a Windows Vista API, but Winapi.Windows only began declaring
+// it in a Delphi later than 10 Seattle - so on Seattle the call is an undeclared
+// identifier even though the function sits in kernel32 on every machine able to
+// run the IDE at all.
+//
+// Declared(), not a CompilerVersion number, on purpose: this asks the compiler in
+// hand whether it already has the symbol, which is the actual question. A version
+// guard would encode a GUESS about which release added it, and would quietly do
+// the wrong thing on either side of a wrong guess.
+function GetTickCount64: UInt64; stdcall; external 'kernel32.dll' name 'GetTickCount64';
+{$IFEND}
+
 { TToolProcessResult }
 
 function TToolProcessResult.Ok: Boolean;

--- a/source/mcp/Tools/Aefos.Tools.Project.pas
+++ b/source/mcp/Tools/Aefos.Tools.Project.pas
@@ -106,6 +106,7 @@ implementation
 
 uses
   System.SysUtils,
+  System.Types,
   System.IOUtils,
   System.Generics.Collections;
 
@@ -257,7 +258,7 @@ class function TProjectOps.ScaffoldFolder(const ATemplateDir, ATargetDir: string
   const AVars: TArray<TToolTemplateVar>; const ABom: TToolFileBom;
   const AAllowOverwrite: Boolean): TToolScaffoldFolderResult;
 var
-  LFiles: TArray<string>;
+  LFiles: TStringDynArray;
   LSrc, LRel, LU, LDest, LDir: string;
   LNameR, LBodyR: TToolTemplateResult;
   LInfo: TToolFileInfo;

--- a/source/terminal/Core/Aefos.OTA.Terminal.Core.GitInfo.pas
+++ b/source/terminal/Core/Aefos.OTA.Terminal.Core.GitInfo.pas
@@ -43,7 +43,7 @@ type
 implementation
 
 uses
-  System.SysUtils, System.IOUtils;
+  System.SysUtils, System.Types, System.IOUtils;   // Types: TStringDynArray
 
 const
   CHeadRefPrefix = 'ref:';
@@ -107,7 +107,7 @@ function _ResolveRef(const AGitDir, ARef: string): string;
 var
   LLoosePath: string;
   LPackedPath: string;
-  LLines: TArray<string>;
+  LLines: TStringDynArray;
   LLine: string;
   LTrimmed: string;
   LParts: TArray<string>;

--- a/source/terminal/Core/Aefos.OTA.Terminal.Core.Layout.pas
+++ b/source/terminal/Core/Aefos.OTA.Terminal.Core.Layout.pas
@@ -201,7 +201,14 @@ begin
     Result.AddPair('type', 'view');
     Result.AddPair('profile', FProfile);
     Result.AddPair('dir', FDir);
-    Result.AddPair('isFocused', FIsFocused);
+    // TJSONTrue/TJSONFalse, not AddPair(name, Boolean): that overload - and
+    // TJSONBool - arrived after 10 Seattle, whose System.JSON takes only a
+    // string or a TJSONValue here. These two classes exist in every version and
+    // emit the same JSON, so this needs no version guard.
+    if FIsFocused then
+      Result.AddPair('isFocused', TJSONTrue.Create)
+    else
+      Result.AddPair('isFocused', TJSONFalse.Create);
   end
   else
   begin

--- a/source/terminal/Core/Aefos.OTA.Terminal.Core.SlashCommands.pas
+++ b/source/terminal/Core/Aefos.OTA.Terminal.Core.SlashCommands.pas
@@ -73,6 +73,7 @@ uses
   Generics.Defaults;
   {$ELSE}
   System.Classes,
+  System.Types,
   System.IOUtils,
   System.Generics.Collections,
   System.Generics.Defaults;
@@ -217,7 +218,7 @@ end;
 procedure _CollectFrom(const ACommandsDir: string; const AScope: TSlashCommandScope;
   const ACollected: TList<TSlashCommand>; const ASeen: TDictionary<string, Byte>);
 var
-  LDirs: TArray<string>;
+  LDirs: TStringDynArray;
   LIndex: Integer;
   LFile, LName, LDesc, LBody, LKey: string;
   LCmd: TSlashCommand;

--- a/source/terminal/Core/Aefos.OTA.Terminal.Core.Snippets.pas
+++ b/source/terminal/Core/Aefos.OTA.Terminal.Core.Snippets.pas
@@ -174,7 +174,11 @@ begin
   LList := TList<string>.Create;
   try
     for LIndex := 0 to LArray.Count - 1 do
-      LList.Add(LArray[LIndex].Value);
+      // .Items[] rather than a bare index: TJSONArray has always had Items, but
+      // only made it the DEFAULT property in a release after 10 Seattle, where
+      // the bare form reads as "class does not have a default property".
+      // Spelling it out works on every version and needs no guard.
+      LList.Add(LArray.Items[LIndex].Value);
     Result := LList.ToArray;
   finally
     LList.Free;
@@ -189,9 +193,9 @@ var
 begin
   for LIndex := 0 to AArray.Count - 1 do
   begin
-    if not (AArray[LIndex] is TJSONObject) then
+    if not (AArray.Items[LIndex] is TJSONObject) then
       Continue;
-    LObj := TJSONObject(AArray[LIndex]);
+    LObj := TJSONObject(AArray.Items[LIndex]);
     FSnippets.Add(TSnippet.Create(
       LObj.GetValue<string>('title', ''),
       LObj.GetValue<string>('command', ''),

--- a/source/terminal/Core/Aefos.OTA.Terminal.Core.TestContract.pas
+++ b/source/terminal/Core/Aefos.OTA.Terminal.Core.TestContract.pas
@@ -94,7 +94,8 @@ type
 implementation
 
 uses
-  System.JSON;
+  System.JSON,
+  Aefos.Compat.JsonFormat;
 
 { TTestSummary }
 

--- a/source/terminal/UI/Aefos.OTA.Terminal.UI.ActionCenterView.pas
+++ b/source/terminal/UI/Aefos.OTA.Terminal.UI.ActionCenterView.pas
@@ -715,7 +715,9 @@ end;
 
 procedure TActionCenterView.SetParent(AParent: TWinControl);
 var
+  {$IF Declared(IOTAIDEThemingServices)}
   LThemeServices: IOTAIDEThemingServices;
+  {$IFEND}
   LParentForm: TCustomForm;
 begin
   inherited SetParent(AParent);
@@ -727,6 +729,9 @@ begin
     if SameText(AParent.ClassName, 'TFloatDockForm') or
        SameText(AParent.ClassName, 'TFloatWindow') then
     begin
+      // Nothing to mirror on an IDE with no themes (10 Seattle): the float host
+      // keeps its own colours.
+      {$IF Declared(IOTAIDEThemingServices)}
       if Supports(BorlandIDEServices, IOTAIDEThemingServices, LThemeServices) and
          LThemeServices.IDEThemingEnabled then
       begin
@@ -734,6 +739,7 @@ begin
         if Assigned(LParentForm) then
           LThemeServices.ApplyTheme(LParentForm);
       end;
+      {$IFEND}
     end;
   end;
 end;
@@ -759,11 +765,19 @@ begin
 end;
 
 function TActionCenterView._IsIDEDarkTheme: Boolean;
+// The var section itself is inside the guard: these are the ONLY locals, and a
+// `var` with nothing under it is a syntax error, not an empty block.
+{$IF Declared(IOTAIDEThemingServices)}
 var
   LThemeServices: IOTAIDEThemingServices;
   LThemeName: string;
+{$IFEND}
 begin
   Result := True; // Default to dark theme
+  // An IDE with no theming service (10 Seattle) has no theme name to inspect,
+  // so the default above stands - the same answer this gives today when theming
+  // is switched off.
+  {$IF Declared(IOTAIDEThemingServices)}
   if Supports(BorlandIDEServices, IOTAIDEThemingServices, LThemeServices) and
      LThemeServices.IDEThemingEnabled then
   begin
@@ -774,6 +788,7 @@ begin
        (LThemeName = 'campbell') then
       Result := False;
   end;
+  {$IFEND}
 end;
 
 procedure TActionCenterView._CreateButtonGlyph(AButton: TSpeedButton; const AIconType: string);

--- a/source/terminal/UI/Aefos.OTA.Terminal.UI.DockForm.pas
+++ b/source/terminal/UI/Aefos.OTA.Terminal.UI.DockForm.pas
@@ -491,13 +491,21 @@ begin
 end;
 
 procedure _ApplyMenuTheme(const AMenu: TPopupMenu);
+{$IF Declared(IOTAIDEThemingServices250)}
 var
   LThemeServices: IOTAIDEThemingServices250;
+{$IFEND}
 begin
+  // There is no theming service to ask on an older ToolsAPI - 10 Seattle's IDE
+  // had no themes - so the menu keeps its stock colours, like every other menu
+  // in that IDE. Declared() asks the ToolsAPI in hand instead of encoding which
+  // release introduced the service.
+  {$IF Declared(IOTAIDEThemingServices250)}
   if Assigned(BorlandIDEServices) and
      Supports(BorlandIDEServices, IOTAIDEThemingServices250, LThemeServices) and
      LThemeServices.IDEThemingEnabled then
     LThemeServices.ApplyTheme(AMenu);
+  {$IFEND}
 end;
 
 function AefosOTATerminalActiveTerminalInput: ITerminalInput;

--- a/source/terminal/UI/Aefos.OTA.Terminal.UI.DockForm.pas
+++ b/source/terminal/UI/Aefos.OTA.Terminal.UI.DockForm.pas
@@ -3538,6 +3538,25 @@ var
   GFontLoaded: Boolean = False;
   GFontFilePath: string = '';
 
+// Size of a file in bytes, or -1 when it cannot be read.
+//
+// Not TFile.GetSize: 10 Seattle's System.IOUtils has no such helper (it arrived
+// in a later release). FindFirst is understood by every supported version and
+// answers from the directory entry without opening a handle - which matters here,
+// because the caller is deciding whether to DELETE and re-extract this file.
+function _FileSizeBytes(const APath: string): Int64;
+var
+  LRec: TSearchRec;
+begin
+  Result := -1;
+  if FindFirst(APath, faAnyFile, LRec) = 0 then
+  try
+    Result := LRec.Size;
+  finally
+    FindClose(LRec);
+  end;
+end;
+
 procedure _LoadPrivateFont;
 var
   LResStream: TResourceStream;
@@ -3553,7 +3572,7 @@ begin
       
     GFontFilePath := TPath.Combine(LDir, 'CaskaydiaCoveNerdFontMono-Regular.ttf');
 
-    if not FileExists(GFontFilePath) or (TFile.GetSize(GFontFilePath) < 1000000) then
+    if not FileExists(GFontFilePath) or (_FileSizeBytes(GFontFilePath) < 1000000) then
     begin
       try
         if FileExists(GFontFilePath) then

--- a/source/terminal/UI/Aefos.OTA.Terminal.UI.DockForm.pas
+++ b/source/terminal/UI/Aefos.OTA.Terminal.UI.DockForm.pas
@@ -400,7 +400,9 @@ implementation
 
 procedure TAefosTerminalToolbarPanel.Paint;
 var
+  {$IF Declared(IOTAIDEThemingServices)}
   LTheming: IOTAIDEThemingServices;
+  {$IFEND}
   LStyle: TCustomStyleServices;
   LBg, LPill: TColor;
   LIndex: Integer;
@@ -409,10 +411,14 @@ var
   LRect: TRect;
 begin
   LStyle := nil;
+  // No theming service on an IDE without themes (10 Seattle): LStyle stays nil
+  // and ChromeBackground falls back to its own surface colour.
+  {$IF Declared(IOTAIDEThemingServices)}
   if Assigned(BorlandIDEServices) and
      Supports(BorlandIDEServices, IOTAIDEThemingServices, LTheming) and
      LTheming.IDEThemingEnabled then
     LStyle := LTheming.GetIDEStyleServices;
+  {$IFEND}
 
   // Base chrome surface comes from StyleServices (BR5) so the toolbar tracks
   // the locked "Delphi IDE" theme; accents come from VisualTokens.
@@ -1073,7 +1079,9 @@ var
   LBitmap: TBitmap;
   LPenColor: TColor;
   LUseIDETheme: Boolean;
+  {$IF Declared(IOTAIDEThemingServices)}
   LTheming: IOTAIDEThemingServices;
+  {$IFEND}
   LStyle: TCustomStyleServices;
 begin
   LBitmap := TBitmap.Create;
@@ -1100,6 +1108,8 @@ begin
       LUseIDETheme := SameText(FThemeManager.Themes[FThemeManager.ActiveThemeIndex].Name, 'Delphi IDE');
 
     LStyle := nil;
+    // Nothing to query on an IDE with no themes (10 Seattle) - the fallback below applies.
+    {$IF Declared(IOTAIDEThemingServices)}
     if LUseIDETheme and
        Assigned(BorlandIDEServices) and
        Supports(BorlandIDEServices, IOTAIDEThemingServices, LTheming) and
@@ -1107,6 +1117,7 @@ begin
     begin
       LStyle := LTheming.GetIDEStyleServices;
     end;
+    {$IFEND}
 
     if Assigned(LStyle) then
       LPenColor := LStyle.GetSystemColor(clWindowText)
@@ -1272,24 +1283,35 @@ end;
 
 function TAefosTerminalDockForm._IsIDEDarkTheme: Boolean;
 var
+  {$IF Declared(IOTAIDEThemingServices)}
   LThemeServices: IOTAIDEThemingServices;
+  {$IFEND}
   LThemeName: string;
   LColor: Longint;
   R, G, B: Byte;
   LInt: Double;
+  LAsked: Boolean;
 begin
   Result := True; // Default to dark theme
+  // The IDE theme is only ASKED where a theming service exists - 10 Seattle's
+  // IDE had none. The luminance fallback below is not an error path: it is what
+  // already runs outside the IDE and under the unit tests, so an IDE without
+  // themes simply lands there.
+  LAsked := False;
+  {$IF Declared(IOTAIDEThemingServices)}
   if Supports(BorlandIDEServices, IOTAIDEThemingServices, LThemeServices) and
      LThemeServices.IDEThemingEnabled then
   begin
+    LAsked := True;
     LThemeName := LowerCase(LThemeServices.ActiveTheme);
     if (Pos('light', LThemeName) > 0) or
        (Pos('mountain', LThemeName) > 0) or
        (LThemeName = 'windows') or
        (LThemeName = 'campbell') then
       Result := False;
-  end
-  else
+  end;
+  {$IFEND}
+  if not LAsked then
   begin
     // Fallback if not running inside the IDE (like in our unit tests)
     LColor := ColorToRGB(Self.Color);
@@ -2469,7 +2491,9 @@ procedure TAefosTerminalDockForm._ApplyActiveTheme;
 var
   LView: TAefosTerminalTerminalView;
   LUseIDETheme: Boolean;
+  {$IF Declared(IOTAIDEThemingServices)}
   LTheming: IOTAIDEThemingServices;
+  {$IFEND}
   LStyle: TCustomStyleServices;
 begin
   // First apply the custom VCL themes recursively to self and child controls
@@ -2490,6 +2514,8 @@ begin
       LUseIDETheme := SameText(FThemeManager.Themes[FThemeManager.ActiveThemeIndex].Name, 'Delphi IDE');
 
     LStyle := nil;
+    // Nothing to query on an IDE with no themes (10 Seattle) - the fallback below applies.
+    {$IF Declared(IOTAIDEThemingServices)}
     if LUseIDETheme and
        Assigned(BorlandIDEServices) and
        Supports(BorlandIDEServices, IOTAIDEThemingServices, LTheming) and
@@ -2497,6 +2523,7 @@ begin
     begin
       LStyle := LTheming.GetIDEStyleServices;
     end;
+    {$IFEND}
 
     if Assigned(LStyle) then
     begin
@@ -2591,7 +2618,9 @@ var
   LSelectedBgRGB: DWORD;
   LSelectedBgLuminance: Double;
   LUseIDETheme: Boolean;
+  {$IF Declared(IOTAIDEThemingServices)}
   LTheming: IOTAIDEThemingServices;
+  {$IFEND}
   LStyle: TCustomStyleServices;
   LDotMid, LSplitLeft, LSplitTop, LTrashLeft, LTrashTop: Integer;
 begin
@@ -2610,6 +2639,8 @@ begin
   // Resolve theme colors
   LUseIDETheme := SameText(LActiveTheme.Name, 'Delphi IDE');
   LStyle := nil;
+  // Nothing to query on an IDE with no themes (10 Seattle) - the fallback below applies.
+  {$IF Declared(IOTAIDEThemingServices)}
   if LUseIDETheme and
      Assigned(BorlandIDEServices) and
      Supports(BorlandIDEServices, IOTAIDEThemingServices, LTheming) and
@@ -2617,6 +2648,7 @@ begin
   begin
     LStyle := LTheming.GetIDEStyleServices;
   end;
+  {$IFEND}
 
   if Assigned(LStyle) then
   begin

--- a/source/terminal/UI/Aefos.OTA.Terminal.UI.FindBar.pas
+++ b/source/terminal/UI/Aefos.OTA.Terminal.UI.FindBar.pas
@@ -381,7 +381,9 @@ end;
 
 procedure TFindBar.ApplyTheme;
 var
+  {$IF Declared(IOTAIDEThemingServices)}
   LTheming: IOTAIDEThemingServices;
+  {$IFEND}
   LStyle: TCustomStyleServices;
   LSurface, LText, LField: TColor;
 begin
@@ -391,10 +393,13 @@ begin
   // Surface tracks the IDE chrome (BR2/BR5); the accent stays reserved for the
   // active-pane outline and focus cues, so the overlay does not compete with it.
   LStyle := nil;
+  // No theming service on an IDE without themes (10 Seattle): LStyle stays nil and the designed colours are used.
+  {$IF Declared(IOTAIDEThemingServices)}
   if Assigned(BorlandIDEServices) and
      Supports(BorlandIDEServices, IOTAIDEThemingServices, LTheming) and
      LTheming.IDEThemingEnabled then
     LStyle := LTheming.GetIDEStyleServices;
+  {$IFEND}
 
   LSurface := TVisualSurfaces.ChromeBackground(LStyle);
   if Assigned(LStyle) then

--- a/source/terminal/UI/Aefos.OTA.Terminal.UI.IDEThemes.pas
+++ b/source/terminal/UI/Aefos.OTA.Terminal.UI.IDEThemes.pas
@@ -53,6 +53,19 @@ begin
   ACanvas.Brush.Style := bsSolid;
 end;
 
+(*
+  Everything from here down to ApplyAefosTerminalIDETheme depends on the IDE
+  theming service. 10 Seattle has no such service - that IDE had no themes at
+  all - so on it this block does not exist and the procedure below is a no-op:
+  the form keeps the stock VCL colours, which is what every other window in
+  that IDE looks like anyway.
+
+  Declared() asks the ToolsAPI in hand rather than encoding which release
+  introduced theming. DrawAefosTerminalFocusRing above is deliberately OUTSIDE
+  the guard: it paints with our own tokens and owes nothing to the IDE theme.
+*)
+{$IF Declared(IOTAIDEThemingServices250)}
+
 function _IsDark(const AColor: TColor): Boolean;
 var
   LRGB: TColor;
@@ -200,6 +213,17 @@ begin
   for LIndex := 0 to Pred(AForm.ComponentCount) do
     _PatchComponentForDark(AForm.Components[LIndex], LInputBg, LFormBg, LFgColor);
 end;
+
+{$ELSE}
+
+// No IDE theming service on this compiler (see the note above), so the form
+// keeps the stock VCL colours. An empty body rather than a guard at every call
+// site, so callers stay identical across versions.
+procedure ApplyAefosTerminalIDETheme(AForm: TCustomForm);
+begin
+end;
+
+{$IFEND}
 
 end.
 

--- a/source/terminal/UI/Aefos.OTA.Terminal.UI.TerminalView.pas
+++ b/source/terminal/UI/Aefos.OTA.Terminal.UI.TerminalView.pas
@@ -411,7 +411,9 @@ var
   LPalette: TBasePalette;
   LFontName: string;
   LFontSize: Integer;
+  {$IF Declared(IOTAIDEThemingServices)}
   LTheming: IOTAIDEThemingServices;
+  {$IFEND}
   LStyle: TCustomStyleServices;
   LIndex: Integer;
 begin
@@ -423,6 +425,10 @@ begin
   begin
     LTheme := FThemeManager.Themes[FThemeManager.ActiveThemeIndex];
     
+    // The IDE style services do not exist on an IDE with no themes
+    // (10 Seattle), so the "Delphi IDE" theme keeps its designed colours there
+    // instead of mirroring the host.
+    {$IF Declared(IOTAIDEThemingServices)}
     // If the active theme is "Delphi IDE" and we are running inside the IDE,
     // dynamically resolve colors from Embarcadero's style services!
     if SameText(LTheme.Name, 'Delphi IDE') and
@@ -442,6 +448,7 @@ begin
           LTheme.ANSIColors[LIndex] := TVisualTokens.AnsiColor(LIndex);
       end;
     end;
+    {$IFEND}
 
     // Orange Embarcadero accent cursor with a dark/light legibility fallback
     // resolved from the final (StyleServices-adjusted) background (ADR-057-03 /


### PR DESCRIPTION
Measured on a real 10 Seattle (BDS 17.0, compiler 30.0) in the VM, one barrier at
a time. **Nine of the ten BPLs now build there.** The tenth is blocked by a
toolchain failure, not by our Pascal — details at the bottom.

`Aefos.Harness · Providers · WebView · Tools · MCP.Core · MCP.Tools.OTA · Data ·
OTA.Terminal · dclAefosWebView`

**No regression:** Delphi 13 builds 10 BPLs (exit 0) and Delphi 11 builds 10 BPLs
on the same tree, same path, with every change in place.

## The rule that shaped almost all of it

`{$IF Declared(X)}` beats `{$IF CompilerVersion >= N}` whenever the release that
introduced a symbol is uncertain. It asks the compiler in hand whether the symbol
exists — which is the actual question — instead of encoding a guess that goes
quietly wrong on one side of a wrong number.

## Two helpers, so the call sites stayed put

**`Aefos.Compat.JsonFormat`** — a class helper on `TJSONAncestor` supplying
`Format(indent)`, which System.JSON only grew after Seattle. Fifteen call sites
across seven units are **unchanged**: on a modern compiler the unit is empty and
the RTL method wins.

**`Aefos.Compat.MainThread`** — `TThread.ForceQueue` does not exist on Seattle,
and `Queue` is **not** a substitute: from the main thread it runs the closure
inline, which is exactly the reentrancy the deferral prevents — a notifier
unregistering itself inside its own callback, i.e. the unload AV this codebase
has already paid for. The fallback posts to a hidden window (the pre-`ForceQueue`
idiom) and `DeallocateHWnd`s at finalization, because that WndProc points into
the BPL.

## What each barrier actually was

| Barrier | Root cause |
|---|---|
| `MSB4066: AfterTargets unrecognized` × 8 projects | Seattle's `rsvars` selects **MSBuild 3.5**; `AfterTargets` needs 4.0 |
| `THTTPClient` timeouts | arrived in 10.1 Berlin |
| `TArray<string>` vs `TStringDynArray` | Seattle does not unify them |
| `GetTickCount64`, `CancelIoEx` | Vista APIs Seattle's `Winapi.Windows` never declared |
| `GetHashStringFromFile`, `TFile.GetSize` | RTL helpers added later |
| `IOTAIDEThemingServices(250)` | that IDE **had no themes**; every site falls back to the luminance path that already existed |
| `cmOTAClean` | no OTA clean — `CleanProject` now returns **False** honestly instead of faking success |
| `FireDAC.Phys.SQLiteWrapper.Stat` | **measured**: absent in 17.0, present in 22.0 |
| `TJSONArray[i]`, `AddPair(name, Boolean)` | index and overload that became available later |

## Three things worth keeping

**`IOTAThreadNotifier.EvaluteComplete`** — that misspelling is Embarcadero's, in
their own interface (the `160` sibling spells it correctly). Both names are
declared, so neither spelling has to be guessed at.

**Four `Synchronize` errors were cascade**, not a barrier — Seattle's
`System.Classes` has the overload. Do not chase later errors in a unit before
fixing its first one.

**The static SQLite guard encodes a measurement, not a belief.** Absent in 17.0,
present in 22.0; the exact release is not established, and the code says so along
with what to change if a 10.1/10.2/10.3 build ever fails there.

## The one that is left, and why it is not ours

`Aefos.OTA.Chat` fails at `RLINK32: Error opening file ...ChatPanel.dfm`. The
Pascal compiles clean — this is the resource link step. Ruled out by experiment:

- the file exists and is readable on the VM, and is pure ASCII;
- an explicit `{$R 'name.dfm'}` instead of `{$R *.dfm}` changes nothing;
- a shorter path changes nothing;
- **Delphi 11 links the same file, same tree, same path**;
- a **minimal DFM with the same file name and form name links fine**.

So it is something in the DFM's *content* that Seattle's resource step rejects,
with a misleading "Error opening file". Bisecting the DFM is the next step and is
deliberately not in this PR.