### PR TITLE
Seattle builds all ten packages: DFM escapes in decimal, not hex

### DIFF
--- a/source/chat/UI/Aefos.OTA.Chat.UI.ChatPanel.dfm
+++ b/source/chat/UI/Aefos.OTA.Chat.UI.ChatPanel.dfm
@@ -876,8 +876,8 @@ object AefosChatPanel: TAefosChatPanel
         Margins.Right = 16
         Align = alClient
         Caption =
-          #$2726' Workspace: -   '#$2022'   '#$2726' Approvals: Default   '#$2022' ' +
-          '  '#$2726' Model: -'
+          #10022' Workspace: -   '#8226'   '#10022' Approvals: Default   '#8226' ' +
+          '  '#10022' Model: -'
         Font.Charset = DEFAULT_CHARSET
         Font.Color = clGray
         Font.Height = -10


### PR DESCRIPTION
The last barrier, and the error pointed nowhere near the cause:

```
error E2161: RLINK32: Error opening file ...ChatPanel.dfm
```

The file opens fine. **It was a parse failure reported as an open failure.**

## Finding it

Bisected the DFM — halves, then thirds, then one child at a time:

| Variant | Result |
|---|---|
| header only (form properties) | OK |
| `FSplitter` + `FHeaderPanel` + `FSessionPanel` | OK |
| `FClientContainer` + `FBottomContainer` + `FCmdList` | **FAIL** |
| `FClientContainer` alone | OK |
| **`FBottomContainer` alone** | **FAIL** |
| `FCmdList` alone | OK |
| `FTipLabel` | OK |
| **`FStatusPanel`** | **FAIL** |
| `FInputPanel` | OK |

`FLabelStatusText.Caption` used `#$2726` and `#$2022`. Newer Delphi writes
character escapes in **hex**; Seattle's resource step only understands the
**decimal** form.

The proof was already in the same file: `FAttachIcon` uses `#62670` — the same
kind of glyph, written in decimal — and links on Seattle without complaint. Hex
fails, decimal passes, same DFM, same build.

## The fix

Five escapes, hex to decimal: `#$2726` → `#10022`, `#$2022` → `#8226`. Same code
points, same characters on screen, understood by every version.

Worth knowing: the IDE may rewrite them as hex if it ever resaves this form. Not
worth guarding against — the check is a Seattle build.

## Result

**10 Seattle builds all ten BPLs.** Delphi 13 still builds ten, exit 0.

```
Aefos.Data      Aefos.Harness   Aefos.MCP.Core   Aefos.MCP.Tools.OTA
Aefos.OTA.Chat  Aefos.OTA.Terminal  Aefos.Providers  Aefos.Tools
Aefos.WebView   dclAefosWebView
```

Note the build is not yet installable there — `Aefos.iss` has no payload block
for 17.0, and `build-installer.ps1` says so out loud (the warning added in #22).