### PR TITLE
Seattle + Berlin: installer payloads, and version guesses become measurements

### DIFF
--- a/installer/Aefos.iss
+++ b/installer/Aefos.iss
@@ -9,6 +9,7 @@
 ;  dir and registers the design packages under that version's Known Packages.
 ;
 ;  Supported design-time versions (the only IDEs that load a plugin):
+;    17.0 = Delphi 10 Seattle    18.0 = Delphi 10.1 Berlin
 ;    22.0 = Delphi 11 Alexandria  23.0 = Delphi 12 Athens  37.0 = Delphi 13
 ;
 ;  Delphi 13 counts as TWO targets, not one: it ships a second IDE executable
@@ -47,19 +48,27 @@
 #define BplSrc     "bpl"
 
 ; --- supported design-time IDE versions ------------------------------------
+; Kept in step with scripts\aefos-ide-versions.ps1, which is the one list the
+; BUILD reads. This file needs its own literals because Inno resolves them at
+; compile time; build-installer.ps1 warns when a version is staged that has no
+; payload block here, so the two cannot drift silently.
+#define VerD10S    "17.0"
+#define VerD10B    "18.0"
 #define VerD11     "22.0"
 #define VerD12     "23.0"
 #define VerD13     "37.0"
 
 ; A version's payload is emitted ONLY if its BPLs were staged, so building just
 ; one Delphi yields a single-version installer (FileExists is a compile-time check).
+#define HaveD10S FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD10S + "\Aefos.OTA.Chat.bpl")
+#define HaveD10B FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD10B + "\Aefos.OTA.Chat.bpl")
 #define HaveD11  FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD11 + "\Aefos.OTA.Chat.bpl")
 #define HaveD12  FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD12 + "\Aefos.OTA.Chat.bpl")
 #define HaveD13  FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD13 + "\Aefos.OTA.Chat.bpl")
 ; The 64-bit IDE payload is independent: -Platform Win32 (the default) stages
 ; nothing under Win64 and the whole block below vanishes at compile time.
 #define HaveD13x FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD13 + "\Win64\Aefos.OTA.Chat.bpl")
-#if !HaveD11 && !HaveD12 && !HaveD13
+#if !HaveD10S && !HaveD10B && !HaveD11 && !HaveD12 && !HaveD13
   #error No staged BPLs found under .\bpl\<ver>. Run scripts\build-packages.ps1 then installer\build-installer.ps1.
 #endif
 
@@ -189,6 +198,35 @@ Source: "redist\cli\gemini.exe"; DestDir: "{userappdata}\Aefos\bin"; Flags: igno
 ; under Lazarus would be a compliance gap, not just clutter.
 Source: "redist\cli\THIRD-PARTY-LICENSES.txt"; DestDir: "{userappdata}\Aefos\bin"; Flags: ignoreversion skipifsourcedoesntexist uninsneveruninstall
 
+; --- Delphi 10 Seattle (BDS 17.0) payload - only if staged; installed if chosen -
+#if HaveD10S
+Source: "{#BplSrc}\{#VerD10S}\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.Providers.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.Tools.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.MCP.Core.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.MCP.Tools.OTA.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.Data.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.WebView.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\WebView2Loader.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.OTA.Chat.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.OTA.Terminal.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\dclAefosWebView.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+#endif
+
+#if HaveD10B
+Source: "{#BplSrc}\{#VerD10B}\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.Providers.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.Tools.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.MCP.Core.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.MCP.Tools.OTA.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.Data.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.WebView.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\WebView2Loader.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.OTA.Chat.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.OTA.Terminal.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\dclAefosWebView.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+#endif
+
 ; --- Delphi 11 (BDS 22.0) payload - only if staged; installed only if chosen ----
 #if HaveD11
 Source: "{#BplSrc}\{#VerD11}\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
@@ -272,6 +310,24 @@ Source: "redist\MicrosoftEdgeWebView2RuntimeInstaller{#WV2Arch}.exe"; Flags: don
 ; Per version: purge stale Disabled/old-layout entries, then register the design
 ; packages in Known Packages. Each entry is gated by Check: WantVer(<ver>) so only
 ; the chosen versions are touched. (commondocs = C:\Users\Public\Documents.)
+
+#if HaveD10S
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\Aefos.OTA.Chat.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10S}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\Aefos.OTA.Terminal.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10S}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\dclAefosWebView.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10S}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\Aefos.OTA.Chat.bpl"; ValueData: "Aefos AI - Chat"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10S}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\Aefos.OTA.Terminal.bpl"; ValueData: "Aefos AI - Terminal"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10S}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\dclAefosWebView.bpl"; ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10S}')
+#endif
+
+#if HaveD10B
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\Aefos.OTA.Chat.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10B}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\Aefos.OTA.Terminal.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10B}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\dclAefosWebView.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10B}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\Aefos.OTA.Chat.bpl"; ValueData: "Aefos AI - Chat"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10B}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\Aefos.OTA.Terminal.bpl"; ValueData: "Aefos AI - Terminal"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10B}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\dclAefosWebView.bpl"; ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10B}')
+#endif
 
 #if HaveD11
 Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD11}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl\Aefos.OTA.Chat.bpl";     Flags: deletevalue; Check: WantVer('{#VerD11}')
@@ -364,7 +420,9 @@ end;
 
 function VerLabel(const Ver: string): string;
 begin
-  if Ver = '{#VerD11}' then Result := 'Delphi 11 Alexandria (BDS {#VerD11})'
+  if Ver = '{#VerD10S}' then Result := 'Delphi 10 Seattle (BDS {#VerD10S})'
+  else if Ver = '{#VerD10B}' then Result := 'Delphi 10.1 Berlin (BDS {#VerD10B})'
+  else if Ver = '{#VerD11}' then Result := 'Delphi 11 Alexandria (BDS {#VerD11})'
   else if Ver = '{#VerD12}' then Result := 'Delphi 12 Athens (BDS {#VerD12})'
   else if Ver = '{#VerD13}' then Result := 'Delphi 13 (BDS {#VerD13})'
   else Result := 'RAD Studio (BDS ' + Ver + ')';
@@ -423,6 +481,12 @@ begin
       + 'set of BPLs (Delphi 12 and Delphi 13 do not share binaries).',
     False, False);
   SetArrayLength(GVer, 0);
+#if HaveD10S
+  AddVersion('{#VerD10S}');
+#endif
+#if HaveD10B
+  AddVersion('{#VerD10B}');
+#endif
 #if HaveD11
   AddVersion('{#VerD11}');
 #endif


### PR DESCRIPTION
Two things, and the second one rewrote the first's assumptions.

## 1. Installer payload blocks (10 Seattle, 10.1 Berlin)

Seattle builds all ten BPLs since #24, but `Aefos.iss` had no payload block for
17.0 — `build-installer.ps1` said so out loud (the #22 warning) rather than
shipping an installer silently missing them. Both versions now get `[Files]`,
`[Registry]` (clear stale Disabled Packages, register the three design packages),
a wizard label and a slot on the version page, oldest first.

Verified with the Seattle BPLs fetched from the VM: **five payloads**
(17.0, 22.0, 23.0, 37.0, 37.0/Win64), and the "STAGED BUT NOT PACKAGED" warning
stayed silent — the guard fires when a block is missing and stops when it is
added. Both directions observed.

## 2. Berlin arrived and disproved three of my guesses

**10.1 Berlin builds all ten BPLs.** Getting there cost three `CompilerVersion`
boundaries, all mine, all the same shape — one measurement plus a plausible story:

| Guard | Guessed | Berlin's answer |
|---|---|---|
| static SQLite | "above Seattle has it" | no `.Stat` either |
| `ForceQueue` | "above Seattle has it" | no `ForceQueue` |
| `TJSONValue.Format` | "Berlin has it" | no `Format` |

So the rules changed, not just the numbers.

**Where the thing is a FILE, measure it.** `build-packages.ps1` looks for
`FireDAC.Phys.SQLiteWrapper.Stat.dcu` in the target IDE's lib folder and defines
`AEFOS_NO_STATIC_SQLITE` only when genuinely absent. The symbol is **negative** on
purpose: an IDE build passes no defines, so no-symbol must mean the correct modern
behaviour. Verified across four IDEs — 17.0/18.0 report "no static SQLite",
22.0/37.0 stay static.

**Where it is a METHOD**, there is no handle to measure, so the gate sits at the
lowest *proven* version instead of a guess. 10.2–10.4 take our fallback even if
their RTL would serve — the harmless direction, since the fallback works
everywhere while a gate guessed too low breaks the build.

A version number was the wrong instrument anyway: these are **base installs with
no update packs**, and an RTL addition shipped in an update is invisible to
`CompilerVersion`, which does not move between updates.

**Whoever measures also provisions.** A build without static SQLite produces a BPL
that loads `sqlite3.dll` at run time; shipping that without the DLL installs
cleanly and then fails when the chat first opens its database — failure far from
its cause. The build now stages the DLL exactly where it defined the symbol, and
`Aefos.iss` has a `skipifsourcedoesntexist` line per version. Proven: 17.0 and
18.0 stage it, 22.0 does not.

The 32-bit `sqlite3.dll` became tracked for that (public domain, like the x86_64
sibling already committed for Lazarus). Two `.gitignore` lines, and the order
matters: git does not descend into an excluded directory, so the folder is
re-included first and the file second — a lone `!file` line silently does nothing.

## Where the tree stands

| IDE | BPLs | SQLite |
|---|---|---|
| 10 Seattle (17.0) | 10 | dll |
| 10.1 Berlin (18.0) | 10 | dll |
| 11 Alexandria (22.0) | 10 | static |
| 13 (37.0) | 10 | static |

**Not proven:** nobody has RUN the setup against a Seattle or Berlin IDE. The
BPLs build and stage; copy → register → IDE loads them has not been exercised.