### PR TITLE
Build from inside the old IDE: stage the BPL without AfterTargets

### DIFF
--- a/packages/Delphi/Aefos.Data.dproj
+++ b/packages/Delphi/Aefos.Data.dproj
@@ -195,7 +195,27 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <Target Name="AefosStageBplForInstaller" AfterTargets="Build" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
+    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
+
+         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
+         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
+         Error] The attribute AfterTargets in element <Target> is unrecognized" -
+         before a line of Pascal is read. It reads like a corrupt .dproj and is a
+         build engine five years older than the attribute.
+
+         The command line already worked around this by putting MSBuild 4.0 on the
+         PATH (scripts\build-packages.ps1), but nothing can do that for a build
+         started from inside the old IDE. Appending to $(BuildDependsOn) is the
+         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
+         understands it, so both paths run the same target. It must come AFTER the
+         CodeGear.Delphi.Targets import, which is where the property is defined.
+
+         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
+         with an empty body, so last in the list still means after the compile. -->
+    <PropertyGroup>
+        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
+    </PropertyGroup>
+    <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
             <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>

--- a/packages/Delphi/Aefos.Harness.dproj
+++ b/packages/Delphi/Aefos.Harness.dproj
@@ -172,7 +172,27 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <Target Name="AefosStageBplForInstaller" AfterTargets="Build" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
+    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
+
+         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
+         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
+         Error] The attribute AfterTargets in element <Target> is unrecognized" -
+         before a line of Pascal is read. It reads like a corrupt .dproj and is a
+         build engine five years older than the attribute.
+
+         The command line already worked around this by putting MSBuild 4.0 on the
+         PATH (scripts\build-packages.ps1), but nothing can do that for a build
+         started from inside the old IDE. Appending to $(BuildDependsOn) is the
+         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
+         understands it, so both paths run the same target. It must come AFTER the
+         CodeGear.Delphi.Targets import, which is where the property is defined.
+
+         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
+         with an empty body, so last in the list still means after the compile. -->
+    <PropertyGroup>
+        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
+    </PropertyGroup>
+    <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
             <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>

--- a/packages/Delphi/Aefos.MCP.Core.dproj
+++ b/packages/Delphi/Aefos.MCP.Core.dproj
@@ -232,7 +232,27 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <Target Name="AefosStageBplForInstaller" AfterTargets="Build" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
+    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
+
+         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
+         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
+         Error] The attribute AfterTargets in element <Target> is unrecognized" -
+         before a line of Pascal is read. It reads like a corrupt .dproj and is a
+         build engine five years older than the attribute.
+
+         The command line already worked around this by putting MSBuild 4.0 on the
+         PATH (scripts\build-packages.ps1), but nothing can do that for a build
+         started from inside the old IDE. Appending to $(BuildDependsOn) is the
+         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
+         understands it, so both paths run the same target. It must come AFTER the
+         CodeGear.Delphi.Targets import, which is where the property is defined.
+
+         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
+         with an empty body, so last in the list still means after the compile. -->
+    <PropertyGroup>
+        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
+    </PropertyGroup>
+    <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
             <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>

--- a/packages/Delphi/Aefos.MCP.Tools.OTA.dproj
+++ b/packages/Delphi/Aefos.MCP.Tools.OTA.dproj
@@ -214,7 +214,27 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <Target Name="AefosStageBplForInstaller" AfterTargets="Build" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
+    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
+
+         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
+         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
+         Error] The attribute AfterTargets in element <Target> is unrecognized" -
+         before a line of Pascal is read. It reads like a corrupt .dproj and is a
+         build engine five years older than the attribute.
+
+         The command line already worked around this by putting MSBuild 4.0 on the
+         PATH (scripts\build-packages.ps1), but nothing can do that for a build
+         started from inside the old IDE. Appending to $(BuildDependsOn) is the
+         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
+         understands it, so both paths run the same target. It must come AFTER the
+         CodeGear.Delphi.Targets import, which is where the property is defined.
+
+         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
+         with an empty body, so last in the list still means after the compile. -->
+    <PropertyGroup>
+        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
+    </PropertyGroup>
+    <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
             <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>

--- a/packages/Delphi/Aefos.OTA.Chat.dproj
+++ b/packages/Delphi/Aefos.OTA.Chat.dproj
@@ -1149,7 +1149,27 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <Target Name="AefosStageBplForInstaller" AfterTargets="Build" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
+    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
+
+         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
+         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
+         Error] The attribute AfterTargets in element <Target> is unrecognized" -
+         before a line of Pascal is read. It reads like a corrupt .dproj and is a
+         build engine five years older than the attribute.
+
+         The command line already worked around this by putting MSBuild 4.0 on the
+         PATH (scripts\build-packages.ps1), but nothing can do that for a build
+         started from inside the old IDE. Appending to $(BuildDependsOn) is the
+         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
+         understands it, so both paths run the same target. It must come AFTER the
+         CodeGear.Delphi.Targets import, which is where the property is defined.
+
+         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
+         with an empty body, so last in the list still means after the compile. -->
+    <PropertyGroup>
+        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
+    </PropertyGroup>
+    <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
             <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>

--- a/packages/Delphi/Aefos.OTA.Terminal.dproj
+++ b/packages/Delphi/Aefos.OTA.Terminal.dproj
@@ -1079,7 +1079,27 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <Target Name="AefosStageBplForInstaller" AfterTargets="Build" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
+    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
+
+         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
+         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
+         Error] The attribute AfterTargets in element <Target> is unrecognized" -
+         before a line of Pascal is read. It reads like a corrupt .dproj and is a
+         build engine five years older than the attribute.
+
+         The command line already worked around this by putting MSBuild 4.0 on the
+         PATH (scripts\build-packages.ps1), but nothing can do that for a build
+         started from inside the old IDE. Appending to $(BuildDependsOn) is the
+         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
+         understands it, so both paths run the same target. It must come AFTER the
+         CodeGear.Delphi.Targets import, which is where the property is defined.
+
+         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
+         with an empty body, so last in the list still means after the compile. -->
+    <PropertyGroup>
+        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
+    </PropertyGroup>
+    <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
             <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>

--- a/packages/Delphi/Aefos.Providers.dproj
+++ b/packages/Delphi/Aefos.Providers.dproj
@@ -197,7 +197,27 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <Target Name="AefosStageBplForInstaller" AfterTargets="Build" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
+    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
+
+         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
+         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
+         Error] The attribute AfterTargets in element <Target> is unrecognized" -
+         before a line of Pascal is read. It reads like a corrupt .dproj and is a
+         build engine five years older than the attribute.
+
+         The command line already worked around this by putting MSBuild 4.0 on the
+         PATH (scripts\build-packages.ps1), but nothing can do that for a build
+         started from inside the old IDE. Appending to $(BuildDependsOn) is the
+         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
+         understands it, so both paths run the same target. It must come AFTER the
+         CodeGear.Delphi.Targets import, which is where the property is defined.
+
+         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
+         with an empty body, so last in the list still means after the compile. -->
+    <PropertyGroup>
+        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
+    </PropertyGroup>
+    <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
             <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>

--- a/packages/Delphi/Aefos.Tools.dproj
+++ b/packages/Delphi/Aefos.Tools.dproj
@@ -194,7 +194,27 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <Target Name="AefosStageBplForInstaller" AfterTargets="Build" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
+    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
+
+         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
+         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
+         Error] The attribute AfterTargets in element <Target> is unrecognized" -
+         before a line of Pascal is read. It reads like a corrupt .dproj and is a
+         build engine five years older than the attribute.
+
+         The command line already worked around this by putting MSBuild 4.0 on the
+         PATH (scripts\build-packages.ps1), but nothing can do that for a build
+         started from inside the old IDE. Appending to $(BuildDependsOn) is the
+         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
+         understands it, so both paths run the same target. It must come AFTER the
+         CodeGear.Delphi.Targets import, which is where the property is defined.
+
+         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
+         with an empty body, so last in the list still means after the compile. -->
+    <PropertyGroup>
+        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
+    </PropertyGroup>
+    <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
             <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>

--- a/scripts/build-packages.ps1
+++ b/scripts/build-packages.ps1
@@ -166,18 +166,19 @@ foreach ($v in $targets) {
     Write-Host "=== Building Aefos group for Delphi $v ($Config/$plat) ===" -ForegroundColor Cyan
     # Prepend MSBuild 4.0 when rsvars picked an older one.
     #
-    # Seattle's rsvars.bat sets FrameworkDir to .NET v3.5, i.e. MSBuild 3.5 - and
-    # AfterTargets does not exist before MSBuild 4.0. Our .dproj files each carry
-    # an AfterTargets="Build" target (AefosStageBplForInstaller), so every package
-    # dies with MSB4066 "the attribute AfterTargets is unrecognized" before a line
-    # of Pascal is read. It reads like a broken project file; it is a build engine
-    # five years older than the attribute.
+    # Seattle's rsvars.bat sets FrameworkDir to .NET v3.5, i.e. MSBuild 3.5, which
+    # is older than several things the toolchain now takes for granted.
     #
-    # Fixing it here rather than in the eight .dproj files is deliberate: those
-    # files are also opened by the IDE, and rewriting the target into a 3.5-era
-    # idiom would degrade every modern build to work around one old one. Proven on
-    # Seattle: same projects, same compiler (30.0), MSBuild 4.0 - builds and the
-    # staging target runs.
+    # The first casualty was AfterTargets (MSBuild 4.0), which our staging target
+    # used to carry: every package died with MSB4066 "the attribute AfterTargets is
+    # unrecognized" before a line of Pascal was read. That one is now fixed at the
+    # source - the .dproj files hook $(BuildDependsOn) instead, an idiom 3.5 and
+    # every version since understand - because a build started from INSIDE the old
+    # IDE hosts its own 3.5 engine and can never be handed a different msbuild.
+    #
+    # This override stays regardless: it is proven on Seattle (same projects, same
+    # 30.0 compiler, MSBuild 4.0 - builds clean), and giving the command line the
+    # modern engine costs nothing while removing a whole class of 3.5-era surprise.
     $msbuildPrefix = ''
     $msOverride = Get-AefosMSBuildOverrideDir $rsvars
     if ($msOverride -ne '') {


### PR DESCRIPTION
Opening `Aefos.Harness.dproj` in **10 Seattle** and pressing Build fails at project *load*:

```
[Fatal Error] The attribute "AfterTargets" in element <Target> is unrecognized.
```

`AfterTargets` arrived in MSBuild 4.0 and the Seattle IDE hosts the 3.5 engine. Our `AefosStageBplForInstaller` target (copies the built `.bpl` into `installer\bpl`) carried that attribute, so **no Pascal is ever reached** — the message reads like a corrupt `.dproj` and is really a build engine five years older than the attribute.

The command line never hit it because `build-packages.ps1` puts MSBuild 4.0 on the PATH first. Nothing can do that for a build started **inside** the IDE — the path being exercised now that each old IDE is opened by hand.

## Change
The eight package projects hook `$(BuildDependsOn)` instead — the MSBuild 2.0 idiom, understood by 3.5 and every version since:

```xml
<PropertyGroup>
  <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
</PropertyGroup>
<Target Name="AefosStageBplForInstaller" Condition="...">
```

`CodeGear.Delphi.Targets` declares `<Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>` with an empty body, so appending still runs after the compile. The PATH override in the script stays (proven on Seattle, and it keeps the command line clear of the rest of the 3.5 era) — its comment is updated to say why both exist.

## Not verified yet
- [ ] Seattle IDE build of the group (this is what the change is for)
- [ ] D12 / D13 non-regression — the script path and the IDE path both

Line endings checked: no lone LF introduced into the CRLF `.dproj` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)