### PR TITLE
Hook the staging target where the old IDE still reads properties

### DIFF
--- a/packages/Delphi/Aefos.Data.dproj
+++ b/packages/Delphi/Aefos.Data.dproj
@@ -76,6 +76,10 @@
         <DCC_K>false</DCC_K>
         <GenDll>true</GenDll>
         <GenPackage>true</GenPackage>
+        <!-- Runs AefosStageBplForInstaller after the compile. _PostCompileTargets
+             is an unassigned extension point in CodeGear.Delphi.Targets and works
+             on every MSBuild back to 3.5, which is the engine the old IDEs host. -->
+        <_PostCompileTargets>AefosStageBplForInstaller</_PostCompileTargets>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <DCC_CBuilderOutput>All</DCC_CBuilderOutput>
         <SanitizedProjectName>Aefos_Data</SanitizedProjectName>
@@ -195,26 +199,6 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
-
-         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
-         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
-         Error] The attribute AfterTargets in element <Target> is unrecognized" -
-         before a line of Pascal is read. It reads like a corrupt .dproj and is a
-         build engine five years older than the attribute.
-
-         The command line already worked around this by putting MSBuild 4.0 on the
-         PATH (scripts\build-packages.ps1), but nothing can do that for a build
-         started from inside the old IDE. Appending to $(BuildDependsOn) is the
-         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
-         understands it, so both paths run the same target. It must come AFTER the
-         CodeGear.Delphi.Targets import, which is where the property is defined.
-
-         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
-         with an empty body, so last in the list still means after the compile. -->
-    <PropertyGroup>
-        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
-    </PropertyGroup>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>

--- a/packages/Delphi/Aefos.Harness.dproj
+++ b/packages/Delphi/Aefos.Harness.dproj
@@ -65,6 +65,10 @@
         <DCC_K>false</DCC_K>
         <GenDll>true</GenDll>
         <GenPackage>true</GenPackage>
+        <!-- Runs AefosStageBplForInstaller after the compile. _PostCompileTargets
+             is an unassigned extension point in CodeGear.Delphi.Targets and works
+             on every MSBuild back to 3.5, which is the engine the old IDEs host. -->
+        <_PostCompileTargets>AefosStageBplForInstaller</_PostCompileTargets>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
         <DCC_CBuilderOutput>All</DCC_CBuilderOutput>
         <SanitizedProjectName>Aefos_Harness</SanitizedProjectName>
@@ -172,26 +176,6 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
-
-         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
-         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
-         Error] The attribute AfterTargets in element <Target> is unrecognized" -
-         before a line of Pascal is read. It reads like a corrupt .dproj and is a
-         build engine five years older than the attribute.
-
-         The command line already worked around this by putting MSBuild 4.0 on the
-         PATH (scripts\build-packages.ps1), but nothing can do that for a build
-         started from inside the old IDE. Appending to $(BuildDependsOn) is the
-         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
-         understands it, so both paths run the same target. It must come AFTER the
-         CodeGear.Delphi.Targets import, which is where the property is defined.
-
-         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
-         with an empty body, so last in the list still means after the compile. -->
-    <PropertyGroup>
-        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
-    </PropertyGroup>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>

--- a/packages/Delphi/Aefos.MCP.Core.dproj
+++ b/packages/Delphi/Aefos.MCP.Core.dproj
@@ -75,6 +75,10 @@
         <DCC_K>false</DCC_K>
         <GenDll>true</GenDll>
         <GenPackage>true</GenPackage>
+        <!-- Runs AefosStageBplForInstaller after the compile. _PostCompileTargets
+             is an unassigned extension point in CodeGear.Delphi.Targets and works
+             on every MSBuild back to 3.5, which is the engine the old IDEs host. -->
+        <_PostCompileTargets>AefosStageBplForInstaller</_PostCompileTargets>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <DCC_CBuilderOutput>All</DCC_CBuilderOutput>
         <SanitizedProjectName>Aefos_MCP_Core</SanitizedProjectName>
@@ -232,26 +236,6 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
-
-         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
-         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
-         Error] The attribute AfterTargets in element <Target> is unrecognized" -
-         before a line of Pascal is read. It reads like a corrupt .dproj and is a
-         build engine five years older than the attribute.
-
-         The command line already worked around this by putting MSBuild 4.0 on the
-         PATH (scripts\build-packages.ps1), but nothing can do that for a build
-         started from inside the old IDE. Appending to $(BuildDependsOn) is the
-         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
-         understands it, so both paths run the same target. It must come AFTER the
-         CodeGear.Delphi.Targets import, which is where the property is defined.
-
-         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
-         with an empty body, so last in the list still means after the compile. -->
-    <PropertyGroup>
-        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
-    </PropertyGroup>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>

--- a/packages/Delphi/Aefos.MCP.Tools.OTA.dproj
+++ b/packages/Delphi/Aefos.MCP.Tools.OTA.dproj
@@ -81,6 +81,10 @@
         <DCC_K>false</DCC_K>
         <GenDll>true</GenDll>
         <GenPackage>true</GenPackage>
+        <!-- Runs AefosStageBplForInstaller after the compile. _PostCompileTargets
+             is an unassigned extension point in CodeGear.Delphi.Targets and works
+             on every MSBuild back to 3.5, which is the engine the old IDEs host. -->
+        <_PostCompileTargets>AefosStageBplForInstaller</_PostCompileTargets>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
         <SanitizedProjectName>Aefos_MCP_Tools_OTA</SanitizedProjectName>
         <DCC_UnitSearchPath>..\..\source\mcp\OTA;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
@@ -214,26 +218,6 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
-
-         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
-         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
-         Error] The attribute AfterTargets in element <Target> is unrecognized" -
-         before a line of Pascal is read. It reads like a corrupt .dproj and is a
-         build engine five years older than the attribute.
-
-         The command line already worked around this by putting MSBuild 4.0 on the
-         PATH (scripts\build-packages.ps1), but nothing can do that for a build
-         started from inside the old IDE. Appending to $(BuildDependsOn) is the
-         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
-         understands it, so both paths run the same target. It must come AFTER the
-         CodeGear.Delphi.Targets import, which is where the property is defined.
-
-         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
-         with an empty body, so last in the list still means after the compile. -->
-    <PropertyGroup>
-        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
-    </PropertyGroup>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>

--- a/packages/Delphi/Aefos.OTA.Chat.dproj
+++ b/packages/Delphi/Aefos.OTA.Chat.dproj
@@ -86,6 +86,10 @@
         <DCC_K>false</DCC_K>
         <GenDll>true</GenDll>
         <GenPackage>true</GenPackage>
+        <!-- Runs AefosStageBplForInstaller after the compile. _PostCompileTargets
+             is an unassigned extension point in CodeGear.Delphi.Targets and works
+             on every MSBuild back to 3.5, which is the engine the old IDEs host. -->
+        <_PostCompileTargets>AefosStageBplForInstaller</_PostCompileTargets>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
         <DCC_CBuilderOutput>All</DCC_CBuilderOutput>
         <SanitizedProjectName>Aefos_OTA_Chat</SanitizedProjectName>
@@ -1149,26 +1153,6 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
-
-         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
-         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
-         Error] The attribute AfterTargets in element <Target> is unrecognized" -
-         before a line of Pascal is read. It reads like a corrupt .dproj and is a
-         build engine five years older than the attribute.
-
-         The command line already worked around this by putting MSBuild 4.0 on the
-         PATH (scripts\build-packages.ps1), but nothing can do that for a build
-         started from inside the old IDE. Appending to $(BuildDependsOn) is the
-         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
-         understands it, so both paths run the same target. It must come AFTER the
-         CodeGear.Delphi.Targets import, which is where the property is defined.
-
-         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
-         with an empty body, so last in the list still means after the compile. -->
-    <PropertyGroup>
-        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
-    </PropertyGroup>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>

--- a/packages/Delphi/Aefos.OTA.Terminal.dproj
+++ b/packages/Delphi/Aefos.OTA.Terminal.dproj
@@ -49,6 +49,10 @@
         <DCC_K>false</DCC_K>
         <GenDll>true</GenDll>
         <GenPackage>true</GenPackage>
+        <!-- Runs AefosStageBplForInstaller after the compile. _PostCompileTargets
+             is an unassigned extension point in CodeGear.Delphi.Targets and works
+             on every MSBuild back to 3.5, which is the engine the old IDEs host. -->
+        <_PostCompileTargets>AefosStageBplForInstaller</_PostCompileTargets>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
         <DCC_CBuilderOutput>All</DCC_CBuilderOutput>
         <SanitizedProjectName>Aefos_OTA_Terminal</SanitizedProjectName>
@@ -1079,26 +1083,6 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
-
-         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
-         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
-         Error] The attribute AfterTargets in element <Target> is unrecognized" -
-         before a line of Pascal is read. It reads like a corrupt .dproj and is a
-         build engine five years older than the attribute.
-
-         The command line already worked around this by putting MSBuild 4.0 on the
-         PATH (scripts\build-packages.ps1), but nothing can do that for a build
-         started from inside the old IDE. Appending to $(BuildDependsOn) is the
-         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
-         understands it, so both paths run the same target. It must come AFTER the
-         CodeGear.Delphi.Targets import, which is where the property is defined.
-
-         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
-         with an empty body, so last in the list still means after the compile. -->
-    <PropertyGroup>
-        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
-    </PropertyGroup>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>

--- a/packages/Delphi/Aefos.Providers.dproj
+++ b/packages/Delphi/Aefos.Providers.dproj
@@ -75,6 +75,10 @@
         <DCC_K>false</DCC_K>
         <GenDll>true</GenDll>
         <GenPackage>true</GenPackage>
+        <!-- Runs AefosStageBplForInstaller after the compile. _PostCompileTargets
+             is an unassigned extension point in CodeGear.Delphi.Targets and works
+             on every MSBuild back to 3.5, which is the engine the old IDEs host. -->
+        <_PostCompileTargets>AefosStageBplForInstaller</_PostCompileTargets>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <DCC_CBuilderOutput>All</DCC_CBuilderOutput>
         <SanitizedProjectName>Aefos_Providers</SanitizedProjectName>
@@ -197,26 +201,6 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
-
-         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
-         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
-         Error] The attribute AfterTargets in element <Target> is unrecognized" -
-         before a line of Pascal is read. It reads like a corrupt .dproj and is a
-         build engine five years older than the attribute.
-
-         The command line already worked around this by putting MSBuild 4.0 on the
-         PATH (scripts\build-packages.ps1), but nothing can do that for a build
-         started from inside the old IDE. Appending to $(BuildDependsOn) is the
-         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
-         understands it, so both paths run the same target. It must come AFTER the
-         CodeGear.Delphi.Targets import, which is where the property is defined.
-
-         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
-         with an empty body, so last in the list still means after the compile. -->
-    <PropertyGroup>
-        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
-    </PropertyGroup>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>

--- a/packages/Delphi/Aefos.Tools.dproj
+++ b/packages/Delphi/Aefos.Tools.dproj
@@ -75,6 +75,10 @@
         <DCC_K>false</DCC_K>
         <GenDll>true</GenDll>
         <GenPackage>true</GenPackage>
+        <!-- Runs AefosStageBplForInstaller after the compile. _PostCompileTargets
+             is an unassigned extension point in CodeGear.Delphi.Targets and works
+             on every MSBuild back to 3.5, which is the engine the old IDEs host. -->
+        <_PostCompileTargets>AefosStageBplForInstaller</_PostCompileTargets>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <DCC_CBuilderOutput>All</DCC_CBuilderOutput>
         <SanitizedProjectName>Aefos_Tools</SanitizedProjectName>
@@ -194,26 +198,6 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
-    <!-- Staging the BPL: hooked through BuildDependsOn, not AfterTargets.
-
-         AfterTargets arrived in MSBuild 4.0. The IDE of 10 Seattle hosts the 3.5
-         engine, so it rejects the ATTRIBUTE while LOADING the project - "[Fatal
-         Error] The attribute AfterTargets in element <Target> is unrecognized" -
-         before a line of Pascal is read. It reads like a corrupt .dproj and is a
-         build engine five years older than the attribute.
-
-         The command line already worked around this by putting MSBuild 4.0 on the
-         PATH (scripts\build-packages.ps1), but nothing can do that for a build
-         started from inside the old IDE. Appending to $(BuildDependsOn) is the
-         MSBuild 2.0 idiom for the same thing and every version from 3.5 to today
-         understands it, so both paths run the same target. It must come AFTER the
-         CodeGear.Delphi.Targets import, which is where the property is defined.
-
-         Build is declared as <Target Name="Build" DependsOnTargets="$(BuildDependsOn)"/>
-         with an empty body, so last in the list still means after the compile. -->
-    <PropertyGroup>
-        <BuildDependsOn>$(BuildDependsOn);AefosStageBplForInstaller</BuildDependsOn>
-    </PropertyGroup>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
             <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>

--- a/scripts/build-packages.ps1
+++ b/scripts/build-packages.ps1
@@ -172,9 +172,17 @@ foreach ($v in $targets) {
     # The first casualty was AfterTargets (MSBuild 4.0), which our staging target
     # used to carry: every package died with MSB4066 "the attribute AfterTargets is
     # unrecognized" before a line of Pascal was read. That one is now fixed at the
-    # source - the .dproj files hook $(BuildDependsOn) instead, an idiom 3.5 and
-    # every version since understand - because a build started from INSIDE the old
-    # IDE hosts its own 3.5 engine and can never be handed a different msbuild.
+    # source - the .dproj files hook $(_PostCompileTargets), an unassigned extension
+    # point that works back to 3.5 - because a build started from INSIDE the old IDE
+    # hosts its own 3.5 engine and can never be handed a different msbuild.
+    #
+    # The hook lives in the Base PropertyGroup, NOT at the end of the file. The tail
+    # of a .dproj is parsed by the IDE itself, and the old IDE stops understanding
+    # the file from the first construct it does not expect there: a first attempt
+    # appended a PropertyGroup after the Import elements, msbuild was perfectly
+    # happy, and the IDE silently lost the whole Base group - packages linked as
+    # .exe (no GenDll) and units failed with "Unit 'SysUtils' not found" (no
+    # DCC_Namespace). Add build logic where the IDE already writes properties.
     #
     # This override stays regardless: it is proven on Seattle (same projects, same
     # 30.0 compiler, MSBuild 4.0 - builds clean), and giving the command line the


### PR DESCRIPTION
Follow-up to #28. Removing `AfterTargets` was right; putting the replacement at the **end** of the `.dproj` was not — it traded one IDE failure for two worse ones.

Building the group inside 10 Seattle after #28:

| Project | Symptom |
|---|---|
| `Aefos.Harness` | linked as `Aefos.Harness.exe`, then `[Fatal Error] Can't load package Aefos.Harness.bpl` |
| `Aefos.Providers` | `[dcc32 Fatal Error] F2613 Unit 'SysUtils' not found`, 0 lines compiled |

**One cause.** `GenDll`, `GenPackage` and `DCC_Namespace` all live in the same `<PropertyGroup Condition="'$(Base)'!=''">`, and in the IDE that group stopped taking effect. No `GenDll` → the targets fall through to `$(ExeExt)` and name the output `.exe`. No `DCC_Namespace` → unit scope names are gone, so `SysUtils` cannot resolve. The only two projects that still built correctly — `Aefos.WebView` and `dclAefosWebView` — are exactly the two with no staging target, never touched by #28.

**msbuild is not the one that disagrees.** Run by hand under Seattle, on both the 3.5 engine `rsvars` selects and the 4.0 one, the same files evaluate `OutputExt = .bpl`, emit `-TX.bpl` and run the staging target. What differs is the IDE, which parses the `.dproj` itself — and the tail of that file is its territory. A `PropertyGroup` after the `Import` elements is not something it expects there.

## Change
The hook moves to `$(_PostCompileTargets)` — an extension point `CodeGear.Delphi.Targets` references and never assigns (verified in 17.0 and 23.0) — declared inside the Base group, among properties the IDE writes anyway:

```xml
<GenPackage>true</GenPackage>
<_PostCompileTargets>AefosStageBplForInstaller</_PostCompileTargets>
```

The tail returns to exactly the shape the IDE emits, minus the one attribute that started this.

## Verified
- Seattle command line, MSBuild **3.5** and **4.0**: `OutputExt = .bpl`, `-TX.bpl`, staging target runs
- No lone-LF introduced into the CRLF `.dproj` files
- Mirrored in the private source repo (`Aefos-AI`, 9 projects — it also has `Aefos.License.dproj`)

## Not verified yet
- [ ] Seattle **IDE** build of the group — this is the one that matters
- [ ] D12 / D13 non-regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)