### PR TITLE
Measure static SQLite in the project, so the IDE can build Aefos.Data too

### DIFF
--- a/packages/Delphi/Aefos.Data.dproj
+++ b/packages/Delphi/Aefos.Data.dproj
@@ -80,6 +80,19 @@
              is an unassigned extension point in CodeGear.Delphi.Targets and works
              on every MSBuild back to 3.5, which is the engine the old IDEs host. -->
         <_PostCompileTargets>AefosStageBplForInstaller</_PostCompileTargets>
+        <!-- Static SQLite: LOOK for the unit, do not guess a version.
+             FireDAC.Phys.SQLiteWrapper.Stat links the SQLite engine into this BPL
+             instead of loading sqlite3.dll at run time, and it is not in every
+             FireDAC: measured absent in 10 Seattle and 10.1 Berlin, present from
+             Delphi 11 on. Aefos.Data.SQLite.pas pulls it in unless the symbol is
+             defined, so on an IDE without it the unit fails with F2613.
+             The test lives here, in the project, because that is the only place
+             BOTH paths read: build-packages.ps1 can pass a define, a build started
+             from inside the IDE cannot be passed anything. The symbol stays
+             NEGATIVE so the default - no symbol - remains correct for a modern
+             Delphi. Where it fires, the BPL needs sqlite3.dll deployed beside it;
+             the script stages that copy. -->
+        <DCC_Define Condition="!Exists('$(BDS)\lib\$(Platform)\release\FireDAC.Phys.SQLiteWrapper.Stat.dcu')">AEFOS_NO_STATIC_SQLITE;$(DCC_Define)</DCC_Define>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;$(DCC_Namespace)</DCC_Namespace>
         <DCC_CBuilderOutput>All</DCC_CBuilderOutput>
         <SanitizedProjectName>Aefos_Data</SanitizedProjectName>

--- a/scripts/build-packages.ps1
+++ b/scripts/build-packages.ps1
@@ -211,25 +211,30 @@ foreach ($v in $targets) {
     $hppOut = Join-Path $root "Bin\$plat\$Config"
     New-Item -ItemType Directory -Force $hppOut | Out-Null
 
-    # Static SQLite: LOOK, do not guess.
+    # Static SQLite: the DEFINE is not decided here.
     #
     # FireDAC.Phys.SQLiteWrapper.Stat is what links the SQLite engine into
     # Aefos.Data instead of loading sqlite3.dll at run time, and it does not exist
     # in every FireDAC. Measured: absent in 10 Seattle AND in 10.1 Berlin, present
     # in Delphi 11. An earlier CompilerVersion guess put the boundary just above
-    # Seattle and Berlin proved it wrong the day it was installed - hence this.
+    # Seattle and Berlin proved it wrong the day it was installed.
     #
-    # The define is NEGATIVE on purpose. Building from the IDE passes no defines at
-    # all, so the default (no symbol) has to be the CORRECT behaviour for every
-    # modern Delphi - static linkage. Only a command-line build that has looked at
-    # the lib folder and found nothing switches it off.
-    $sqliteDefine = ''
+    # This script used to pass AEFOS_NO_STATIC_SQLITE when the .dcu was missing,
+    # which left the IDE with no way to build Aefos.Data at all: a build started
+    # from inside the IDE is passed no defines by anyone, so on Seattle it died
+    # with F2613 on a unit the command line had quietly compiled around. The same
+    # Exists() test now lives in Aefos.Data.dproj, which is the one thing BOTH
+    # paths read. Proven on the VM: BDS 17.0 gets RELEASE;AEFOS_NO_STATIC_SQLITE
+    # and 22.0 gets RELEASE, each building clean.
+    #
+    # What stays here is the consequence the project file cannot carry out: with
+    # no static engine the BPL loads sqlite3.dll at RUN time, so the DLL has to
+    # travel with it. Measure the same way for that decision only.
     $needsSqliteDll = $false
     $statDcu = Join-Path (Split-Path -Parent (Split-Path -Parent $rsvars)) `
                          "lib\$($plat.ToLower())\release\FireDAC.Phys.SQLiteWrapper.Stat.dcu"
     if (-not (Test-Path $statDcu)) {
       Write-Host "  no static SQLite in this FireDAC -- Aefos.Data will load sqlite3.dll at run time." -ForegroundColor DarkYellow
-      $sqliteDefine = '/p:DCC_Define=AEFOS_NO_STATIC_SQLITE '
       $needsSqliteDll = $true
     }
     # Say WHERE the BPLs go, rather than trusting the IDE's per-user state.
@@ -249,7 +254,7 @@ foreach ($v in $targets) {
     $cmd = "`"$rsvars`" && $msbuildPrefix" +
            "msbuild `"$grp`" /t:Build /p:Config=$Config /p:Platform=$plat " +
            "/p:DCC_BplOutput=`"$bplOut`" " +
-           "$sqliteDefine/p:DCC_ForceExecute=true /v:minimal /nologo"
+           "/p:DCC_ForceExecute=true /v:minimal /nologo"
     cmd /c $cmd
     if ($LASTEXITCODE -ne 0) { throw "Build FAILED for Delphi $v/$plat (exit $LASTEXITCODE)." }
 


### PR DESCRIPTION
Building the group inside 10 Seattle now reaches `Aefos.Data` and dies:

```
[dcc32 Fatal Error] Aefos.Data.SQLite.pas(81):
F2613 Unit 'FireDAC.Phys.SQLiteWrapper.Stat' not found.
```

The unit links the SQLite engine into the BPL instead of loading `sqlite3.dll` at run time, and it is not in every FireDAC — measured absent in 10 Seattle and 10.1 Berlin, present from Delphi 11 on. The source already guards it with `{$IFNDEF AEFOS_NO_STATIC_SQLITE}`, but **only `build-packages.ps1` ever defined that symbol**. A build started from inside the IDE is passed no defines by anyone, so the guard could never fire there — the command line was quietly compiling around a wall the IDE walks straight into.

## Change
The test moves into `Aefos.Data.dproj`, the one thing both paths read:

```xml
<DCC_Define Condition="!Exists('$(BDS)\lib\$(Platform)\release\FireDAC.Phys.SQLiteWrapper.Stat.dcu')">AEFOS_NO_STATIC_SQLITE;$(DCC_Define)</DCC_Define>
```

Still a **measurement**, not a version guess (the mistake Berlin disproved the day it was installed), still a **negative** symbol so a modern Delphi with no symbol keeps static linkage, and it sits in the Base property group among properties the IDE writes — not at the end of the file, per #29.

`build-packages.ps1` stops passing the define so there is one source of truth. It keeps the same `Exists()` test for the part a project file cannot do: staging `sqlite3.dll` beside a BPL that will load it at run time.

## Verified on the VM, both directions, same tree
| IDE | `DCC_Define` | Result |
|---|---|---|
| BDS 17.0 (Seattle) | `RELEASE;AEFOS_NO_STATIC_SQLITE;` | build clean |
| BDS 22.0 (Delphi 11) | `RELEASE;` | build clean, BPL produced |

## Note — not mirrored to the private repo
`Aefos-AI` has no `{$IFNDEF AEFOS_NO_STATIC_SQLITE}` in `Aefos.Data.SQLite.pas` (it uses the unit unconditionally) and no `source/compat/` or `scripts/aefos-ide-versions.ps1`. The whole Seattle campaign lives only in this tree, so mirroring just the define there would be inert. Flagged for the maintainer to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)