### PR TITLE
Aefos.OTA.Chat recompiles Aefos.Data.SQLite, so it needs the same measurement

### DIFF
--- a/packages/Delphi/Aefos.OTA.Chat.dproj
+++ b/packages/Delphi/Aefos.OTA.Chat.dproj
@@ -90,6 +90,13 @@
              is an unassigned extension point in CodeGear.Delphi.Targets and works
              on every MSBuild back to 3.5, which is the engine the old IDEs host. -->
         <_PostCompileTargets>AefosStageBplForInstaller</_PostCompileTargets>
+        <!-- Same static-SQLite measurement as Aefos.Data.dproj, and for the same
+             reason: this package requires Aefos.Data and reaches
+             Aefos.Data.SQLite.pas through SessionStore.SQLite, so a build-all
+             recompiles that unit HERE too and needs the symbol here too. Seattle
+             found this the hard way, one package after Aefos.Data went green.
+             Any package that ends up compiling that unit needs this line. -->
+        <DCC_Define Condition="!Exists('$(BDS)\lib\$(Platform)\release\FireDAC.Phys.SQLiteWrapper.Stat.dcu')">AEFOS_NO_STATIC_SQLITE;$(DCC_Define)</DCC_Define>
         <DCC_Namespace>System;Xml;Data;Datasnap;Web;Soap;Vcl;Vcl.Imaging;Vcl.Touch;Vcl.Samples;Vcl.Shell;$(DCC_Namespace)</DCC_Namespace>
         <DCC_CBuilderOutput>All</DCC_CBuilderOutput>
         <SanitizedProjectName>Aefos_OTA_Chat</SanitizedProjectName>


### PR DESCRIPTION
Follow-up to #30, found by the next Build in Seattle: `Aefos.Data` went green and `Aefos.OTA.Chat` failed with the identical error.

```
[dcc32 Fatal Error] Aefos.Data.SQLite.pas(81):
F2613 Unit 'FireDAC.Phys.SQLiteWrapper.Stat' not found.
```

A `requires` is not a wall: `Aefos.OTA.Chat` requires `Aefos.Data` and reaches `Aefos.Data.SQLite.pas` through `SessionStore.SQLite`, so a build-all recompiles that unit **inside this project** and the symbol has to be defined here too. This is what the old `/p:DCC_Define` did for free: it was passed to the whole GROUP, so per-project placement never came up until the measurement moved into the project files.

Only these two projects can reach the unit — `Aefos.Data` contains it, `Aefos.OTA.Chat` pulls it in. The comment says so, so the next package that starts compiling it knows what it needs.

## Verified on the VM, same tree
| IDE | `DCC_Define` for Aefos.OTA.Chat |
|---|---|
| BDS 17.0 (Seattle) | `RELEASE;AEFOS_NO_STATIC_SQLITE;` |
| BDS 22.0 (Delphi 11) | `RELEASE;;FRAMEWORK_VCL` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)