### PR TITLE
Give every BPL the IDE's own suffix, so two RAD Studios stop sharing file names

### DIFF
--- a/docs/build-install.md
+++ b/docs/build-install.md
@@ -75,15 +75,22 @@ a monorepo-wide build script lands. Each package's Release/Win32 build auto-stag
 1. **Make the runtime BPLs reachable.** Put the built BPLs in a fixed folder (e.g.
    `C:\Aefos\bpl`) and add it to the Windows **PATH**, or to the IDE library
    path under **Tools → Options → Language → Delphi → Library → Library path**
-   (Win32). This ensures the runtime BPLs (`Aefos.WebView.bpl`,
-   `Aefos.Harness.bpl`, `Aefos.Providers.bpl`,
-   `Aefos.Tools.bpl`, `Aefos.MCP.Core.bpl`, `Aefos.MCP.Tools.OTA.bpl`,
-   `Aefos.Data.bpl`) are found at load time.
+   (Win32). This ensures the runtime BPLs (`Aefos.WebView`, `Aefos.Harness`,
+   `Aefos.Providers`, `Aefos.Tools`, `Aefos.MCP.Core`, `Aefos.MCP.Tools.OTA`,
+   `Aefos.Data`) are found at load time.
+
+   > **Every file name carries the IDE's package suffix** — the same one
+   > Embarcadero puts on theirs: `Aefos.MCP.Core230.bpl` on 10 Seattle, `...270`
+   > on Sydney, `...290` on Delphi 12, `...370` on Delphi 13. That is what lets
+   > two RAD Studios share a machine. Without it every version ships the same
+   > file name, the first `Bpl` folder on `PATH` answers for all of them, and a
+   > Seattle IDE ends up loading a Sydney package.
 2. **Register the design-time package(s).** Go to **Components → Install Packages… →
-   Add…** and select the design-time BPL(s) you want:
-   - `Aefos.OTA.Chat.bpl` — the AI chat panel
-   - `Aefos.OTA.Terminal.bpl` — the docked terminal
-   - `dclAefosWebView.bpl` — (optional) the `TAefosWebView` palette component
+   Add…** and select the design-time BPL(s) you want (`<sfx>` is your IDE's
+   suffix — `290` on Delphi 12):
+   - `Aefos.OTA.Chat<sfx>.bpl` — the AI chat panel
+   - `Aefos.OTA.Terminal<sfx>.bpl` — the docked terminal
+   - `dclAefosWebView<sfx>.bpl` — (optional) the `TAefosWebView` palette component
 
    The IDE loads the design-time package and, through its `requires` chain, the
    runtime core. You do **not** install the runtime packages separately — they only

--- a/installer/Aefos.iss
+++ b/installer/Aefos.iss
@@ -64,19 +64,41 @@
 #define VerD12     "23.0"
 #define VerD13     "37.0"
 
+; --- package name suffix, one per version ----------------------------------
+; Our BPLs carry the same suffix Embarcadero puts on theirs (rtl230, rtl290,
+; rtl370), because without it every version shipped the SAME file name: on a
+; machine with two RAD Studios the first Bpl folder on PATH answered for both,
+; and a Seattle IDE was measured loading a Sydney Aefos.MCP.Core.bpl.
+;
+; These literals exist because Inno resolves file names at compile time. They are
+; NOT the source of truth - Aefos.LibSuffix.inc tells the compiler, and
+; build-installer.ps1 reads the suffix back off the staged files and refuses to
+; build when it disagrees with what is declared here.
+;
+; Win32 and Win64 share a suffix: RAD Studio ships rtl290.bpl in both bin and
+; bin64 and tells the bitnesses apart by folder.
+#define SufD10S    "230"
+#define SufD10B    "240"
+#define SufD10T    "250"
+#define SufD10R    "260"
+#define SufD10Y    "270"
+#define SufD11     "280"
+#define SufD12     "290"
+#define SufD13     "370"
+
 ; A version's payload is emitted ONLY if its BPLs were staged, so building just
 ; one Delphi yields a single-version installer (FileExists is a compile-time check).
-#define HaveD10S FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD10S + "\Aefos.OTA.Chat.bpl")
-#define HaveD10B FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD10B + "\Aefos.OTA.Chat.bpl")
-#define HaveD10T   FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD10T + "\Aefos.OTA.Chat.bpl")
-#define HaveD10R   FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD10R + "\Aefos.OTA.Chat.bpl")
-#define HaveD10Y   FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD10Y + "\Aefos.OTA.Chat.bpl")
-#define HaveD11  FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD11 + "\Aefos.OTA.Chat.bpl")
-#define HaveD12  FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD12 + "\Aefos.OTA.Chat.bpl")
-#define HaveD13  FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD13 + "\Aefos.OTA.Chat.bpl")
+#define HaveD10S FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD10S + "\Aefos.OTA.Chat" + SufD10S + ".bpl")
+#define HaveD10B FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD10B + "\Aefos.OTA.Chat" + SufD10B + ".bpl")
+#define HaveD10T   FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD10T + "\Aefos.OTA.Chat" + SufD10T + ".bpl")
+#define HaveD10R   FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD10R + "\Aefos.OTA.Chat" + SufD10R + ".bpl")
+#define HaveD10Y   FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD10Y + "\Aefos.OTA.Chat" + SufD10Y + ".bpl")
+#define HaveD11  FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD11 + "\Aefos.OTA.Chat" + SufD11 + ".bpl")
+#define HaveD12  FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD12 + "\Aefos.OTA.Chat" + SufD12 + ".bpl")
+#define HaveD13  FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD13 + "\Aefos.OTA.Chat" + SufD13 + ".bpl")
 ; The 64-bit IDE payload is independent: -Platform Win32 (the default) stages
 ; nothing under Win64 and the whole block below vanishes at compile time.
-#define HaveD13x FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD13 + "\Win64\Aefos.OTA.Chat.bpl")
+#define HaveD13x FileExists(AddBackslash(SourcePath) + BplSrc + "\" + VerD13 + "\Win64\Aefos.OTA.Chat" + SufD13 + ".bpl")
 #if !HaveD10S && !HaveD10B && !HaveD10T && !HaveD10R && !HaveD10Y && !HaveD11 && !HaveD12 && !HaveD13
   #error No staged BPLs found under .\bpl\<ver>. Run scripts\build-packages.ps1 then installer\build-installer.ps1.
 #endif
@@ -209,126 +231,126 @@ Source: "redist\cli\THIRD-PARTY-LICENSES.txt"; DestDir: "{userappdata}\Aefos\bin
 
 ; --- Delphi 10 Seattle (BDS 17.0) payload - only if staged; installed if chosen -
 #if HaveD10S
-Source: "{#BplSrc}\{#VerD10S}\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
-Source: "{#BplSrc}\{#VerD10S}\Aefos.Providers.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
-Source: "{#BplSrc}\{#VerD10S}\Aefos.Tools.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
-Source: "{#BplSrc}\{#VerD10S}\Aefos.MCP.Core.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
-Source: "{#BplSrc}\{#VerD10S}\Aefos.MCP.Tools.OTA.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
-Source: "{#BplSrc}\{#VerD10S}\Aefos.Data.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
-Source: "{#BplSrc}\{#VerD10S}\Aefos.WebView.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.Harness{#SufD10S}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.Providers{#SufD10S}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.Tools{#SufD10S}.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.MCP.Core{#SufD10S}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.MCP.Tools.OTA{#SufD10S}.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.Data{#SufD10S}.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.WebView{#SufD10S}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
 Source: "{#BplSrc}\{#VerD10S}\WebView2Loader.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
 Source: "{#BplSrc}\{#VerD10S}\sqlite3.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion skipifsourcedoesntexist; Check: WantVer('{#VerD10S}')
-Source: "{#BplSrc}\{#VerD10S}\Aefos.OTA.Chat.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
-Source: "{#BplSrc}\{#VerD10S}\Aefos.OTA.Terminal.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
-Source: "{#BplSrc}\{#VerD10S}\dclAefosWebView.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.OTA.Chat{#SufD10S}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\Aefos.OTA.Terminal{#SufD10S}.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
+Source: "{#BplSrc}\{#VerD10S}\dclAefosWebView{#SufD10S}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10S}')
 #endif
 
 #if HaveD10B
-Source: "{#BplSrc}\{#VerD10B}\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
-Source: "{#BplSrc}\{#VerD10B}\Aefos.Providers.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
-Source: "{#BplSrc}\{#VerD10B}\Aefos.Tools.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
-Source: "{#BplSrc}\{#VerD10B}\Aefos.MCP.Core.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
-Source: "{#BplSrc}\{#VerD10B}\Aefos.MCP.Tools.OTA.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
-Source: "{#BplSrc}\{#VerD10B}\Aefos.Data.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
-Source: "{#BplSrc}\{#VerD10B}\Aefos.WebView.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.Harness{#SufD10B}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.Providers{#SufD10B}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.Tools{#SufD10B}.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.MCP.Core{#SufD10B}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.MCP.Tools.OTA{#SufD10B}.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.Data{#SufD10B}.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.WebView{#SufD10B}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
 Source: "{#BplSrc}\{#VerD10B}\WebView2Loader.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
 Source: "{#BplSrc}\{#VerD10B}\sqlite3.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion skipifsourcedoesntexist; Check: WantVer('{#VerD10B}')
-Source: "{#BplSrc}\{#VerD10B}\Aefos.OTA.Chat.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
-Source: "{#BplSrc}\{#VerD10B}\Aefos.OTA.Terminal.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
-Source: "{#BplSrc}\{#VerD10B}\dclAefosWebView.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.OTA.Chat{#SufD10B}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\Aefos.OTA.Terminal{#SufD10B}.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
+Source: "{#BplSrc}\{#VerD10B}\dclAefosWebView{#SufD10B}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10B}')
 #endif
 
 #if HaveD10T
-Source: "{#BplSrc}\{#VerD10T}\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
-Source: "{#BplSrc}\{#VerD10T}\Aefos.Providers.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
-Source: "{#BplSrc}\{#VerD10T}\Aefos.Tools.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
-Source: "{#BplSrc}\{#VerD10T}\Aefos.MCP.Core.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
-Source: "{#BplSrc}\{#VerD10T}\Aefos.MCP.Tools.OTA.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
-Source: "{#BplSrc}\{#VerD10T}\Aefos.Data.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
-Source: "{#BplSrc}\{#VerD10T}\Aefos.WebView.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
+Source: "{#BplSrc}\{#VerD10T}\Aefos.Harness{#SufD10T}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
+Source: "{#BplSrc}\{#VerD10T}\Aefos.Providers{#SufD10T}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
+Source: "{#BplSrc}\{#VerD10T}\Aefos.Tools{#SufD10T}.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
+Source: "{#BplSrc}\{#VerD10T}\Aefos.MCP.Core{#SufD10T}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
+Source: "{#BplSrc}\{#VerD10T}\Aefos.MCP.Tools.OTA{#SufD10T}.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
+Source: "{#BplSrc}\{#VerD10T}\Aefos.Data{#SufD10T}.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
+Source: "{#BplSrc}\{#VerD10T}\Aefos.WebView{#SufD10T}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
 Source: "{#BplSrc}\{#VerD10T}\WebView2Loader.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
 Source: "{#BplSrc}\{#VerD10T}\sqlite3.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion skipifsourcedoesntexist; Check: WantVer('{#VerD10T}')
-Source: "{#BplSrc}\{#VerD10T}\Aefos.OTA.Chat.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
-Source: "{#BplSrc}\{#VerD10T}\Aefos.OTA.Terminal.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
-Source: "{#BplSrc}\{#VerD10T}\dclAefosWebView.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
+Source: "{#BplSrc}\{#VerD10T}\Aefos.OTA.Chat{#SufD10T}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
+Source: "{#BplSrc}\{#VerD10T}\Aefos.OTA.Terminal{#SufD10T}.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
+Source: "{#BplSrc}\{#VerD10T}\dclAefosWebView{#SufD10T}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10T}')
 #endif
 
 #if HaveD10R
-Source: "{#BplSrc}\{#VerD10R}\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
-Source: "{#BplSrc}\{#VerD10R}\Aefos.Providers.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
-Source: "{#BplSrc}\{#VerD10R}\Aefos.Tools.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
-Source: "{#BplSrc}\{#VerD10R}\Aefos.MCP.Core.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
-Source: "{#BplSrc}\{#VerD10R}\Aefos.MCP.Tools.OTA.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
-Source: "{#BplSrc}\{#VerD10R}\Aefos.Data.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
-Source: "{#BplSrc}\{#VerD10R}\Aefos.WebView.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
+Source: "{#BplSrc}\{#VerD10R}\Aefos.Harness{#SufD10R}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
+Source: "{#BplSrc}\{#VerD10R}\Aefos.Providers{#SufD10R}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
+Source: "{#BplSrc}\{#VerD10R}\Aefos.Tools{#SufD10R}.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
+Source: "{#BplSrc}\{#VerD10R}\Aefos.MCP.Core{#SufD10R}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
+Source: "{#BplSrc}\{#VerD10R}\Aefos.MCP.Tools.OTA{#SufD10R}.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
+Source: "{#BplSrc}\{#VerD10R}\Aefos.Data{#SufD10R}.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
+Source: "{#BplSrc}\{#VerD10R}\Aefos.WebView{#SufD10R}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
 Source: "{#BplSrc}\{#VerD10R}\WebView2Loader.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
 Source: "{#BplSrc}\{#VerD10R}\sqlite3.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion skipifsourcedoesntexist; Check: WantVer('{#VerD10R}')
-Source: "{#BplSrc}\{#VerD10R}\Aefos.OTA.Chat.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
-Source: "{#BplSrc}\{#VerD10R}\Aefos.OTA.Terminal.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
-Source: "{#BplSrc}\{#VerD10R}\dclAefosWebView.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
+Source: "{#BplSrc}\{#VerD10R}\Aefos.OTA.Chat{#SufD10R}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
+Source: "{#BplSrc}\{#VerD10R}\Aefos.OTA.Terminal{#SufD10R}.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
+Source: "{#BplSrc}\{#VerD10R}\dclAefosWebView{#SufD10R}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10R}')
 #endif
 
 #if HaveD10Y
-Source: "{#BplSrc}\{#VerD10Y}\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
-Source: "{#BplSrc}\{#VerD10Y}\Aefos.Providers.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
-Source: "{#BplSrc}\{#VerD10Y}\Aefos.Tools.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
-Source: "{#BplSrc}\{#VerD10Y}\Aefos.MCP.Core.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
-Source: "{#BplSrc}\{#VerD10Y}\Aefos.MCP.Tools.OTA.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
-Source: "{#BplSrc}\{#VerD10Y}\Aefos.Data.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
-Source: "{#BplSrc}\{#VerD10Y}\Aefos.WebView.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
+Source: "{#BplSrc}\{#VerD10Y}\Aefos.Harness{#SufD10Y}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
+Source: "{#BplSrc}\{#VerD10Y}\Aefos.Providers{#SufD10Y}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
+Source: "{#BplSrc}\{#VerD10Y}\Aefos.Tools{#SufD10Y}.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
+Source: "{#BplSrc}\{#VerD10Y}\Aefos.MCP.Core{#SufD10Y}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
+Source: "{#BplSrc}\{#VerD10Y}\Aefos.MCP.Tools.OTA{#SufD10Y}.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
+Source: "{#BplSrc}\{#VerD10Y}\Aefos.Data{#SufD10Y}.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
+Source: "{#BplSrc}\{#VerD10Y}\Aefos.WebView{#SufD10Y}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
 Source: "{#BplSrc}\{#VerD10Y}\WebView2Loader.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
 Source: "{#BplSrc}\{#VerD10Y}\sqlite3.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion skipifsourcedoesntexist; Check: WantVer('{#VerD10Y}')
-Source: "{#BplSrc}\{#VerD10Y}\Aefos.OTA.Chat.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
-Source: "{#BplSrc}\{#VerD10Y}\Aefos.OTA.Terminal.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
-Source: "{#BplSrc}\{#VerD10Y}\dclAefosWebView.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
+Source: "{#BplSrc}\{#VerD10Y}\Aefos.OTA.Chat{#SufD10Y}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
+Source: "{#BplSrc}\{#VerD10Y}\Aefos.OTA.Terminal{#SufD10Y}.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
+Source: "{#BplSrc}\{#VerD10Y}\dclAefosWebView{#SufD10Y}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD10Y}')
 #endif
 
 ; --- Delphi 11 (BDS 22.0) payload - only if staged; installed only if chosen ----
 #if HaveD11
-Source: "{#BplSrc}\{#VerD11}\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
-Source: "{#BplSrc}\{#VerD11}\Aefos.Providers.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
-Source: "{#BplSrc}\{#VerD11}\Aefos.Tools.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
-Source: "{#BplSrc}\{#VerD11}\Aefos.MCP.Core.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
-Source: "{#BplSrc}\{#VerD11}\Aefos.MCP.Tools.OTA.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
-Source: "{#BplSrc}\{#VerD11}\Aefos.Data.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
-Source: "{#BplSrc}\{#VerD11}\Aefos.WebView.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
+Source: "{#BplSrc}\{#VerD11}\Aefos.Harness{#SufD11}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
+Source: "{#BplSrc}\{#VerD11}\Aefos.Providers{#SufD11}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
+Source: "{#BplSrc}\{#VerD11}\Aefos.Tools{#SufD11}.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
+Source: "{#BplSrc}\{#VerD11}\Aefos.MCP.Core{#SufD11}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
+Source: "{#BplSrc}\{#VerD11}\Aefos.MCP.Tools.OTA{#SufD11}.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
+Source: "{#BplSrc}\{#VerD11}\Aefos.Data{#SufD11}.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
+Source: "{#BplSrc}\{#VerD11}\Aefos.WebView{#SufD11}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
 Source: "{#BplSrc}\{#VerD11}\WebView2Loader.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
 Source: "{#BplSrc}\{#VerD11}\sqlite3.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion skipifsourcedoesntexist; Check: WantVer('{#VerD11}')
-Source: "{#BplSrc}\{#VerD11}\Aefos.OTA.Chat.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
-Source: "{#BplSrc}\{#VerD11}\Aefos.OTA.Terminal.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
-Source: "{#BplSrc}\{#VerD11}\dclAefosWebView.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
+Source: "{#BplSrc}\{#VerD11}\Aefos.OTA.Chat{#SufD11}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
+Source: "{#BplSrc}\{#VerD11}\Aefos.OTA.Terminal{#SufD11}.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
+Source: "{#BplSrc}\{#VerD11}\dclAefosWebView{#SufD11}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD11}')
 #endif
 
 ; --- Delphi 12 (BDS 23.0) payload - only if staged; installed only if chosen ----
 #if HaveD12
-Source: "{#BplSrc}\{#VerD12}\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
-Source: "{#BplSrc}\{#VerD12}\Aefos.Providers.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
-Source: "{#BplSrc}\{#VerD12}\Aefos.Tools.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
-Source: "{#BplSrc}\{#VerD12}\Aefos.MCP.Core.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
-Source: "{#BplSrc}\{#VerD12}\Aefos.MCP.Tools.OTA.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
-Source: "{#BplSrc}\{#VerD12}\Aefos.Data.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
-Source: "{#BplSrc}\{#VerD12}\Aefos.WebView.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
+Source: "{#BplSrc}\{#VerD12}\Aefos.Harness{#SufD12}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
+Source: "{#BplSrc}\{#VerD12}\Aefos.Providers{#SufD12}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
+Source: "{#BplSrc}\{#VerD12}\Aefos.Tools{#SufD12}.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
+Source: "{#BplSrc}\{#VerD12}\Aefos.MCP.Core{#SufD12}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
+Source: "{#BplSrc}\{#VerD12}\Aefos.MCP.Tools.OTA{#SufD12}.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
+Source: "{#BplSrc}\{#VerD12}\Aefos.Data{#SufD12}.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
+Source: "{#BplSrc}\{#VerD12}\Aefos.WebView{#SufD12}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
 Source: "{#BplSrc}\{#VerD12}\WebView2Loader.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
 Source: "{#BplSrc}\{#VerD12}\sqlite3.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion skipifsourcedoesntexist; Check: WantVer('{#VerD12}')
-Source: "{#BplSrc}\{#VerD12}\Aefos.OTA.Chat.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
-Source: "{#BplSrc}\{#VerD12}\Aefos.OTA.Terminal.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
-Source: "{#BplSrc}\{#VerD12}\dclAefosWebView.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
+Source: "{#BplSrc}\{#VerD12}\Aefos.OTA.Chat{#SufD12}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
+Source: "{#BplSrc}\{#VerD12}\Aefos.OTA.Terminal{#SufD12}.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
+Source: "{#BplSrc}\{#VerD12}\dclAefosWebView{#SufD12}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD12}')
 #endif
 
 ; --- Delphi 13 (BDS 37.0) payload - only if staged; installed only if chosen ----
 #if HaveD13
-Source: "{#BplSrc}\{#VerD13}\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Aefos.Providers.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Aefos.Tools.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Aefos.MCP.Core.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Aefos.MCP.Tools.OTA.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Aefos.Data.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Aefos.WebView.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Aefos.Harness{#SufD13}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Aefos.Providers{#SufD13}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Aefos.Tools{#SufD13}.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Aefos.MCP.Core{#SufD13}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Aefos.MCP.Tools.OTA{#SufD13}.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Aefos.Data{#SufD13}.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Aefos.WebView{#SufD13}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
 Source: "{#BplSrc}\{#VerD13}\WebView2Loader.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
 Source: "{#BplSrc}\{#VerD13}\sqlite3.dll";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion skipifsourcedoesntexist; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Aefos.OTA.Chat.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Aefos.OTA.Terminal.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\dclAefosWebView.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Aefos.OTA.Chat{#SufD13}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Aefos.OTA.Terminal{#SufD13}.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\dclAefosWebView{#SufD13}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
 #endif
 
 ; --- Delphi 13, 64-bit IDE (bin64\bds.exe) - a SEPARATE set of packages --------
@@ -342,16 +364,16 @@ Source: "{#BplSrc}\{#VerD13}\dclAefosWebView.bpl";     DestDir: "{commondocs}\Em
 ; Optional exactly like a version payload: build-packages.ps1 -Platform Win32 (the
 ; default) stages nothing here, and this whole block disappears at compile time.
 #if HaveD13x
-Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.Harness.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.Providers.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.Tools.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.MCP.Core.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.MCP.Tools.OTA.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.Data.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.WebView.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.OTA.Chat.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.OTA.Terminal.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
-Source: "{#BplSrc}\{#VerD13}\Win64\dclAefosWebView.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.Harness{#SufD13}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.Providers{#SufD13}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.Tools{#SufD13}.bpl";         DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.MCP.Core{#SufD13}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.MCP.Tools.OTA{#SufD13}.bpl"; DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.Data{#SufD13}.bpl";          DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.WebView{#SufD13}.bpl";       DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.OTA.Chat{#SufD13}.bpl";      DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\Aefos.OTA.Terminal{#SufD13}.bpl";  DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
+Source: "{#BplSrc}\{#VerD13}\Win64\dclAefosWebView{#SufD13}.bpl";     DestDir: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64"; Flags: ignoreversion; Check: WantVer('{#VerD13}')
 ; A 64-bit IDE process cannot bind the 32-bit loader RAD Studio ships, so this is
 ; the x64 one -- staged by build-installer.ps1 from the same place the Lazarus
 ; installer gets it. Without it the chat would fall back to plain text in the
@@ -372,83 +394,83 @@ Source: "redist\MicrosoftEdgeWebView2RuntimeInstaller{#WV2Arch}.exe"; Flags: don
 ; the chosen versions are touched. (commondocs = C:\Users\Public\Documents.)
 
 #if HaveD10S
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\Aefos.OTA.Chat.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10S}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\Aefos.OTA.Terminal.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10S}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\dclAefosWebView.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10S}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\Aefos.OTA.Chat.bpl"; ValueData: "Aefos AI - Chat"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10S}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\Aefos.OTA.Terminal.bpl"; ValueData: "Aefos AI - Terminal"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10S}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\dclAefosWebView.bpl"; ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10S}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\Aefos.OTA.Chat{#SufD10S}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10S}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\Aefos.OTA.Terminal{#SufD10S}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10S}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\dclAefosWebView{#SufD10S}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10S}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\Aefos.OTA.Chat{#SufD10S}.bpl"; ValueData: "Aefos AI - Chat"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10S}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\Aefos.OTA.Terminal{#SufD10S}.bpl"; ValueData: "Aefos AI - Terminal"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10S}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10S}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10S}\Bpl\dclAefosWebView{#SufD10S}.bpl"; ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10S}')
 #endif
 
 #if HaveD10B
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\Aefos.OTA.Chat.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10B}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\Aefos.OTA.Terminal.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10B}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\dclAefosWebView.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10B}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\Aefos.OTA.Chat.bpl"; ValueData: "Aefos AI - Chat"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10B}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\Aefos.OTA.Terminal.bpl"; ValueData: "Aefos AI - Terminal"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10B}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\dclAefosWebView.bpl"; ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10B}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\Aefos.OTA.Chat{#SufD10B}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10B}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\Aefos.OTA.Terminal{#SufD10B}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10B}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\dclAefosWebView{#SufD10B}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10B}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\Aefos.OTA.Chat{#SufD10B}.bpl"; ValueData: "Aefos AI - Chat"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10B}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\Aefos.OTA.Terminal{#SufD10B}.bpl"; ValueData: "Aefos AI - Terminal"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10B}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10B}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10B}\Bpl\dclAefosWebView{#SufD10B}.bpl"; ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10B}')
 #endif
 
 #if HaveD10T
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10T}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl\Aefos.OTA.Chat.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10T}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10T}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl\Aefos.OTA.Terminal.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10T}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10T}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl\dclAefosWebView.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10T}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10T}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl\Aefos.OTA.Chat.bpl"; ValueData: "Aefos AI - Chat"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10T}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10T}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl\Aefos.OTA.Terminal.bpl"; ValueData: "Aefos AI - Terminal"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10T}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10T}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl\dclAefosWebView.bpl"; ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10T}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10T}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl\Aefos.OTA.Chat{#SufD10T}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10T}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10T}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl\Aefos.OTA.Terminal{#SufD10T}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10T}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10T}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl\dclAefosWebView{#SufD10T}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10T}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10T}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl\Aefos.OTA.Chat{#SufD10T}.bpl"; ValueData: "Aefos AI - Chat"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10T}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10T}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl\Aefos.OTA.Terminal{#SufD10T}.bpl"; ValueData: "Aefos AI - Terminal"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10T}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10T}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10T}\Bpl\dclAefosWebView{#SufD10T}.bpl"; ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10T}')
 #endif
 
 #if HaveD10R
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10R}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl\Aefos.OTA.Chat.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10R}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10R}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl\Aefos.OTA.Terminal.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10R}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10R}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl\dclAefosWebView.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10R}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10R}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl\Aefos.OTA.Chat.bpl"; ValueData: "Aefos AI - Chat"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10R}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10R}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl\Aefos.OTA.Terminal.bpl"; ValueData: "Aefos AI - Terminal"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10R}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10R}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl\dclAefosWebView.bpl"; ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10R}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10R}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl\Aefos.OTA.Chat{#SufD10R}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10R}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10R}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl\Aefos.OTA.Terminal{#SufD10R}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10R}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10R}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl\dclAefosWebView{#SufD10R}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10R}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10R}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl\Aefos.OTA.Chat{#SufD10R}.bpl"; ValueData: "Aefos AI - Chat"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10R}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10R}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl\Aefos.OTA.Terminal{#SufD10R}.bpl"; ValueData: "Aefos AI - Terminal"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10R}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10R}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10R}\Bpl\dclAefosWebView{#SufD10R}.bpl"; ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10R}')
 #endif
 
 #if HaveD10Y
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10Y}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl\Aefos.OTA.Chat.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10Y}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10Y}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl\Aefos.OTA.Terminal.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10Y}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10Y}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl\dclAefosWebView.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10Y}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10Y}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl\Aefos.OTA.Chat.bpl"; ValueData: "Aefos AI - Chat"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10Y}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10Y}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl\Aefos.OTA.Terminal.bpl"; ValueData: "Aefos AI - Terminal"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10Y}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10Y}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl\dclAefosWebView.bpl"; ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10Y}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10Y}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl\Aefos.OTA.Chat{#SufD10Y}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10Y}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10Y}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl\Aefos.OTA.Terminal{#SufD10Y}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10Y}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10Y}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl\dclAefosWebView{#SufD10Y}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD10Y}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10Y}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl\Aefos.OTA.Chat{#SufD10Y}.bpl"; ValueData: "Aefos AI - Chat"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10Y}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10Y}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl\Aefos.OTA.Terminal{#SufD10Y}.bpl"; ValueData: "Aefos AI - Terminal"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10Y}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD10Y}\Known Packages"; ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD10Y}\Bpl\dclAefosWebView{#SufD10Y}.bpl"; ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD10Y}')
 #endif
 
 #if HaveD11
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD11}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl\Aefos.OTA.Chat.bpl";     Flags: deletevalue; Check: WantVer('{#VerD11}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD11}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl\Aefos.OTA.Terminal.bpl"; Flags: deletevalue; Check: WantVer('{#VerD11}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD11}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl\dclAefosWebView.bpl";       Flags: deletevalue; Check: WantVer('{#VerD11}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD11}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl\Aefos.OTA.Chat.bpl";     ValueData: "Aefos AI - Chat";              Flags: uninsdeletevalue; Check: WantVer('{#VerD11}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD11}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl\Aefos.OTA.Terminal.bpl"; ValueData: "Aefos AI - Terminal";          Flags: uninsdeletevalue; Check: WantVer('{#VerD11}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD11}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl\dclAefosWebView.bpl";       ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD11}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD11}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl\Aefos.OTA.Chat{#SufD11}.bpl";     Flags: deletevalue; Check: WantVer('{#VerD11}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD11}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl\Aefos.OTA.Terminal{#SufD11}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD11}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD11}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl\dclAefosWebView{#SufD11}.bpl";       Flags: deletevalue; Check: WantVer('{#VerD11}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD11}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl\Aefos.OTA.Chat{#SufD11}.bpl";     ValueData: "Aefos AI - Chat";              Flags: uninsdeletevalue; Check: WantVer('{#VerD11}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD11}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl\Aefos.OTA.Terminal{#SufD11}.bpl"; ValueData: "Aefos AI - Terminal";          Flags: uninsdeletevalue; Check: WantVer('{#VerD11}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD11}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD11}\Bpl\dclAefosWebView{#SufD11}.bpl";       ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD11}')
 #endif
 
 #if HaveD12
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD12}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl\Aefos.OTA.Chat.bpl";     Flags: deletevalue; Check: WantVer('{#VerD12}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD12}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl\Aefos.OTA.Terminal.bpl"; Flags: deletevalue; Check: WantVer('{#VerD12}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD12}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl\dclAefosWebView.bpl";       Flags: deletevalue; Check: WantVer('{#VerD12}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD12}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl\Aefos.OTA.Chat.bpl";     ValueData: "Aefos AI - Chat";              Flags: uninsdeletevalue; Check: WantVer('{#VerD12}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD12}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl\Aefos.OTA.Terminal.bpl"; ValueData: "Aefos AI - Terminal";          Flags: uninsdeletevalue; Check: WantVer('{#VerD12}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD12}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl\dclAefosWebView.bpl";       ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD12}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD12}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl\Aefos.OTA.Chat{#SufD12}.bpl";     Flags: deletevalue; Check: WantVer('{#VerD12}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD12}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl\Aefos.OTA.Terminal{#SufD12}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD12}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD12}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl\dclAefosWebView{#SufD12}.bpl";       Flags: deletevalue; Check: WantVer('{#VerD12}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD12}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl\Aefos.OTA.Chat{#SufD12}.bpl";     ValueData: "Aefos AI - Chat";              Flags: uninsdeletevalue; Check: WantVer('{#VerD12}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD12}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl\Aefos.OTA.Terminal{#SufD12}.bpl"; ValueData: "Aefos AI - Terminal";          Flags: uninsdeletevalue; Check: WantVer('{#VerD12}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD12}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD12}\Bpl\dclAefosWebView{#SufD12}.bpl";       ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD12}')
 #endif
 
 #if HaveD13
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Aefos.OTA.Chat.bpl";     Flags: deletevalue; Check: WantVer('{#VerD13}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Aefos.OTA.Terminal.bpl"; Flags: deletevalue; Check: WantVer('{#VerD13}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\dclAefosWebView.bpl";       Flags: deletevalue; Check: WantVer('{#VerD13}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Aefos.OTA.Chat.bpl";     ValueData: "Aefos AI - Chat";              Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Aefos.OTA.Terminal.bpl"; ValueData: "Aefos AI - Terminal";          Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\dclAefosWebView.bpl";       ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Aefos.OTA.Chat{#SufD13}.bpl";     Flags: deletevalue; Check: WantVer('{#VerD13}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Aefos.OTA.Terminal{#SufD13}.bpl"; Flags: deletevalue; Check: WantVer('{#VerD13}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Disabled Packages"; ValueType: none; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\dclAefosWebView{#SufD13}.bpl";       Flags: deletevalue; Check: WantVer('{#VerD13}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Aefos.OTA.Chat{#SufD13}.bpl";     ValueData: "Aefos AI - Chat";              Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Aefos.OTA.Terminal{#SufD13}.bpl"; ValueData: "Aefos AI - Terminal";          Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\dclAefosWebView{#SufD13}.bpl";       ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
 
 ; The 64-bit IDE reads a DIFFERENT key. Registering under "Known Packages" alone
 ; installs nothing visible in the 64-bit IDE -- it reads "Known Packages x64",
 ; and the two lists never see each other.
 #if HaveD13x
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages x64";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64\Aefos.OTA.Chat.bpl";     ValueData: "Aefos AI - Chat";              Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages x64";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64\Aefos.OTA.Terminal.bpl"; ValueData: "Aefos AI - Terminal";          Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
-Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages x64";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64\dclAefosWebView.bpl";       ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages x64";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64\Aefos.OTA.Chat{#SufD13}.bpl";     ValueData: "Aefos AI - Chat";              Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages x64";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64\Aefos.OTA.Terminal{#SufD13}.bpl"; ValueData: "Aefos AI - Terminal";          Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
+Root: HKCU; Subkey: "Software\Embarcadero\BDS\{#VerD13}\Known Packages x64";    ValueType: string; ValueName: "{commondocs}\Embarcadero\Studio\{#VerD13}\Bpl\Win64\dclAefosWebView{#SufD13}.bpl";       ValueData: "Aefos AI - WebView2 component"; Flags: uninsdeletevalue; Check: WantVer('{#VerD13}')
 #endif
 #endif
 
@@ -968,13 +990,59 @@ end;
 // break the very IDE it skipped. A per-bitness answer (or a LIBSUFFIX, which
 // makes the whole collision impossible) is what D13 needs; until then it keeps
 // today's behaviour, which is no worse than before this procedure existed.
-procedure PinBplSearchPathForSelectedVersions;
+// An upgrade from a pre-suffix Aefos leaves the old BPLs sitting in the IDE's Bpl
+// folder AND still listed in Known Packages under their old names. That is not
+// clutter: the IDE would load the old design package beside the new one, and the
+// old runtime BPLs keep the very file names this release exists to stop using -
+// so a second RAD Studio on the machine could still be answered by them.
+//
+// Every name is spelled out rather than wildcarded. This deletes files from a
+// folder full of other people's packages, which is no place for a pattern match.
+procedure _RemoveLegacyUnsuffixedInstall(const Ver: string);
+var
+  Dir, KeyBase, F: string;
+  Names: array[0..9] of string;
+  I: Integer;
+begin
+  Dir := ExpandConstant('{commondocs}\Embarcadero\Studio\' + Ver + '\Bpl\');
+  KeyBase := 'Software\Embarcadero\BDS\' + Ver + '\';
+  Names[0] := 'Aefos.Harness';
+  Names[1] := 'Aefos.Providers';
+  Names[2] := 'Aefos.WebView';
+  Names[3] := 'Aefos.Tools';
+  Names[4] := 'Aefos.MCP.Core';
+  Names[5] := 'Aefos.MCP.Tools.OTA';
+  Names[6] := 'Aefos.Data';
+  Names[7] := 'Aefos.OTA.Chat';
+  Names[8] := 'Aefos.OTA.Terminal';
+  Names[9] := 'dclAefosWebView';
+  for I := 0 to 9 do
+  begin
+    F := Dir + Names[I] + '.bpl';
+    RegDeleteValue(HKCU, KeyBase + 'Known Packages', F);
+    RegDeleteValue(HKCU, KeyBase + 'Disabled Packages', F);
+    DeleteFile(F);
+    // Delphi 13's 64-bit IDE keeps its own folder AND its own registry key.
+    F := Dir + 'Win64\' + Names[I] + '.bpl';
+    RegDeleteValue(HKCU, KeyBase + 'Known Packages x64', F);
+    RegDeleteValue(HKCU, KeyBase + 'Disabled Packages x64', F);
+    DeleteFile(F);
+  end;
+end;
+
+procedure PrepareSelectedVersions;
 var
   I: Integer;
 begin
   for I := 0 to GetArrayLength(GVer) - 1 do
-    if WantVer(GVer[I]) and (GVer[I] <> '{#VerD13}') then
-      _PinBplSearchPath(GVer[I]);
+    if WantVer(GVer[I]) then
+    begin
+      _RemoveLegacyUnsuffixedInstall(GVer[I]);
+      // D13 stays out of the Path pin for the reason given above; the suffix now
+      // carries that version too, so it loses nothing by being skipped here.
+      if GVer[I] <> '{#VerD13}' then
+        _PinBplSearchPath(GVer[I]);
+    end;
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
@@ -989,7 +1057,7 @@ begin
   if CurStep <> ssPostInstall then
     exit;
 
-  PinBplSearchPathForSelectedVersions();
+  PrepareSelectedVersions();
   WriteMcpJson();
   _ExtractCopilotZip();
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -12,12 +12,20 @@ show up **already installed** in the IDE.
 
 | File | Where it goes | Kind |
 |------|---------------|------|
-| `Aefos.Tools.bpl` | `{app}\Bpl` | runtime |
-| `Aefos.MCP.Core.bpl` | `{app}\Bpl` | runtime |
-| `Aefos.MCP.Tools.OTA.bpl` | `{app}\Bpl` | runtime |
-| `Aefos.Data.bpl` | `{app}\Bpl` | runtime (static SQLite) |
-| `Aefos.OTA.Chat.bpl` | `{app}\Bpl` | **design-time** (registered) |
-| `Aefos.OTA.Terminal.bpl` | `{app}\Bpl` | **design-time** (registered) |
+Every BPL below carries the IDE's own package suffix — `Aefos.MCP.Core230.bpl`
+on 10 Seattle, `...290` on Delphi 12, `...370` on Delphi 13 — exactly as
+Embarcadero suffixes `rtl230`/`rtl290`/`rtl370`. That is what keeps two RAD
+Studios on one machine from answering for each other's packages, since the IDE
+finds a required BPL through `PATH` and every version's `Bpl` folder is on it.
+
+| File | Where it goes | Kind |
+|------|---------------|------|
+| `Aefos.Tools<sfx>.bpl` | `{app}\Bpl` | runtime |
+| `Aefos.MCP.Core<sfx>.bpl` | `{app}\Bpl` | runtime |
+| `Aefos.MCP.Tools.OTA<sfx>.bpl` | `{app}\Bpl` | runtime |
+| `Aefos.Data<sfx>.bpl` | `{app}\Bpl` | runtime (static SQLite) |
+| `Aefos.OTA.Chat<sfx>.bpl` | `{app}\Bpl` | **design-time** (registered) |
+| `Aefos.OTA.Terminal<sfx>.bpl` | `{app}\Bpl` | **design-time** (registered) |
 | `mcp-bridge.ps1` | `{app}` | Terminal MCP relay (one fixed copy) |
 | `pytools\*` (5 default tools) | `{userappdata}\Aefos\pytools` | drop-a-folder Python MCP tools |
 

--- a/installer/build-installer.ps1
+++ b/installer/build-installer.ps1
@@ -34,12 +34,37 @@ $iss   = Join-Path $here 'Aefos.iss'
 
 . (Join-Path (Split-Path -Parent $here) 'scripts\aefos-ide-versions.ps1')
 $Supported = $script:AefosIdeSupported
-$Bpls = @(
-  'Aefos.Harness.bpl', 'Aefos.Providers.bpl',
-  'Aefos.WebView.bpl', 'Aefos.Tools.bpl', 'Aefos.MCP.Core.bpl',
-  'Aefos.MCP.Tools.OTA.bpl', 'Aefos.Data.bpl', 'Aefos.OTA.Chat.bpl',
-  'Aefos.OTA.Terminal.bpl', 'dclAefosWebView.bpl'
+# Base names. Each staged file carries the IDE's package suffix
+# (Aefos.MCP.Core230.bpl for Seattle, ...290 for Athens) so that two RAD Studios
+# on one machine can no longer answer for each other's packages.
+$BplNames = @(
+  'Aefos.Harness', 'Aefos.Providers',
+  'Aefos.WebView', 'Aefos.Tools', 'Aefos.MCP.Core',
+  'Aefos.MCP.Tools.OTA', 'Aefos.Data', 'Aefos.OTA.Chat',
+  'Aefos.OTA.Terminal', 'dclAefosWebView'
 )
+
+function Get-StagedSuffix {
+  <#
+    .SYNOPSIS
+      The package suffix of an already-staged payload folder, read from the files.
+
+    .DESCRIPTION
+      Deliberately NOT Get-AefosIdePackageSuffix: that one asks the IDE, and the
+      IDE whose payload this is may not exist on this machine at all - old-version
+      payloads are built in a VM and the folder copied over. What is on disk is
+      the only thing true here.
+
+      Returns an empty string for a payload built before the suffix existed, which
+      the caller must refuse rather than ship.
+  #>
+  param([Parameter(Mandatory = $true)][string] $Dir)
+  $f = Get-ChildItem $Dir -Filter 'Aefos.OTA.Chat*.bpl' -ErrorAction SilentlyContinue |
+       Select-Object -First 1
+  if (-not $f) { return $null }
+  if ($f.Name -match '^Aefos\.OTA\.Chat(\d*)\.bpl$') { return $Matches[1] }
+  return $null
+}
 
 # WebView2Loader.dll is a Microsoft component (version-independent, x86). We ship
 # it beside our BPLs and point the RTL at it by full path (SetWebView2Path). Source
@@ -60,9 +85,11 @@ if (-not (Test-Path $stage)) {
   throw "No staged BPLs at $stage. Run scripts\build-packages.ps1 first."
 }
 
-# Discover which versions are staged (folder holds the design package).
+# Discover which versions are staged (folder holds the design package, under
+# whatever suffix that IDE gives it).
 $staged = $Supported | Where-Object {
-  Test-Path (Join-Path (Join-Path $stage $_) 'Aefos.OTA.Chat.bpl')
+  $d = Join-Path $stage $_
+  (Test-Path $d) -and (Get-ChildItem $d -Filter 'Aefos.OTA.Chat*.bpl' -ErrorAction SilentlyContinue)
 }
 if (-not $staged) {
   throw "No version is staged under $stage. Run scripts\build-packages.ps1 (and, for " +
@@ -91,28 +118,53 @@ if ($orphans.Count -gt 0) {
   if (-not $staged) { throw "Nothing left to package: every staged version is unknown to Aefos.iss." }
 }
 
+# Aefos.iss names every payload file literally, suffix included, through a
+# per-version #define. That is a second copy of a number the compiler already
+# decided - so rather than trust the two to stay in step, read both and refuse to
+# build when they disagree. A wrong suffix here does not fail loudly on its own:
+# the [Files] entry would simply point at a name nothing produced.
+$issSuffixes = @{}
+foreach ($m in [regex]::Matches($issText, '(?m)^#define\s+Ver(\w+)\s+"([\d.]+)"')) {
+  $key = $m.Groups[1].Value
+  $s = [regex]::Match($issText, "(?m)^#define\s+Suf$key\s+`"(\d+)`"")
+  if ($s.Success) { $issSuffixes[$m.Groups[2].Value] = $s.Groups[1].Value }
+}
+
 $wv2 = Get-WebView2Loader
 Write-Host "WebView2Loader.dll: $wv2" -ForegroundColor DarkGray
 
 foreach ($v in $staged) {
   $dir = Join-Path $stage $v
-  $missing = $Bpls | Where-Object { -not (Test-Path (Join-Path $dir $_)) }
+  $suffix = Get-StagedSuffix $dir
+  if ([string]::IsNullOrEmpty($suffix)) {
+    throw ("Delphi ${v}: the staged BPLs have no version suffix, so this payload predates " +
+           "Aefos.LibSuffix.inc. Re-run scripts\build-packages.ps1 -Version $v on the machine " +
+           "that has that IDE; shipping unsuffixed BPLs puts the cross-version collision back.")
+  }
+  if ($issSuffixes.ContainsKey($v) -and $issSuffixes[$v] -ne $suffix) {
+    throw ("Delphi ${v}: staged BPLs carry suffix $suffix but Aefos.iss declares " +
+           "$($issSuffixes[$v]). One of the two is wrong - the installer would package file " +
+           "names that do not exist.")
+  }
+  $missing = $BplNames | Where-Object { -not (Test-Path (Join-Path $dir "$_$suffix.bpl")) }
   if ($missing) {
-    throw "Delphi ${v}: staged folder is missing $($missing.Count) BPL(s): $($missing -join ', '). " +
+    throw "Delphi ${v}: staged folder is missing $($missing.Count) BPL(s): $(($missing | ForEach-Object { "$_$suffix.bpl" }) -join ', '). " +
           "Re-run scripts\build-packages.ps1 -Version $v on the machine that has it."
   }
   Copy-Item $wv2 $dir -Force   # ensure the loader is present (VM build may lack it)
-  Write-Host "  ok  Delphi $v  ($($Bpls.Count) BPLs + WebView2Loader.dll)" -ForegroundColor Green
+  Write-Host "  ok  Delphi $v  ($($BplNames.Count) BPLs, suffix $suffix + WebView2Loader.dll)" -ForegroundColor Green
 
   # Delphi 13's 64-bit IDE, when its packages were built (-Platform Win64). It is
   # a separate set: a design-time BPL loads into the IDE PROCESS, so the Win32 ones
   # above are invisible to bin64\bds.exe.
   $x64Dir = Join-Path $dir 'Win64'
-  if (Test-Path (Join-Path $x64Dir 'Aefos.OTA.Chat.bpl')) {
-    $missing64 = $Bpls | Where-Object { -not (Test-Path (Join-Path $x64Dir $_)) }
+  if ((Test-Path $x64Dir) -and (Get-ChildItem $x64Dir -Filter 'Aefos.OTA.Chat*.bpl' -ErrorAction SilentlyContinue)) {
+    # Same suffix as Win32 on purpose: Embarcadero ships rtl290.bpl in both bin and
+    # bin64, telling the two bitnesses apart by FOLDER rather than by name.
+    $missing64 = $BplNames | Where-Object { -not (Test-Path (Join-Path $x64Dir "$_$suffix.bpl")) }
     if ($missing64) {
       throw "Delphi $v/Win64: staged folder is missing $($missing64.Count) BPL(s): " +
-            "$($missing64 -join ', '). Re-run build-packages.ps1 -Version $v -Platform Win64."
+            "$(($missing64 | ForEach-Object { "$_$suffix.bpl" }) -join ', '). Re-run build-packages.ps1 -Version $v -Platform Win64."
     }
     # A 64-bit IDE process cannot bind the 32-bit loader RAD Studio ships, and RAD
     # Studio has no x64 one (verified: nothing under any bin64). It comes from the
@@ -125,7 +177,7 @@ foreach ($v in $staged) {
     }
     if (Test-Path $loader64) {
       Copy-Item $loader64 $x64Dir -Force
-      Write-Host "  ok  Delphi $v/Win64  ($($Bpls.Count) BPLs + x64 WebView2Loader.dll)" -ForegroundColor Green
+      Write-Host "  ok  Delphi $v/Win64  ($($BplNames.Count) BPLs, suffix $suffix + x64 WebView2Loader.dll)" -ForegroundColor Green
     } else {
       throw "Delphi $v/Win64: no x64 WebView2Loader.dll. See " +
             "installer\lazarus\redist\x86_64\README.md."

--- a/packages/Delphi/Aefos.Data.dpk
+++ b/packages/Delphi/Aefos.Data.dpk
@@ -41,6 +41,7 @@
 {$RUNONLY}
 {$DESCRIPTION 'Aefos Data - shared SQLite/FireDAC persistence (static SQLite, WAL)'}
 {$IMPLICITBUILD ON}
+{$I Aefos.LibSuffix.inc}   // one BPL name per IDE version - see the file
 
 requires
   rtl,

--- a/packages/Delphi/Aefos.Data.dproj
+++ b/packages/Delphi/Aefos.Data.dproj
@@ -214,12 +214,20 @@
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
-            <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
-            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>
+            <!-- Per version, because the same file name now exists once per IDE and a
+                 flat folder would mix Seattle and Athens builds under one roof. -->
+            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl\$(PRODUCTVERSION)</AefosStage>
         </PropertyGroup>
+        <ItemGroup>
+            <!-- The BPL carries a per-version LIBSUFFIX (see Aefos.LibSuffix.inc), so its
+                 name cannot be written here without copying that table into a fourth
+                 place. The wildcard asks the disk, which is the one source that cannot
+                 drift out of step with what the compiler actually produced. -->
+            <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+        </ItemGroup>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
-        <Copy SourceFiles="$(AefosBpl)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false" Condition="Exists('$(AefosBpl)')"/>
-        <Message Importance="high" Condition="Exists('$(AefosBpl)')" Text="[Aefos] staged $(MSBuildProjectName).bpl -&gt; installer\bpl"/>
+        <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
+        <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>
     </Target>
     <Import Project="$(MSBuildProjectName).deployproj" Condition="Exists('$(MSBuildProjectName).deployproj')"/>
 </Project>

--- a/packages/Delphi/Aefos.Harness.dpk
+++ b/packages/Delphi/Aefos.Harness.dpk
@@ -30,6 +30,7 @@ package Aefos.Harness;
 {$DESCRIPTION 'Aefos Harness - IDE Design/Code view duality + backstage helpers'}
 {$RUNONLY}
 {$IMPLICITBUILD ON}
+{$I Aefos.LibSuffix.inc}   // one BPL name per IDE version - see the file
 
 requires
   rtl,

--- a/packages/Delphi/Aefos.Harness.dproj
+++ b/packages/Delphi/Aefos.Harness.dproj
@@ -178,12 +178,20 @@
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
-            <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
-            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>
+            <!-- Per version, because the same file name now exists once per IDE and a
+                 flat folder would mix Seattle and Athens builds under one roof. -->
+            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl\$(PRODUCTVERSION)</AefosStage>
         </PropertyGroup>
+        <ItemGroup>
+            <!-- The BPL carries a per-version LIBSUFFIX (see Aefos.LibSuffix.inc), so its
+                 name cannot be written here without copying that table into a fourth
+                 place. The wildcard asks the disk, which is the one source that cannot
+                 drift out of step with what the compiler actually produced. -->
+            <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+        </ItemGroup>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
-        <Copy SourceFiles="$(AefosBpl)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false" Condition="Exists('$(AefosBpl)')"/>
-        <Message Importance="high" Condition="Exists('$(AefosBpl)')" Text="[Aefos] staged $(MSBuildProjectName).bpl -&gt; installer\bpl"/>
+        <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
+        <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>
     </Target>
     <Import Project="$(MSBuildProjectName).deployproj" Condition="Exists('$(MSBuildProjectName).deployproj')"/>
 </Project>

--- a/packages/Delphi/Aefos.LibSuffix.inc
+++ b/packages/Delphi/Aefos.LibSuffix.inc
@@ -1,0 +1,70 @@
+(*
+  One BPL file name per RAD Studio version.
+
+  WHY THIS EXISTS. A design package names the runtime packages it needs, and the
+  IDE resolves each one through the process PATH - where every installed RAD
+  Studio has already put its own Bpl folder. Without a suffix our packages carry
+  the SAME file name in every version, so on a machine with more than one IDE the
+  first Bpl folder on PATH answers for all of them. Measured on a VM holding 17.0
+  through 22.0: the Seattle IDE loaded the SYDNEY Aefos.MCP.Core.bpl, which has
+  no Aefos.Compat.JsonFormat helper (compiled only below CompilerVersion 33), and
+  the install died with "entry point ...TAefosJsonFormatHelper@Format not found".
+  The WebView package failed differently - a Sydney BPL dragging the Sydney RTL
+  into a Seattle process, access violation - from the same single cause.
+
+  Embarcadero solved this for their own packages long ago: rtl230.bpl, rtl270.bpl,
+  rtl290.bpl. We follow their suffix exactly, so an Aefos BPL sits next to the RTL
+  it was built against and reads as belonging to it.
+
+  THE NUMBERS ARE MEASURED, NOT REMEMBERED. Each one was read off the IDE's own
+  bin folder (rtl<suffix>.bpl / designide<suffix>.bpl) on 2026-08-07:
+
+    CompilerVersion  BDS    Product          Suffix
+    30               17.0   10 Seattle       230
+    31               18.0   10.1 Berlin      240
+    32               19.0   10.2 Tokyo       250
+    33               20.0   10.3 Rio         260
+    34               21.0   10.4 Sydney      270
+    35               22.0   Delphi 11        280
+    36               23.0   Delphi 12        290
+    37               37.0   Delphi 13        370
+
+  Note the jump at the end: 35 -> 280 and 36 -> 290 are ten apart, 36 -> 37 is
+  eighty. There is no formula to derive, which is exactly why the table is read
+  from disk rather than computed - the one time this file could be "obviously"
+  generalised is the time it would be wrong.
+
+  Win32 and Win64 share a suffix; Embarcadero ships rtl290.bpl in both bin and
+  bin64. The two bitnesses are told apart by their FOLDER (Bpl and Bpl\Win64), not
+  by their name, and inventing a difference here would break that convention for
+  no gain.
+
+  AUTO covers whatever ships next: it asks the compiler for its own suffix, so a
+  future RAD Studio needs no edit here. It is only reached above 37 because every
+  version at or below that has a measured number, and a measured number beats a
+  mechanism we have not watched run.
+
+  IF THIS FILE STOPS BEING INCLUDED - the IDE rewrites a .dpk when you add or
+  remove files through the Project Manager, and a directive it does not recognise
+  can be dropped - the BPL silently goes back to its unsuffixed name and the
+  collision returns. That is why build-packages.ps1 asserts the SUFFIXED file
+  exists after every build: the failure has to be loud.
+*)
+
+{$IFNDEF FPC}
+
+{$IF CompilerVersion < 30}
+  {$MESSAGE FATAL 'Aefos needs Delphi 10 Seattle (CompilerVersion 30) or newer.'}
+{$IFEND}
+
+{$IF CompilerVersion = 30}{$LIBSUFFIX '230'}{$IFEND}
+{$IF CompilerVersion = 31}{$LIBSUFFIX '240'}{$IFEND}
+{$IF CompilerVersion = 32}{$LIBSUFFIX '250'}{$IFEND}
+{$IF CompilerVersion = 33}{$LIBSUFFIX '260'}{$IFEND}
+{$IF CompilerVersion = 34}{$LIBSUFFIX '270'}{$IFEND}
+{$IF CompilerVersion = 35}{$LIBSUFFIX '280'}{$IFEND}
+{$IF CompilerVersion = 36}{$LIBSUFFIX '290'}{$IFEND}
+{$IF CompilerVersion = 37}{$LIBSUFFIX '370'}{$IFEND}
+{$IF CompilerVersion > 37}{$LIBSUFFIX AUTO}{$IFEND}
+
+{$ENDIF}

--- a/packages/Delphi/Aefos.MCP.Core.dpk
+++ b/packages/Delphi/Aefos.MCP.Core.dpk
@@ -47,6 +47,7 @@
 {$RUNONLY}
 {$DESCRIPTION 'Aefos MCP Core - RTL-only MCP engine (no ToolsAPI)'}
 {$IMPLICITBUILD ON}
+{$I Aefos.LibSuffix.inc}   // one BPL name per IDE version - see the file
 
 requires
   rtl,

--- a/packages/Delphi/Aefos.MCP.Core.dproj
+++ b/packages/Delphi/Aefos.MCP.Core.dproj
@@ -238,12 +238,20 @@
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
-            <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
-            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>
+            <!-- Per version, because the same file name now exists once per IDE and a
+                 flat folder would mix Seattle and Athens builds under one roof. -->
+            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl\$(PRODUCTVERSION)</AefosStage>
         </PropertyGroup>
+        <ItemGroup>
+            <!-- The BPL carries a per-version LIBSUFFIX (see Aefos.LibSuffix.inc), so its
+                 name cannot be written here without copying that table into a fourth
+                 place. The wildcard asks the disk, which is the one source that cannot
+                 drift out of step with what the compiler actually produced. -->
+            <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+        </ItemGroup>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
-        <Copy SourceFiles="$(AefosBpl)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false" Condition="Exists('$(AefosBpl)')"/>
-        <Message Importance="high" Condition="Exists('$(AefosBpl)')" Text="[Aefos] staged $(MSBuildProjectName).bpl -&gt; installer\bpl"/>
+        <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
+        <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>
     </Target>
     <Import Project="$(MSBuildProjectName).deployproj" Condition="Exists('$(MSBuildProjectName).deployproj')"/>
 </Project>

--- a/packages/Delphi/Aefos.MCP.Tools.OTA.dpk
+++ b/packages/Delphi/Aefos.MCP.Tools.OTA.dpk
@@ -27,6 +27,7 @@ package Aefos.MCP.Tools.OTA;
 {$DESCRIPTION 'Aefos shared OTA MCP facade (Tools.OTA)'}
 {$RUNONLY}
 {$IMPLICITBUILD ON}
+{$I Aefos.LibSuffix.inc}   // one BPL name per IDE version - see the file
 
 requires
   rtl,

--- a/packages/Delphi/Aefos.MCP.Tools.OTA.dproj
+++ b/packages/Delphi/Aefos.MCP.Tools.OTA.dproj
@@ -220,11 +220,19 @@
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
-            <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
-            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>
+            <!-- Per version, because the same file name now exists once per IDE and a
+                 flat folder would mix Seattle and Athens builds under one roof. -->
+            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl\$(PRODUCTVERSION)</AefosStage>
         </PropertyGroup>
+        <ItemGroup>
+            <!-- The BPL carries a per-version LIBSUFFIX (see Aefos.LibSuffix.inc), so its
+                 name cannot be written here without copying that table into a fourth
+                 place. The wildcard asks the disk, which is the one source that cannot
+                 drift out of step with what the compiler actually produced. -->
+            <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+        </ItemGroup>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
-        <Copy SourceFiles="$(AefosBpl)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false" Condition="Exists('$(AefosBpl)')"/>
-        <Message Importance="high" Condition="Exists('$(AefosBpl)')" Text="[Aefos] staged $(MSBuildProjectName).bpl -&gt; installer\bpl"/>
+        <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
+        <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>
     </Target>
 </Project>

--- a/packages/Delphi/Aefos.OTA.Chat.dpk
+++ b/packages/Delphi/Aefos.OTA.Chat.dpk
@@ -27,6 +27,7 @@ package Aefos.OTA.Chat;
 {$ENDIF IMPLICITBUILDING}
 {$DESCRIPTION 'Aefos AI - Chat (in-IDE AI chat/agent panel + in-process MCP server)'}
 {$IMPLICITBUILD ON}
+{$I Aefos.LibSuffix.inc}   // one BPL name per IDE version - see the file
 
 requires
   vcl,

--- a/packages/Delphi/Aefos.OTA.Chat.dproj
+++ b/packages/Delphi/Aefos.OTA.Chat.dproj
@@ -1162,12 +1162,20 @@
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
-            <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
-            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>
+            <!-- Per version, because the same file name now exists once per IDE and a
+                 flat folder would mix Seattle and Athens builds under one roof. -->
+            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl\$(PRODUCTVERSION)</AefosStage>
         </PropertyGroup>
+        <ItemGroup>
+            <!-- The BPL carries a per-version LIBSUFFIX (see Aefos.LibSuffix.inc), so its
+                 name cannot be written here without copying that table into a fourth
+                 place. The wildcard asks the disk, which is the one source that cannot
+                 drift out of step with what the compiler actually produced. -->
+            <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+        </ItemGroup>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
-        <Copy SourceFiles="$(AefosBpl)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false" Condition="Exists('$(AefosBpl)')"/>
-        <Message Importance="high" Condition="Exists('$(AefosBpl)')" Text="[Aefos] staged $(MSBuildProjectName).bpl -&gt; installer\bpl"/>
+        <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
+        <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>
     </Target>
     <Import Project="$(MSBuildProjectName).deployproj" Condition="Exists('$(MSBuildProjectName).deployproj')"/>
 </Project>

--- a/packages/Delphi/Aefos.OTA.Terminal.dpk
+++ b/packages/Delphi/Aefos.OTA.Terminal.dpk
@@ -27,6 +27,7 @@ package Aefos.OTA.Terminal;
 {$ENDIF IMPLICITBUILDING}
 {$DESCRIPTION 'Aefos AI - Terminal (integrated IDE terminal + in-process MCP server)'}
 {$IMPLICITBUILD ON}
+{$I Aefos.LibSuffix.inc}   // one BPL name per IDE version - see the file
 
 requires
   rtl,

--- a/packages/Delphi/Aefos.OTA.Terminal.dproj
+++ b/packages/Delphi/Aefos.OTA.Terminal.dproj
@@ -1085,12 +1085,20 @@
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
-            <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
-            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>
+            <!-- Per version, because the same file name now exists once per IDE and a
+                 flat folder would mix Seattle and Athens builds under one roof. -->
+            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl\$(PRODUCTVERSION)</AefosStage>
         </PropertyGroup>
+        <ItemGroup>
+            <!-- The BPL carries a per-version LIBSUFFIX (see Aefos.LibSuffix.inc), so its
+                 name cannot be written here without copying that table into a fourth
+                 place. The wildcard asks the disk, which is the one source that cannot
+                 drift out of step with what the compiler actually produced. -->
+            <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+        </ItemGroup>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
-        <Copy SourceFiles="$(AefosBpl)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false" Condition="Exists('$(AefosBpl)')"/>
-        <Message Importance="high" Condition="Exists('$(AefosBpl)')" Text="[Aefos] staged $(MSBuildProjectName).bpl -&gt; installer\bpl"/>
+        <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
+        <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>
     </Target>
     <Import Project="$(MSBuildProjectName).deployproj" Condition="Exists('$(MSBuildProjectName).deployproj')"/>
 </Project>

--- a/packages/Delphi/Aefos.Providers.dpk
+++ b/packages/Delphi/Aefos.Providers.dpk
@@ -30,6 +30,7 @@ package Aefos.Providers;
 {$DESCRIPTION 'Aefos Providers - AI executor profiles (Claude/Codex/Copilot/Gemini) + local Ollama transport'}
 {$RUNONLY}
 {$IMPLICITBUILD ON}
+{$I Aefos.LibSuffix.inc}   // one BPL name per IDE version - see the file
 
 requires
   rtl;

--- a/packages/Delphi/Aefos.Providers.dproj
+++ b/packages/Delphi/Aefos.Providers.dproj
@@ -203,12 +203,20 @@
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
-            <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
-            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>
+            <!-- Per version, because the same file name now exists once per IDE and a
+                 flat folder would mix Seattle and Athens builds under one roof. -->
+            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl\$(PRODUCTVERSION)</AefosStage>
         </PropertyGroup>
+        <ItemGroup>
+            <!-- The BPL carries a per-version LIBSUFFIX (see Aefos.LibSuffix.inc), so its
+                 name cannot be written here without copying that table into a fourth
+                 place. The wildcard asks the disk, which is the one source that cannot
+                 drift out of step with what the compiler actually produced. -->
+            <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+        </ItemGroup>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
-        <Copy SourceFiles="$(AefosBpl)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false" Condition="Exists('$(AefosBpl)')"/>
-        <Message Importance="high" Condition="Exists('$(AefosBpl)')" Text="[Aefos] staged $(MSBuildProjectName).bpl -&gt; installer\bpl"/>
+        <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
+        <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>
     </Target>
     <Import Project="$(MSBuildProjectName).deployproj" Condition="Exists('$(MSBuildProjectName).deployproj')"/>
 </Project>

--- a/packages/Delphi/Aefos.Tools.dpk
+++ b/packages/Delphi/Aefos.Tools.dpk
@@ -28,6 +28,7 @@
 {$DESCRIPTION 'Aefos Tools - pure Delphi file-editing engine (no IDE coupling)'}
 {$RUNONLY}
 {$IMPLICITBUILD ON}
+{$I Aefos.LibSuffix.inc}   // one BPL name per IDE version - see the file
 
 requires
   rtl;

--- a/packages/Delphi/Aefos.Tools.dproj
+++ b/packages/Delphi/Aefos.Tools.dproj
@@ -200,12 +200,20 @@
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
     <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
         <PropertyGroup>
-            <AefosBpl>$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl</AefosBpl>
-            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl</AefosStage>
+            <!-- Per version, because the same file name now exists once per IDE and a
+                 flat folder would mix Seattle and Athens builds under one roof. -->
+            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl\$(PRODUCTVERSION)</AefosStage>
         </PropertyGroup>
+        <ItemGroup>
+            <!-- The BPL carries a per-version LIBSUFFIX (see Aefos.LibSuffix.inc), so its
+                 name cannot be written here without copying that table into a fourth
+                 place. The wildcard asks the disk, which is the one source that cannot
+                 drift out of step with what the compiler actually produced. -->
+            <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+        </ItemGroup>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
-        <Copy SourceFiles="$(AefosBpl)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false" Condition="Exists('$(AefosBpl)')"/>
-        <Message Importance="high" Condition="Exists('$(AefosBpl)')" Text="[Aefos] staged $(MSBuildProjectName).bpl -&gt; installer\bpl"/>
+        <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
+        <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>
     </Target>
     <Import Project="$(MSBuildProjectName).deployproj" Condition="Exists('$(MSBuildProjectName).deployproj')"/>
 </Project>

--- a/packages/Delphi/Aefos.WebView.dpk
+++ b/packages/Delphi/Aefos.WebView.dpk
@@ -28,6 +28,7 @@ package Aefos.WebView;
 {$DESCRIPTION 'Aefos AI - composition-hosted WebView2 (activation-independent rendering)'}
 {$RUNONLY}
 {$IMPLICITBUILD ON}
+{$I Aefos.LibSuffix.inc}   // one BPL name per IDE version - see the file
 
 requires
   rtl,

--- a/packages/Delphi/dclAefosWebView.dpk
+++ b/packages/Delphi/dclAefosWebView.dpk
@@ -28,6 +28,7 @@ package dclAefosWebView;
 {$DESCRIPTION 'Aefos AI - WebView2 component (design-time)'}
 {$DESIGNONLY}
 {$IMPLICITBUILD ON}
+{$I Aefos.LibSuffix.inc}   // one BPL name per IDE version - see the file
 
 requires
   rtl,

--- a/scripts/aefos-ide-versions.ps1
+++ b/scripts/aefos-ide-versions.ps1
@@ -64,6 +64,39 @@ function Get-AefosRsVarsPath {
   Join-Path ${env:ProgramFiles(x86)} "Embarcadero\Studio\$Bds\bin\rsvars.bat"
 }
 
+function Get-AefosIdePackageSuffix {
+  <#
+    .SYNOPSIS
+      The suffix a given RAD Studio puts on its package file names: 230, 290, 370.
+
+    .DESCRIPTION
+      Our BPLs carry this suffix too, so an Aefos package built for Seattle is
+      Aefos.MCP.Core230.bpl and cannot be mistaken for the Athens one. Without it
+      every version shipped the same file name, and on a machine with more than
+      one IDE the first Bpl folder on PATH answered for all of them - which is how
+      a Seattle IDE came to load a Sydney BPL.
+
+      MEASURED, not tabulated. rtl<suffix>.bpl sits in every version's bin folder,
+      so the number is read off the target IDE rather than remembered here.
+      Aefos.LibSuffix.inc does keep the same numbers on the Pascal side, because
+      {$LIBSUFFIX} needs a literal - but reading from disk here means a
+      disagreement between the two surfaces as a missing file while staging,
+      loudly, instead of as a wrongly-named BPL that ships.
+
+      There is no formula to derive: 22.0 -> 280 and 23.0 -> 290 are ten apart,
+      23.0 -> 37.0 is eighty.
+  #>
+  param([Parameter(Mandatory = $true)][string] $Bds)
+  $bin = Join-Path ${env:ProgramFiles(x86)} "Embarcadero\Studio\$Bds\bin"
+  $rtl = Get-ChildItem $bin -Filter 'rtl*.bpl' -ErrorAction SilentlyContinue |
+         Where-Object { $_.Name -match '^rtl(\d+)\.bpl$' } |
+         Select-Object -First 1
+  if (-not $rtl) {
+    throw "Cannot read the package suffix for BDS $Bds : no rtl<suffix>.bpl in $bin."
+  }
+  return [regex]::Match($rtl.Name, '^rtl(\d+)\.bpl$').Groups[1].Value
+}
+
 function Get-AefosFrameworkVersion {
   <#
     .SYNOPSIS

--- a/scripts/build-packages.ps1
+++ b/scripts/build-packages.ps1
@@ -70,11 +70,15 @@ if ($drift.Count -gt 0) {
   throw ("-Version's ValidateSet and aefos-ide-versions.ps1 disagree: {0}. Update the ValidateSet literal." -f
          (($drift | ForEach-Object { "$($_.InputObject) ($($_.SideIndicator))" }) -join ', '))
 }
-$Bpls = @(
-  'Aefos.Harness.bpl', 'Aefos.Providers.bpl',
-  'Aefos.WebView.bpl', 'Aefos.Tools.bpl', 'Aefos.MCP.Core.bpl',
-  'Aefos.MCP.Tools.OTA.bpl', 'Aefos.Data.bpl', 'Aefos.OTA.Chat.bpl',
-  'Aefos.OTA.Terminal.bpl', 'dclAefosWebView.bpl'
+# Base names only. The file on disk carries the IDE's package suffix
+# (Aefos.LibSuffix.inc gives it to the compiler; Get-AefosIdePackageSuffix reads
+# the same number back off the target IDE), so Seattle produces
+# Aefos.MCP.Core230.bpl and Athens Aefos.MCP.Core290.bpl.
+$BplNames = @(
+  'Aefos.Harness', 'Aefos.Providers',
+  'Aefos.WebView', 'Aefos.Tools', 'Aefos.MCP.Core',
+  'Aefos.MCP.Tools.OTA', 'Aefos.Data', 'Aefos.OTA.Chat',
+  'Aefos.OTA.Terminal', 'dclAefosWebView'
 )
 
 function Get-PublicBplDir([string]$Ver, [string]$Plat) {
@@ -264,13 +268,34 @@ foreach ($v in $targets) {
     $dst = Join-Path $stage $v
     if ($plat -ne 'Win32') { $dst = Join-Path $dst $plat }
     New-Item -ItemType Directory -Force $dst | Out-Null
+
+    # This is where a lost LIBSUFFIX has to become audible. If the include ever
+    # stops reaching the compiler - the IDE rewrites a .dpk when files are added
+    # or removed through the Project Manager, and can drop a directive it does not
+    # recognise - the BPL quietly goes back to its unsuffixed name and the whole
+    # collision returns. Asking for the SUFFIXED name means that failure stops the
+    # build here instead of shipping.
+    $suffix = Get-AefosIdePackageSuffix $v
     $missing = @()
-    foreach ($b in $Bpls) {
-      $f = Join-Path $src $b
-      if (Test-Path $f) { Copy-Item $f $dst -Force } else { $missing += $b }
+    foreach ($b in $BplNames) {
+      $f = Join-Path $src "$b$suffix.bpl"
+      if (Test-Path $f) { Copy-Item $f $dst -Force } else { $missing += "$b$suffix.bpl" }
     }
     if ($missing.Count -gt 0) {
-      throw "Delphi $v/${plat}: built but $($missing.Count) BPL(s) not found in $src : $($missing -join ', ')."
+      throw ("Delphi $v/${plat}: built but $($missing.Count) BPL(s) not found in $src : " +
+             "$($missing -join ', '). If the unsuffixed names are there instead, a .dpk " +
+             "lost its {`$I Aefos.LibSuffix.inc} line.")
+    }
+
+    # An unsuffixed BPL left over from a build before this change is not inert:
+    # it sits in the folder the IDE searches, under the very name that used to
+    # collide across versions. Sweeping it is the point of the rename.
+    foreach ($b in $BplNames) {
+      $legacy = Join-Path $src "$b.bpl"
+      if (Test-Path $legacy) {
+        Remove-Item $legacy -Force
+        Write-Host "  -   removed pre-suffix $b.bpl from $src" -ForegroundColor DarkYellow
+      }
     }
 
     # Whoever measured also provisions. A build without static SQLite produces a
@@ -291,7 +316,7 @@ foreach ($v in $targets) {
       Write-Host "  +   sqlite3.dll staged (this IDE has no static SQLite)" -ForegroundColor DarkYellow
     }
 
-    Write-Host "  OK  Delphi $v/$plat  ($($Bpls.Count) BPLs)" -ForegroundColor Green
+    Write-Host "  OK  Delphi $v/$plat  ($($BplNames.Count) BPLs, suffix $suffix)" -ForegroundColor Green
     $built += "$v/$plat"
   }
 }

--- a/source/chat/Aefos.OTA.Chat.Register.pas
+++ b/source/chat/Aefos.OTA.Chat.Register.pas
@@ -3940,28 +3940,45 @@ end;
 // the IDE still references after the BPL unmaps.
 procedure _LogAefosModuleBases;
 const
+  // Base names. The file on disk carries the IDE's package suffix
+  // (Aefos.LibSuffix.inc), so the real module is Aefos.Data230.bpl on Seattle and
+  // Aefos.Data290.bpl on Athens.
   CModules: array[0..5] of string = (
-    'Aefos.OTA.Chat.bpl', 'Aefos.Data.bpl', 'Aefos.Tools.bpl',
-    'Aefos.MCP.Core.bpl', 'Aefos.MCP.Tools.OTA.bpl', 'Aefos.OTA.Terminal.bpl');
+    'Aefos.OTA.Chat', 'Aefos.Data', 'Aefos.Tools',
+    'Aefos.MCP.Core', 'Aefos.MCP.Tools.OTA', 'Aefos.OTA.Terminal');
 var
-  LIdx:  Integer;
-  LBase: HMODULE;
-  LNt:   PImageNtHeaders;
-  LSize: Cardinal;
+  LIdx:   Integer;
+  LBase:  HMODULE;
+  LNt:    PImageNtHeaders;
+  LSize:  Cardinal;
+  LSuffix: string;
+  LName:  string;
 begin
-  _TeardownLog('=== LOAD (module bases) ===');
+  // The suffix is READ OFF THIS VERY MODULE rather than kept in a table here. A
+  // fifth copy of that table is a fifth chance to update four of them: if this
+  // one drifted, GetModuleHandle would return 0 for everything and the log would
+  // report "not loaded" six times - a diagnostic that lies quietly is worse than
+  // none, and this one exists precisely for the unload AV that is hard to see.
+  LSuffix := ChangeFileExt(ExtractFileName(GetModuleName(HInstance)), '');
+  if Copy(LSuffix, 1, Length(CModules[0])) = CModules[0] then
+    LSuffix := Copy(LSuffix, Length(CModules[0]) + 1, MaxInt)
+  else
+    LSuffix := '';
+
+  _TeardownLog('=== LOAD (module bases, suffix "' + LSuffix + '") ===');
   for LIdx := Low(CModules) to High(CModules) do
   begin
-    LBase := GetModuleHandle(PChar(CModules[LIdx]));
+    LName := CModules[LIdx] + LSuffix + '.bpl';
+    LBase := GetModuleHandle(PChar(LName));
     if LBase = 0 then
-      _TeardownLog('[load] ' + CModules[LIdx] + ' not loaded')
+      _TeardownLog('[load] ' + LName + ' not loaded')
     else
     begin
       LNt := PImageNtHeaders(NativeUInt(LBase) +
         Cardinal(PImageDosHeader(LBase)^._lfanew));
       LSize := LNt^.OptionalHeader.SizeOfImage;
       _TeardownLog(Format('[load] %s base=%.8x end=%.8x size=%.8x',
-        [CModules[LIdx], NativeUInt(LBase), NativeUInt(LBase) + LSize, LSize]));
+        [LName, NativeUInt(LBase), NativeUInt(LBase) + LSize, LSize]));
     end;
   end;
 end;


### PR DESCRIPTION
Follow-up to #32, and the fix that makes it unnecessary.

## The problem #32 worked around

Aefos shipped the **same ten file names to every supported version**. A design package names the runtime packages it needs, and the IDE resolves each through the process `PATH` — where every installed RAD Studio has already put its own `Bpl` folder. So on a machine with more than one IDE, the first folder answered for all of them.

Measured on the VM: a **Seattle** IDE loading the **Sydney** `Aefos.MCP.Core.bpl`, which failed once as a missing entry point and once as an access violation. One cause, two unrelated-looking symptoms.

#32 reordered `PATH` per IDE. This removes the ambiguity instead — and unlike #32 it also covers **Delphi 13**, which had to be skipped there because its 32- and 64-bit IDEs share one registry hive.

## The suffix

Embarcadero solved this for their own packages long ago (`rtl230`, `rtl270`, `rtl290`, `rtl370`). We now carry the same one, so an Aefos BPL sits beside the RTL it was built against:

| BDS | 17.0 | 18.0 | 19.0 | 20.0 | 21.0 | 22.0 | 23.0 | 37.0 |
|---|---|---|---|---|---|---|---|---|
| suffix | 230 | 240 | 250 | 260 | 270 | 280 | 290 | 370 |

**Every number was read off the IDE's own `bin` folder** (`rtl<suffix>.bpl`), not recalled. `22.0 → 280` and `23.0 → 290` are ten apart; `23.0 → 37.0` is eighty. There is no formula, which is exactly why this is measured — the one place it could be "obviously" generalised is the place it would be wrong.

`requires` clauses are untouched: `LIBSUFFIX` renames the `.bpl` only, and the `.dcp` keeps its base name (verified — `rtl.dcp` ↔ `rtl290.bpl`).

## Four surfaces, one authority

| Where | Role |
|---|---|
| `Aefos.LibSuffix.inc` | `{$LIBSUFFIX}` needs a literal, so the table lives here |
| `build-packages.ps1` | **measures** the target IDE and demands the suffixed file |
| `build-installer.ps1` | **reads** the suffix back off the staged payload, refuses an unsuffixed one, cross-checks `Aefos.iss` |
| `Aefos.iss` | its own literals (Inno resolves names at compile time), kept honest by the check above |

The build-time assertion matters more than it looks: the IDE rewrites a `.dpk` when files are added or removed through the Project Manager, and can drop a directive it does not recognise. If that ever takes the `{$I}` line, the BPL silently goes back to its old name — so staging asks for the **new** name and stops the build rather than shipping the collision back.

## Also in here, because it is the same change

- **The `.dproj` staging target** copies by wildcard instead of by name, and stages into `installer\bpl\<version>` rather than one flat folder — with a name per version, a shared folder was the last place they could still mix.
- **The installer removes a pre-suffix install** — old BPLs and their `Known Packages` entries. Left alone, the IDE would load the old design package beside the new one, and those files keep the very names this change exists to retire.
- **The DEBUG module-base log** built its names from a hardcoded list and would have reported `not loaded` six times. It now reads the suffix off its own module. A diagnostic that lies quietly is worse than none, and this one exists for the unload AV that is hard to see without it.

## Verification

- `ISCC` compiles `Aefos.iss` clean against a suffixed payload (exit 0), and **refuses** an unsuffixed one — the new guard proving itself.
- All three PowerShell scripts parse clean.
- **Not yet done, and it is the gate: an actual build.** No BPL has been produced with `{$LIBSUFFIX}` yet, so the first `build-packages.ps1` run is what proves the include reaches the compiler and the names come out as declared.

## Known gap

`Aefos.WebView.dproj` and `dclAefosWebView.dproj` have no staging target at all (they never did), so an IDE-only build stages 8 of 10. `build-packages.ps1` stages all ten, so the script path is complete. Left alone here rather than widened into this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)