### PR TITLE
Refuse an unsuffixed BPL from inside the IDE too, where no script can

### DIFF
--- a/packages/Delphi/Aefos.Data.dproj
+++ b/packages/Delphi/Aefos.Data.dproj
@@ -224,7 +224,18 @@
                  place. The wildcard asks the disk, which is the one source that cannot
                  drift out of step with what the compiler actually produced. -->
             <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+            <AefosBplPlain Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl"/>
         </ItemGroup>
+        <!-- The suffix comes from {$LIBSUFFIX} inside the .dpk, and the IDE rewrites a
+             .dpk whenever files are added or removed through the Project Manager (or the
+             Description page is saved), which can take the {$I Aefos.LibSuffix.inc} line
+             with it. build-packages.ps1 already refuses an unsuffixed BPL, but a build
+             started INSIDE the IDE never reaches that script - so the same refusal has to
+             live here, or the one path most likely to break is the one with no guard.
+             Fires only when the unsuffixed file is the ONLY one there: during the
+             changeover a stale copy can still sit beside a good new one. -->
+        <Error Condition="'@(AefosBplFiles)'=='@(AefosBplPlain)' and '@(AefosBplPlain)'!=''"
+               Text="[Aefos] $(MSBuildProjectName).bpl was built WITHOUT its version suffix. The {$I Aefos.LibSuffix.inc} line is missing from $(MSBuildProjectName).dpk - the IDE drops it when it rewrites the package. Put it back above the requires clause; without it two RAD Studios on one machine load each other%27s BPLs."/>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
         <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
         <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>

--- a/packages/Delphi/Aefos.Harness.dproj
+++ b/packages/Delphi/Aefos.Harness.dproj
@@ -188,7 +188,18 @@
                  place. The wildcard asks the disk, which is the one source that cannot
                  drift out of step with what the compiler actually produced. -->
             <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+            <AefosBplPlain Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl"/>
         </ItemGroup>
+        <!-- The suffix comes from {$LIBSUFFIX} inside the .dpk, and the IDE rewrites a
+             .dpk whenever files are added or removed through the Project Manager (or the
+             Description page is saved), which can take the {$I Aefos.LibSuffix.inc} line
+             with it. build-packages.ps1 already refuses an unsuffixed BPL, but a build
+             started INSIDE the IDE never reaches that script - so the same refusal has to
+             live here, or the one path most likely to break is the one with no guard.
+             Fires only when the unsuffixed file is the ONLY one there: during the
+             changeover a stale copy can still sit beside a good new one. -->
+        <Error Condition="'@(AefosBplFiles)'=='@(AefosBplPlain)' and '@(AefosBplPlain)'!=''"
+               Text="[Aefos] $(MSBuildProjectName).bpl was built WITHOUT its version suffix. The {$I Aefos.LibSuffix.inc} line is missing from $(MSBuildProjectName).dpk - the IDE drops it when it rewrites the package. Put it back above the requires clause; without it two RAD Studios on one machine load each other%27s BPLs."/>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
         <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
         <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>

--- a/packages/Delphi/Aefos.MCP.Core.dproj
+++ b/packages/Delphi/Aefos.MCP.Core.dproj
@@ -248,7 +248,18 @@
                  place. The wildcard asks the disk, which is the one source that cannot
                  drift out of step with what the compiler actually produced. -->
             <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+            <AefosBplPlain Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl"/>
         </ItemGroup>
+        <!-- The suffix comes from {$LIBSUFFIX} inside the .dpk, and the IDE rewrites a
+             .dpk whenever files are added or removed through the Project Manager (or the
+             Description page is saved), which can take the {$I Aefos.LibSuffix.inc} line
+             with it. build-packages.ps1 already refuses an unsuffixed BPL, but a build
+             started INSIDE the IDE never reaches that script - so the same refusal has to
+             live here, or the one path most likely to break is the one with no guard.
+             Fires only when the unsuffixed file is the ONLY one there: during the
+             changeover a stale copy can still sit beside a good new one. -->
+        <Error Condition="'@(AefosBplFiles)'=='@(AefosBplPlain)' and '@(AefosBplPlain)'!=''"
+               Text="[Aefos] $(MSBuildProjectName).bpl was built WITHOUT its version suffix. The {$I Aefos.LibSuffix.inc} line is missing from $(MSBuildProjectName).dpk - the IDE drops it when it rewrites the package. Put it back above the requires clause; without it two RAD Studios on one machine load each other%27s BPLs."/>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
         <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
         <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>

--- a/packages/Delphi/Aefos.MCP.Tools.OTA.dproj
+++ b/packages/Delphi/Aefos.MCP.Tools.OTA.dproj
@@ -230,7 +230,18 @@
                  place. The wildcard asks the disk, which is the one source that cannot
                  drift out of step with what the compiler actually produced. -->
             <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+            <AefosBplPlain Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl"/>
         </ItemGroup>
+        <!-- The suffix comes from {$LIBSUFFIX} inside the .dpk, and the IDE rewrites a
+             .dpk whenever files are added or removed through the Project Manager (or the
+             Description page is saved), which can take the {$I Aefos.LibSuffix.inc} line
+             with it. build-packages.ps1 already refuses an unsuffixed BPL, but a build
+             started INSIDE the IDE never reaches that script - so the same refusal has to
+             live here, or the one path most likely to break is the one with no guard.
+             Fires only when the unsuffixed file is the ONLY one there: during the
+             changeover a stale copy can still sit beside a good new one. -->
+        <Error Condition="'@(AefosBplFiles)'=='@(AefosBplPlain)' and '@(AefosBplPlain)'!=''"
+               Text="[Aefos] $(MSBuildProjectName).bpl was built WITHOUT its version suffix. The {$I Aefos.LibSuffix.inc} line is missing from $(MSBuildProjectName).dpk - the IDE drops it when it rewrites the package. Put it back above the requires clause; without it two RAD Studios on one machine load each other%27s BPLs."/>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
         <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
         <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>

--- a/packages/Delphi/Aefos.OTA.Chat.dproj
+++ b/packages/Delphi/Aefos.OTA.Chat.dproj
@@ -1172,7 +1172,18 @@
                  place. The wildcard asks the disk, which is the one source that cannot
                  drift out of step with what the compiler actually produced. -->
             <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+            <AefosBplPlain Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl"/>
         </ItemGroup>
+        <!-- The suffix comes from {$LIBSUFFIX} inside the .dpk, and the IDE rewrites a
+             .dpk whenever files are added or removed through the Project Manager (or the
+             Description page is saved), which can take the {$I Aefos.LibSuffix.inc} line
+             with it. build-packages.ps1 already refuses an unsuffixed BPL, but a build
+             started INSIDE the IDE never reaches that script - so the same refusal has to
+             live here, or the one path most likely to break is the one with no guard.
+             Fires only when the unsuffixed file is the ONLY one there: during the
+             changeover a stale copy can still sit beside a good new one. -->
+        <Error Condition="'@(AefosBplFiles)'=='@(AefosBplPlain)' and '@(AefosBplPlain)'!=''"
+               Text="[Aefos] $(MSBuildProjectName).bpl was built WITHOUT its version suffix. The {$I Aefos.LibSuffix.inc} line is missing from $(MSBuildProjectName).dpk - the IDE drops it when it rewrites the package. Put it back above the requires clause; without it two RAD Studios on one machine load each other%27s BPLs."/>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
         <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
         <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>

--- a/packages/Delphi/Aefos.OTA.Terminal.dproj
+++ b/packages/Delphi/Aefos.OTA.Terminal.dproj
@@ -1095,7 +1095,18 @@
                  place. The wildcard asks the disk, which is the one source that cannot
                  drift out of step with what the compiler actually produced. -->
             <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+            <AefosBplPlain Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl"/>
         </ItemGroup>
+        <!-- The suffix comes from {$LIBSUFFIX} inside the .dpk, and the IDE rewrites a
+             .dpk whenever files are added or removed through the Project Manager (or the
+             Description page is saved), which can take the {$I Aefos.LibSuffix.inc} line
+             with it. build-packages.ps1 already refuses an unsuffixed BPL, but a build
+             started INSIDE the IDE never reaches that script - so the same refusal has to
+             live here, or the one path most likely to break is the one with no guard.
+             Fires only when the unsuffixed file is the ONLY one there: during the
+             changeover a stale copy can still sit beside a good new one. -->
+        <Error Condition="'@(AefosBplFiles)'=='@(AefosBplPlain)' and '@(AefosBplPlain)'!=''"
+               Text="[Aefos] $(MSBuildProjectName).bpl was built WITHOUT its version suffix. The {$I Aefos.LibSuffix.inc} line is missing from $(MSBuildProjectName).dpk - the IDE drops it when it rewrites the package. Put it back above the requires clause; without it two RAD Studios on one machine load each other%27s BPLs."/>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
         <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
         <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>

--- a/packages/Delphi/Aefos.Providers.dproj
+++ b/packages/Delphi/Aefos.Providers.dproj
@@ -213,7 +213,18 @@
                  place. The wildcard asks the disk, which is the one source that cannot
                  drift out of step with what the compiler actually produced. -->
             <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+            <AefosBplPlain Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl"/>
         </ItemGroup>
+        <!-- The suffix comes from {$LIBSUFFIX} inside the .dpk, and the IDE rewrites a
+             .dpk whenever files are added or removed through the Project Manager (or the
+             Description page is saved), which can take the {$I Aefos.LibSuffix.inc} line
+             with it. build-packages.ps1 already refuses an unsuffixed BPL, but a build
+             started INSIDE the IDE never reaches that script - so the same refusal has to
+             live here, or the one path most likely to break is the one with no guard.
+             Fires only when the unsuffixed file is the ONLY one there: during the
+             changeover a stale copy can still sit beside a good new one. -->
+        <Error Condition="'@(AefosBplFiles)'=='@(AefosBplPlain)' and '@(AefosBplPlain)'!=''"
+               Text="[Aefos] $(MSBuildProjectName).bpl was built WITHOUT its version suffix. The {$I Aefos.LibSuffix.inc} line is missing from $(MSBuildProjectName).dpk - the IDE drops it when it rewrites the package. Put it back above the requires clause; without it two RAD Studios on one machine load each other%27s BPLs."/>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
         <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
         <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>

--- a/packages/Delphi/Aefos.Tools.dproj
+++ b/packages/Delphi/Aefos.Tools.dproj
@@ -210,7 +210,18 @@
                  place. The wildcard asks the disk, which is the one source that cannot
                  drift out of step with what the compiler actually produced. -->
             <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+            <AefosBplPlain Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl"/>
         </ItemGroup>
+        <!-- The suffix comes from {$LIBSUFFIX} inside the .dpk, and the IDE rewrites a
+             .dpk whenever files are added or removed through the Project Manager (or the
+             Description page is saved), which can take the {$I Aefos.LibSuffix.inc} line
+             with it. build-packages.ps1 already refuses an unsuffixed BPL, but a build
+             started INSIDE the IDE never reaches that script - so the same refusal has to
+             live here, or the one path most likely to break is the one with no guard.
+             Fires only when the unsuffixed file is the ONLY one there: during the
+             changeover a stale copy can still sit beside a good new one. -->
+        <Error Condition="'@(AefosBplFiles)'=='@(AefosBplPlain)' and '@(AefosBplPlain)'!=''"
+               Text="[Aefos] $(MSBuildProjectName).bpl was built WITHOUT its version suffix. The {$I Aefos.LibSuffix.inc} line is missing from $(MSBuildProjectName).dpk - the IDE drops it when it rewrites the package. Put it back above the requires clause; without it two RAD Studios on one machine load each other%27s BPLs."/>
         <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
         <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
         <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>

--- a/packages/Delphi/Aefos.WebView.dproj
+++ b/packages/Delphi/Aefos.WebView.dproj
@@ -53,6 +53,7 @@
         <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
         <GenDll>true</GenDll>
         <GenPackage>true</GenPackage>
+        <_PostCompileTargets>AefosStageBplForInstaller</_PostCompileTargets>
         <RuntimeOnlyPackage>true</RuntimeOnlyPackage>
         <VerInfo_Locale>1046</VerInfo_Locale>
         <DCC_Description>Aefos AI - composition-hosted WebView2</DCC_Description>
@@ -127,4 +128,32 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+    <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
+        <PropertyGroup>
+            <!-- Per version, because the same file name now exists once per IDE and a
+                 flat folder would mix Seattle and Athens builds under one roof. -->
+            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl\$(PRODUCTVERSION)</AefosStage>
+        </PropertyGroup>
+        <ItemGroup>
+            <!-- The BPL carries a per-version LIBSUFFIX (see Aefos.LibSuffix.inc), so its
+                 name cannot be written here without copying that table into a fourth
+                 place. The wildcard asks the disk, which is the one source that cannot
+                 drift out of step with what the compiler actually produced. -->
+            <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+            <AefosBplPlain Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl"/>
+        </ItemGroup>
+        <!-- The suffix comes from {$LIBSUFFIX} inside the .dpk, and the IDE rewrites a
+             .dpk whenever files are added or removed through the Project Manager (or the
+             Description page is saved), which can take the {$I Aefos.LibSuffix.inc} line
+             with it. build-packages.ps1 already refuses an unsuffixed BPL, but a build
+             started INSIDE the IDE never reaches that script - so the same refusal has to
+             live here, or the one path most likely to break is the one with no guard.
+             Fires only when the unsuffixed file is the ONLY one there: during the
+             changeover a stale copy can still sit beside a good new one. -->
+        <Error Condition="'@(AefosBplFiles)'=='@(AefosBplPlain)' and '@(AefosBplPlain)'!=''"
+               Text="[Aefos] $(MSBuildProjectName).bpl was built WITHOUT its version suffix. The {$I Aefos.LibSuffix.inc} line is missing from $(MSBuildProjectName).dpk - the IDE drops it when it rewrites the package. Put it back above the requires clause; without it two RAD Studios on one machine load each other%27s BPLs."/>
+        <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
+        <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
+        <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>
+    </Target>
 </Project>

--- a/packages/Delphi/dclAefosWebView.dproj
+++ b/packages/Delphi/dclAefosWebView.dproj
@@ -93,6 +93,7 @@
         <DCC_ExeOutput>.\$(Platform)\$(Config)</DCC_ExeOutput>
         <GenDll>true</GenDll>
         <GenPackage>true</GenPackage>
+        <_PostCompileTargets>AefosStageBplForInstaller</_PostCompileTargets>
         <DesignOnlyPackage>true</DesignOnlyPackage>
         <VerInfo_Locale>1046</VerInfo_Locale>
         <DCC_Description>Aefos AI - WebView2 component (design-time)</DCC_Description>
@@ -190,4 +191,32 @@
     </ProjectExtensions>
     <Import Project="$(BDS)\Bin\CodeGear.Delphi.Targets" Condition="Exists('$(BDS)\Bin\CodeGear.Delphi.Targets')"/>
     <Import Project="$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj" Condition="Exists('$(APPDATA)\Embarcadero\$(BDSAPPDATABASEDIR)\$(PRODUCTVERSION)\UserTools.proj')"/>
+    <Target Name="AefosStageBplForInstaller" Condition="'$(Config)'=='Release' and '$(Platform)'=='Win32'">
+        <PropertyGroup>
+            <!-- Per version, because the same file name now exists once per IDE and a
+                 flat folder would mix Seattle and Athens builds under one roof. -->
+            <AefosStage>$(MSBuildProjectDirectory)\..\..\installer\bpl\$(PRODUCTVERSION)</AefosStage>
+        </PropertyGroup>
+        <ItemGroup>
+            <!-- The BPL carries a per-version LIBSUFFIX (see Aefos.LibSuffix.inc), so its
+                 name cannot be written here without copying that table into a fourth
+                 place. The wildcard asks the disk, which is the one source that cannot
+                 drift out of step with what the compiler actually produced. -->
+            <AefosBplFiles Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName)*.bpl"/>
+            <AefosBplPlain Include="$(BDSCOMMONDIR)\Bpl\$(MSBuildProjectName).bpl"/>
+        </ItemGroup>
+        <!-- The suffix comes from {$LIBSUFFIX} inside the .dpk, and the IDE rewrites a
+             .dpk whenever files are added or removed through the Project Manager (or the
+             Description page is saved), which can take the {$I Aefos.LibSuffix.inc} line
+             with it. build-packages.ps1 already refuses an unsuffixed BPL, but a build
+             started INSIDE the IDE never reaches that script - so the same refusal has to
+             live here, or the one path most likely to break is the one with no guard.
+             Fires only when the unsuffixed file is the ONLY one there: during the
+             changeover a stale copy can still sit beside a good new one. -->
+        <Error Condition="'@(AefosBplFiles)'=='@(AefosBplPlain)' and '@(AefosBplPlain)'!=''"
+               Text="[Aefos] $(MSBuildProjectName).bpl was built WITHOUT its version suffix. The {$I Aefos.LibSuffix.inc} line is missing from $(MSBuildProjectName).dpk - the IDE drops it when it rewrites the package. Put it back above the requires clause; without it two RAD Studios on one machine load each other%27s BPLs."/>
+        <MakeDir Directories="$(AefosStage)" Condition="!Exists('$(AefosStage)')"/>
+        <Copy SourceFiles="@(AefosBplFiles)" DestinationFolder="$(AefosStage)" SkipUnchangedFiles="false"/>
+        <Message Importance="high" Text="[Aefos] staged @(AefosBplFiles-&gt;'%(Filename)%(Extension)') -&gt; installer\bpl\$(PRODUCTVERSION)"/>
+    </Target>
 </Project>


### PR DESCRIPTION
Answers a question from the maintainer: *if I build and install from the IDE, does it add the suffix?*

## Measured: yes

`msbuild` on the `.dproj` alone — no `DCC_BplOutput`, no defines, which is the IDE's own path — produced **`Aefos.Tools290.bpl`**. The suffix comes from `{$LIBSUFFIX}` in the `.dpk`, and the `.dpk` is what `dcc` compiles regardless of who starts the build. The `.dproj` does not carry the suffix at all.

## But the worry was pointing at something real

What can take the suffix away is the **IDE rewriting the `.dpk`** — which it does whenever files are added or removed through the Project Manager. **Project Options → Description** is worse: the `LIB suffix` field is exactly where the IDE keeps this setting, and it shows **empty**, because a conditional include is not something that dialog evaluates. Saving that page can carry the `{$I Aefos.LibSuffix.inc}` line away, and the next build quietly returns to the old name.

`build-packages.ps1` already refuses an unsuffixed BPL — but a build started inside the IDE never reaches that script. **The path most likely to break was the one with no guard.**

## The guard

It now lives in the staging target too, so it runs wherever the build is started, and it fails with the reason and the fix instead of a missing-file complaint.

**Proven by mutation, not by reading.** With the `{$I}` line stripped from `Aefos.Tools.dpk`:

```
error : [Aefos] Aefos.Tools.bpl was built WITHOUT its version suffix. The
{$I Aefos.LibSuffix.inc} line is missing from Aefos.Tools.dpk - the IDE drops it
when it rewrites the package. Put it back above the requires clause; without it
two RAD Studios on one machine load each other's BPLs.
```

With the line restored, it builds and stages `Aefos.Tools290.bpl`.

It fires only when the unsuffixed file is the **only** one present — during the changeover a stale copy can still sit beside a good new one, and failing there would stop a build that is actually correct.

## And the two packages that had no guard at all

`Aefos.WebView` and `dclAefosWebView` never had a staging target, so in the IDE they were precisely the two that could drift back to an unsuffixed name with nothing watching. They have it now, hooked through `_PostCompileTargets` inside the `Base` group like the other eight — and both were built to prove it, staging as `Aefos.WebView290.bpl` and `dclAefosWebView290.bpl`.

That also closes the 8-of-10 staging gap noted in #33.

## Note on the LIB suffix field

It cannot solve this on its own. It accepts a **literal**, not a variable — there is no `$(...)` there that expands to the IDE version — and its one automatic value, `AUTO`, exists only from 10.4 up, so it would break Seattle, Berlin, Tokyo and Rio. A literal is also fixed to one version and would have to be typed into all ten packages. That is what the include exists to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)