### PR TITLE
A store the user configures, read in any format, installed from the one they chose

### DIFF
--- a/cli/Aefos.Addons.Args.pas
+++ b/cli/Aefos.Addons.Args.pas
@@ -1,4 +1,4 @@
-unit Aefos.Addons.Args;
+﻿unit Aefos.Addons.Args;
 {$IFDEF FPC}{$mode delphiunicode}{$ENDIF}
 
 {
@@ -25,13 +25,14 @@ uses
 
 type
   TAddonCommand = (acNone, acInstall, acUninstall, acUpdate, acList,
-    acHelp, acVersion);
+    acHelp, acVersion, acCatalog, acSources);
 
   TAddonCliArgs = record
     Command: TAddonCommand;
     Slug: string;
     Yes: Boolean;
     Check: Boolean;     // --check: dry-run, report without installing
+    Json: Boolean;      // --json: machine-readable output (the IDE dialog reads it)
     Registry: string;   // '' = default/env
     Error: string;      // non-empty => parse failed (user-facing one-liner)
     { Parses the argv tail into this record. Never raises; a bad input lands in
@@ -53,6 +54,10 @@ begin
     ACmd := acUpdate
   else if SameText(AWord, 'list') or SameText(AWord, 'ls') then
     ACmd := acList
+  else if SameText(AWord, 'catalog') or SameText(AWord, 'search') then
+    ACmd := acCatalog
+  else if SameText(AWord, 'sources') then
+    ACmd := acSources
   else
     Result := False;
 end;
@@ -82,6 +87,8 @@ begin
       Result.Yes := True
     else if LArg = '--check' then
       Result.Check := True
+    else if SameText(LArg, '--json') then
+      Result.Json := True
     else if LArg = '--registry' then
     begin
       if LIndex >= High(AArgv) then
@@ -102,7 +109,7 @@ begin
       if not _ParseCommand(LArg, Result.Command) then
       begin
         Result.Error := 'Unknown command "' + LArg +
-          '". Use install, uninstall, update or list.';
+          '". Use install, uninstall, update, list, catalog or sources.';
         Exit;
       end;
     end

--- a/cli/Aefos.Addons.Args.pas
+++ b/cli/Aefos.Addons.Args.pas
@@ -12,6 +12,8 @@
     options:  --yes | -y            pre-consent third-party (mcp/tools) code
               --check                dry-run: report what would update, install nothing
                                      (valid on update, with or without a slug)
+              --source <name>        take the slug from THAT configured store
+                                     (required when two stores publish the name)
               --registry <url>       override the registry URL (also AEFOS_ADDONS_REGISTRY)
               -h | --help | -v | --version
 
@@ -33,6 +35,7 @@ type
     Yes: Boolean;
     Check: Boolean;     // --check: dry-run, report without installing
     Json: Boolean;      // --json: machine-readable output (the IDE dialog reads it)
+    Source: string;     // --source: which configured store to use ('' = any)
     Registry: string;   // '' = default/env
     Error: string;      // non-empty => parse failed (user-facing one-liner)
     { Parses the argv tail into this record. Never raises; a bad input lands in
@@ -89,6 +92,16 @@ begin
       Result.Check := True
     else if SameText(LArg, '--json') then
       Result.Json := True
+    else if SameText(LArg, '--source') then
+    begin
+      if LIndex >= High(AArgv) then
+      begin
+        Result.Error := 'Missing store name after --source.';
+        Exit;
+      end;
+      Inc(LIndex);
+      Result.Source := AArgv[LIndex];
+    end
     else if LArg = '--registry' then
     begin
       if LIndex >= High(AArgv) then

--- a/cli/Aefos.Addons.Catalog.pas
+++ b/cli/Aefos.Addons.Catalog.pas
@@ -51,6 +51,24 @@ type
       the same document so the UI can show a store as unreachable instead of
       quietly listing fewer addons than exist. }
     class function ToJson(const AResults: TArray<TAddonCatalogResult>): string; static;
+
+    { Finds ASlug across AResults. APreferSource, when non-empty, restricts the
+      search to that store - which is how `--source` and the ledger's recorded
+      source both say "this one, not the same name somewhere else".
+
+      Raises rather than picking for you when the slug is in more than one
+      store: with two stores a bare name is not an identity, and quietly
+      choosing would install a stranger's addon under the name of the one the
+      user meant. The message names the candidates so the fix is one flag away.
+
+      A store that FAILED is reported inside the not-found message. "addon not
+      found" while the store holding it was unreachable is a lie the user would
+      act on. }
+    class function Resolve(const AResults: TArray<TAddonCatalogResult>;
+      const ASlug, APreferSource: string): TAddonCatalogRow; static;
+
+    { Resolve over a freshly read catalogue - the single-shot form. }
+    class function ResolveOne(const ASlug, APreferSource: string): TAddonCatalogRow; static;
   end;
 
 implementation
@@ -123,6 +141,18 @@ begin
     end;
   end;
   Result := True;
+end;
+
+// A store that could not be read may be the store that HAS the slug, so the
+// not-found message has to carry it. Silence here would send the user hunting
+// for a typo in a name that is perfectly correct.
+function _ErrSuffix(const AErrors: string): string;
+begin
+  if AErrors = '' then
+    Result := ''
+  else
+    Result := ' (a store could not be read, and may be the one that has it - ' +
+      AErrors + ')';
 end;
 
 class function TAddonCatalog.ReadSource(
@@ -202,6 +232,63 @@ begin
     Inc(LCount);
   end;
   SetLength(Result, LCount);
+end;
+
+class function TAddonCatalog.Resolve(
+  const AResults: TArray<TAddonCatalogResult>;
+  const ASlug, APreferSource: string): TAddonCatalogRow;
+var
+  LI, LJ, LFound: Integer;
+  LCandidates, LErrors: string;
+begin
+  Result := Default(TAddonCatalogRow);
+  LFound := 0;
+  LCandidates := '';
+  LErrors := '';
+  for LI := 0 to High(AResults) do
+  begin
+    if AResults[LI].Error <> '' then
+    begin
+      if LErrors <> '' then
+        LErrors := LErrors + '; ';
+      LErrors := LErrors + AResults[LI].Source.Name + ': ' + AResults[LI].Error;
+      Continue;
+    end;
+    if (APreferSource <> '') and
+       not SameText(AResults[LI].Source.Name, APreferSource) then
+      Continue;
+    for LJ := 0 to High(AResults[LI].Rows) do
+    begin
+      if not SameText(AResults[LI].Rows[LJ].Entry.Slug, ASlug) then
+        Continue;
+      if LFound = 0 then
+        Result := AResults[LI].Rows[LJ];
+      Inc(LFound);
+      if LCandidates <> '' then
+        LCandidates := LCandidates + ', ';
+      LCandidates := LCandidates + AResults[LI].Rows[LJ].Source;
+    end;
+  end;
+
+  if LFound > 1 then
+    raise EAddonError.CreateFmt(
+      '"%s" exists in more than one store (%s). Say which one with ' +
+      '--source <name>.', [ASlug, LCandidates]);
+
+  if LFound = 0 then
+  begin
+    if APreferSource <> '' then
+      raise EAddonNotFound.CreateFmt('addon "%s" is not in store "%s".%s',
+        [ASlug, APreferSource, _ErrSuffix(LErrors)]);
+    raise EAddonNotFound.CreateFmt('addon "%s" is not in any configured store.%s',
+      [ASlug, _ErrSuffix(LErrors)]);
+  end;
+end;
+
+class function TAddonCatalog.ResolveOne(
+  const ASlug, APreferSource: string): TAddonCatalogRow;
+begin
+  Result := Resolve(ReadAll, ASlug, APreferSource);
 end;
 
 class function TAddonCatalog.ToJson(

--- a/cli/Aefos.Addons.Catalog.pas
+++ b/cli/Aefos.Addons.Catalog.pas
@@ -1,0 +1,248 @@
+unit Aefos.Addons.Catalog;
+{$IFDEF FPC}{$mode delphiunicode}{$ENDIF}
+
+(*
+  Aefos Addons - the merged list of what can be installed.
+
+  This is the contract the IDE dialog will consume: ask the CLI what is
+  available, get one row per addon with the store it came from. Written CLI-side
+  on purpose - reading a store is real logic (fetch, parse, tolerate a store
+  being down) and having it in two languages would mean fixing every bug twice.
+  The plugin spawns aefos.exe and parses JSON; that is the whole coupling.
+
+  WHY EACH ROW CARRIES ITS SOURCE. With more than one store, a bare name stops
+  being an identity: the gallery and a company store may both publish "review".
+  Carrying the source turns what would be a collision to guess about into two
+  honest rows, and lets the install that follows say exactly which one it meant.
+
+  A STORE THAT IS DOWN MUST NOT TAKE THE LIST WITH IT. Each source is read
+  independently and a failure becomes a row-less error string, not an exception:
+  a user whose company VPN is off should still see the gallery, with a line
+  saying the other store could not be read. The alternative - one unreachable
+  store and an empty dialog - looks like "there is nothing to install".
+*)
+
+interface
+
+uses
+  SysUtils,
+  Aefos.Addons.Types,
+  Aefos.Addons.Sources;
+
+type
+  { What one store answered. Error is empty when it answered normally. }
+  TAddonCatalogResult = record
+    Source: TAddonSource;
+    Rows: TArray<TAddonCatalogRow>;
+    Error: string;
+  end;
+
+  { Static, sealed namespace; never instantiated. }
+  TAddonCatalog = class sealed
+  public
+    { Reads one store. Never raises for a store-side problem - the reason lands
+      in Error so the caller can report it beside the stores that did answer. }
+    class function ReadSource(const ASource: TAddonSource): TAddonCatalogResult; static;
+
+    { Reads every ENABLED configured store, in configuration order. }
+    class function ReadAll: TArray<TAddonCatalogResult>; static;
+
+    { The merged catalogue as JSON - what the IDE dialog reads. Errors travel in
+      the same document so the UI can show a store as unreachable instead of
+      quietly listing fewer addons than exist. }
+    class function ToJson(const AResults: TArray<TAddonCatalogResult>): string; static;
+  end;
+
+implementation
+
+uses
+  Classes,
+  IOUtils,
+  Types,
+  Aefos.Compat.Json,
+  Aefos.Compat.JsonFormat,
+  Aefos.Addons.Manifest,
+  Aefos.Addons.Net,
+  Aefos.Addons.PluginFormat;
+
+function _Str(const AObj: TJSONObject; const AKey: string): string;
+var
+  LVal: TJSONValue;
+begin
+  Result := '';
+  if AObj = nil then
+    Exit;
+  LVal := AObj.Values[AKey];
+  if LVal is TJSONString then
+    Result := TJSONString(LVal).Value;
+end;
+
+{ Reads a bundle folder into a catalogue entry. The slug is the FOLDER name -
+  it is what `aefos install` will be told and what uninstall will remove, so it
+  has to be the thing the user can see and type, not a field inside a file. }
+function _EntryFromDir(const ADir: string; out AEntry: TAddonRegistryEntry): Boolean;
+var
+  LFormat: TPluginFormat;
+  LJson: string;
+  LVal: TJSONValue;
+  LObj: TJSONObject;
+begin
+  Result := False;
+  LFormat := TAddonPluginFormat.Detect(ADir);
+  if LFormat = pfNone then
+    Exit;
+  AEntry := Default(TAddonRegistryEntry);
+  AEntry.Slug := TPath.GetFileName(ExcludeTrailingPathDelimiter(ADir));
+  AEntry.Url := ADir;                       // a path store installs from disk
+  AEntry.Trust := atCommunity;              // never "official" unless we said so
+  AEntry.Name := AEntry.Slug;
+  LJson := '';
+  try
+    if TFile.Exists(TAddonPluginFormat.ManifestPathOf(ADir, LFormat)) then
+      LJson := TFile.ReadAllText(
+        TAddonPluginFormat.ManifestPathOf(ADir, LFormat), TEncoding.UTF8);
+  except
+    LJson := '';
+  end;
+  if LJson <> '' then
+  begin
+    LVal := TJSONObject.ParseJSONValue(LJson);
+    try
+      if LVal is TJSONObject then
+      begin
+        LObj := TJSONObject(LVal);
+        AEntry.Version := _Str(LObj, 'version');
+        AEntry.Description := _Str(LObj, 'description');
+        if _Str(LObj, 'displayName') <> '' then
+          AEntry.Name := _Str(LObj, 'displayName')
+        else if _Str(LObj, 'name') <> '' then
+          AEntry.Name := _Str(LObj, 'name');
+      end;
+    finally
+      LVal.Free;
+    end;
+  end;
+  Result := True;
+end;
+
+class function TAddonCatalog.ReadSource(
+  const ASource: TAddonSource): TAddonCatalogResult;
+var
+  LEntries: TArray<TAddonRegistryEntry>;
+  LDirs: TStringDynArray;
+  LEntry: TAddonRegistryEntry;
+  LIndex, LCount: Integer;
+  LUrl: string;
+begin
+  Result := Default(TAddonCatalogResult);
+  Result.Source := ASource;
+  try
+    case ASource.Kind of
+      askAefos:
+        begin
+          LUrl := ASource.Location;
+          if Trim(LUrl) = '' then
+            LUrl := TAddonNet.RegistryUrl;   // the built-in gallery
+          LEntries := TAddonManifestParser.ParseRegistry(
+            TAddonNet.DownloadText(LUrl));
+          SetLength(Result.Rows, Length(LEntries));
+          for LIndex := 0 to High(LEntries) do
+          begin
+            Result.Rows[LIndex].Source := ASource.Name;
+            Result.Rows[LIndex].Entry := LEntries[LIndex];
+          end;
+        end;
+      askPath:
+        begin
+          if not TDirectory.Exists(ASource.Location) then
+            raise EAddonError.CreateFmt('folder "%s" does not exist.',
+              [ASource.Location]);
+          LDirs := TDirectory.GetDirectories(ASource.Location);
+          SetLength(Result.Rows, Length(LDirs));
+          LCount := 0;
+          for LIndex := 0 to High(LDirs) do
+          begin
+            if not _EntryFromDir(LDirs[LIndex], LEntry) then
+              Continue;   // not a bundle - a store folder may hold other things
+            Result.Rows[LCount].Source := ASource.Name;
+            Result.Rows[LCount].Entry := LEntry;
+            Inc(LCount);
+          end;
+          SetLength(Result.Rows, LCount);
+        end;
+    else
+      // Named in the config format from the start so adding it later needs no
+      // migration, and refused clearly until then. A source that silently
+      // returns nothing reads as an empty store, which is a lie.
+      raise EAddonError.Create(
+        'git sources are not readable yet - use a path source, or the gallery.');
+    end;
+  except
+    on E: Exception do
+    begin
+      SetLength(Result.Rows, 0);
+      Result.Error := E.Message;
+    end;
+  end;
+end;
+
+class function TAddonCatalog.ReadAll: TArray<TAddonCatalogResult>;
+var
+  LSources: TArray<TAddonSource>;
+  LIndex, LCount: Integer;
+begin
+  LSources := TAddonSources.Load;
+  SetLength(Result, Length(LSources));
+  LCount := 0;
+  for LIndex := 0 to High(LSources) do
+  begin
+    if not LSources[LIndex].Enabled then
+      Continue;
+    Result[LCount] := ReadSource(LSources[LIndex]);
+    Inc(LCount);
+  end;
+  SetLength(Result, LCount);
+end;
+
+class function TAddonCatalog.ToJson(
+  const AResults: TArray<TAddonCatalogResult>): string;
+var
+  LRoot, LObj: TJSONObject;
+  LAddons, LErrors: TJSONArray;
+  LI, LJ: Integer;
+begin
+  LRoot := TJSONObject.Create;
+  try
+    LAddons := TJSONArray.Create;
+    LRoot.AddPair('addons', LAddons);
+    LErrors := TJSONArray.Create;
+    LRoot.AddPair('errors', LErrors);
+    for LI := 0 to High(AResults) do
+    begin
+      if AResults[LI].Error <> '' then
+      begin
+        LObj := TJSONObject.Create;
+        LObj.AddPair('source', AResults[LI].Source.Name);
+        LObj.AddPair('message', AResults[LI].Error);
+        LErrors.AddElement(LObj);
+        Continue;
+      end;
+      for LJ := 0 to High(AResults[LI].Rows) do
+      begin
+        LObj := TJSONObject.Create;
+        LObj.AddPair('source', AResults[LI].Rows[LJ].Source);
+        LObj.AddPair('slug', AResults[LI].Rows[LJ].Entry.Slug);
+        LObj.AddPair('name', AResults[LI].Rows[LJ].Entry.Name);
+        LObj.AddPair('version', AResults[LI].Rows[LJ].Entry.Version);
+        LObj.AddPair('description', AResults[LI].Rows[LJ].Entry.Description);
+        LObj.AddPair('trust', AResults[LI].Rows[LJ].Entry.Trust.ToStr);
+        LAddons.AddElement(LObj);
+      end;
+    end;
+    Result := LRoot.Format(2);
+  finally
+    LRoot.Free;
+  end;
+end;
+
+end.

--- a/cli/Aefos.Addons.Installer.pas
+++ b/cli/Aefos.Addons.Installer.pas
@@ -1,4 +1,4 @@
-unit Aefos.Addons.Installer;
+﻿unit Aefos.Addons.Installer;
 {$IFDEF FPC}{$mode delphiunicode}{$ENDIF}
 
 {
@@ -91,6 +91,7 @@ uses
   Generics.Collections,
   Aefos.Addons.Paths,
   Aefos.Addons.Manifest,
+  Aefos.Addons.PluginFormat,
   Aefos.Addons.Ledger,
   Aefos.Addons.McpRewrite,
   Aefos.Addons.Net,
@@ -474,6 +475,7 @@ var
   LEntry: TAddonRegistryEntry;
   LManifest: TAddonManifest;
   LTempZip, LTempDir, LBundleDir, LManifestPath, LShortSha: string;
+  LFormat: TPluginFormat;
   LFiles, LRoots: TList<string>;
   LArts: TAddonArtifacts;
   LItem: TInstalledAddon;
@@ -512,22 +514,49 @@ begin
     if not TDirectory.Exists(LBundleDir) then
       raise EAddonIntegrity.CreateFmt(
         'archive for "%s" has no top-level "%s\" folder.', [ASlug, ASlug]);
-    LManifestPath := TPath.Combine(LBundleDir, 'addon.json');
-    if not TFile.Exists(LManifestPath) then
-      raise EAddonManifest.CreateFmt('bundle "%s" has no addon.json.', [ASlug]);
-    LManifest := TAddonManifestParser.ParseManifest(
-      TFile.ReadAllText(LManifestPath, TEncoding.UTF8));
-    if not SameText(LManifest.Slug, ASlug) then
+    // An addon is a directory under a JSON manifest, and Aefos is not the only
+    // one packaging that shape. addon.json stays native and keeps priority;
+    // when it is absent the bundle may still be a perfectly good agent plugin -
+    // Agent Plugins 1.0, Copilot or Claude, which differ from one another only
+    // in where two files sit. Reading those costs a detection table and buys
+    // every bundle already published elsewhere, including the marketplace a
+    // user's employer keeps.
+    //
+    // Nothing is renamed by this: what gets installed is still an addon, still
+    // recorded in the same ledger, still removed by the same uninstall. Only
+    // the manifest it was read from differs.
+    LFormat := TAddonPluginFormat.Detect(LBundleDir);
+    if LFormat = pfAefos then
+    begin
+      LManifestPath := TPath.Combine(LBundleDir, 'addon.json');
+      LManifest := TAddonManifestParser.ParseManifest(
+        TFile.ReadAllText(LManifestPath, TEncoding.UTF8));
+      if not SameText(LManifest.Slug, ASlug) then
+        raise EAddonManifest.CreateFmt(
+          'bundle slug "%s" does not match "%s".', [LManifest.Slug, ASlug]);
+      // Version cross-check only when BOTH sides carry one. Under evergreen an
+      // empty version on either side is legitimate; the sha256 verification above
+      // already guarantees the bytes match. The slug guard stays unconditional.
+      if (LManifest.Version <> '') and (LEntry.Version <> '') and
+         not SameText(LManifest.Version, LEntry.Version) then
+        raise EAddonManifest.CreateFmt(
+          'bundle version "%s" does not match registry "%s".',
+          [LManifest.Version, LEntry.Version]);
+    end
+    else if LFormat = pfNone then
       raise EAddonManifest.CreateFmt(
-        'bundle slug "%s" does not match "%s".', [LManifest.Slug, ASlug]);
-    // Version cross-check only when BOTH sides carry one. Under evergreen an
-    // empty version on either side is legitimate; the sha256 verification above
-    // already guarantees the bytes match. The slug guard stays unconditional.
-    if (LManifest.Version <> '') and (LEntry.Version <> '') and
-       not SameText(LManifest.Version, LEntry.Version) then
-      raise EAddonManifest.CreateFmt(
-        'bundle version "%s" does not match registry "%s".',
-        [LManifest.Version, LEntry.Version]);
+        'bundle "%s" carries no manifest Aefos can read (addon.json, ' +
+        'plugin.json or .claude-plugin\plugin.json).', [ASlug])
+    else
+    begin
+      ALog(Format('Reading as %s (this bundle has no addon.json) ...',
+        [TAddonPluginFormat.FormatName(LFormat)]));
+      // A foreign bundle carries no slug of ours to cross-check against, so the
+      // registry entry is the only authority on identity - which is exactly what
+      // the sha256 above already verified.
+      LManifest := TAddonPluginFormat.Adopt(LBundleDir, ASlug, LFormat, ALog);
+      LManifest.RequiresAefos := LEntry.RequiresAefos;
+    end;
 
     _RequireConsent(LEntry, LManifest, AOptions, ALog);
 

--- a/cli/Aefos.Addons.Installer.pas
+++ b/cli/Aefos.Addons.Installer.pas
@@ -37,10 +37,11 @@ type
   TInstallOptions = record
     Yes: Boolean;       // --yes: pre-consent third-party (mcp/tools) code
     AefosVersion: string; // installed Aefos version for the requirement gate
+    Source: string;     // --source: which store to take the slug from ('' = any)
     { Factory: one named owner for building the options record instead of a
       Default() + field-by-field fill at the call site. }
     class function Create(AYes: Boolean;
-      const AAefosVersion: string): TInstallOptions; static;
+      const AAefosVersion: string; const ASource: string = ''): TInstallOptions; static;
   end;
 
   { Static, sealed namespace for install/uninstall/update/list orchestration.
@@ -92,6 +93,8 @@ uses
   Aefos.Addons.Paths,
   Aefos.Addons.Manifest,
   Aefos.Addons.PluginFormat,
+  Aefos.Addons.Sources,
+  Aefos.Addons.Catalog,
   Aefos.Addons.Ledger,
   Aefos.Addons.McpRewrite,
   Aefos.Addons.Net,
@@ -191,11 +194,12 @@ end;
 { TInstallOptions }
 
 class function TInstallOptions.Create(AYes: Boolean;
-  const AAefosVersion: string): TInstallOptions;
+  const AAefosVersion: string; const ASource: string): TInstallOptions;
 begin
   Result := Default(TInstallOptions);
   Result.Yes := AYes;
   Result.AefosVersion := AAefosVersion;
+  Result.Source := ASource;
 end;
 
 { TAddonInstaller }
@@ -223,22 +227,26 @@ begin
     Result := 'v' + Trim(AVersion);
 end;
 
-// Non-raising registry lookup (TAddonManifestParser.FindEntry raises). Used by
-// the "all" / dry-run paths so a slug no longer in the registry can be reported
-// and skipped rather than aborting the whole run.
-function _TryFindEntry(const AEntries: TArray<TAddonRegistryEntry>;
-  const ASlug: string; out AEntry: TAddonRegistryEntry): Boolean;
-var
-  LIndex: Integer;
+// Which store an update should look in: an explicit --source wins, otherwise
+// the store this addon was installed FROM. Falling back to "any store" only
+// happens for a ledger written before sources existed.
+function _PreferredSource(const AOptions: TInstallOptions;
+  const AItem: TInstalledAddon): string;
 begin
-  for LIndex := 0 to High(AEntries) do
-    if SameText(AEntries[LIndex].Slug, ASlug) then
-    begin
-      AEntry := AEntries[LIndex];
-      Exit(True);
-    end;
-  AEntry := Default(TAddonRegistryEntry);
-  Result := False;
+  if Trim(AOptions.Source) <> '' then
+    Result := AOptions.Source
+  else
+    Result := AItem.Source;
+end;
+
+// A folder bundle publishes no sha - it is a directory, not a release - so one
+// is MEASURED before any comparison. Without this every update run would find
+// an empty sha against a recorded one, call it "changed", and reinstall an
+// addon that has not moved.
+procedure _EnsureIdentity(var AEntry: TAddonRegistryEntry);
+begin
+  if (Trim(AEntry.Sha256) = '') and TDirectory.Exists(AEntry.Url) then
+    AEntry.Sha256 := TAddonNet.Sha256OfTree(AEntry.Url);
 end;
 
 // Recursively copies ASrcDir into ADstDir, appending every written file to
@@ -471,49 +479,104 @@ end;
 class procedure TAddonInstaller.Install(const ASlug: string;
   const AOptions: TInstallOptions; const ALog: TAddonLog);
 var
-  LRegistry: TArray<TAddonRegistryEntry>;
+  LRow: TAddonCatalogRow;
   LEntry: TAddonRegistryEntry;
   LManifest: TAddonManifest;
-  LTempZip, LTempDir, LBundleDir, LManifestPath, LShortSha: string;
+  LTempZip, LTempDir, LBundleDir, LStoreDir, LManifestPath, LShortSha: string;
   LFormat: TPluginFormat;
-  LFiles, LRoots: TList<string>;
+  LFiles, LRoots, LScratch: TList<string>;
   LArts: TAddonArtifacts;
   LItem: TInstalledAddon;
 begin
   if not TAddonPaths.IsValidSlug(ASlug) then
     raise EAddonError.CreateFmt('invalid addon slug "%s".', [ASlug]);
 
+  // Resolution goes through the CATALOGUE, not a compiled-in gallery URL: with
+  // stores configured, "install <slug>" has to be able to mean the company's
+  // store. Ambiguity raises inside Resolve rather than being guessed here.
   ALog(Format('Resolving %s ...', [ASlug]));
-  LRegistry := TAddonManifestParser.ParseRegistry(TAddonNet.DownloadText(TAddonNet.RegistryUrl));
-  LEntry := TAddonManifestParser.FindEntry(LRegistry, ASlug); // raises EAddonNotFound
+  LRow := TAddonCatalog.ResolveOne(ASlug, AOptions.Source);
+  LEntry := LRow.Entry;
+  ALog(Format('  found in %s', [LRow.Source]));
 
   if not TAddonVersion.Satisfies(AOptions.AefosVersion, LEntry.RequiresAefos) then
     raise EAddonRequirement.CreateFmt(
       'addon "%s" requires Aefos %s but this is %s.',
       [ASlug, LEntry.RequiresAefos, AOptions.AefosVersion]);
 
-  // The temp discriminator must not depend on a version that may be empty
-  // (evergreen). The sha256 is always present and IS the identity, so a short
-  // prefix of it is the stable temp key.
-  LShortSha := Copy(LEntry.Sha256, 1, 12);
-  LTempDir := TPath.Combine(TPath.GetTempPath,
-    'aefos-addon-' + ASlug + '-' + LShortSha);
-  LTempZip := LTempDir + '.zip';
+  // A store may hand us a bundle already unpacked - that is what a path store
+  // (a folder, a company share) IS. Measured, never declared: a URL that names
+  // an existing directory is a folder bundle, everything else is an archive.
+  // Same instinct as the SQLite gate - where the thing is a FILE, measure it.
+  LStoreDir := '';
+  if TDirectory.Exists(LEntry.Url) then
+    LStoreDir := TPath.GetFullPath(LEntry.Url);
+
+  LTempZip := '';
+  LTempDir := '';
+  LBundleDir := '';
   try
-    ALog(Format('Downloading %s %s ...', [ASlug, _VerLabel(LEntry.Version)]));
-    TAddonNet.DownloadFile(LEntry.Url, LTempZip);
-    ALog('Verifying integrity (sha256) ...');
-    TAddonNet.VerifySha256(LTempZip, LEntry.Sha256);
+    if LStoreDir <> '' then
+    begin
+      ALog(Format('Reading %s from %s ...', [ASlug, LStoreDir]));
+      // The folder has no published sha, so it gets a MEASURED one - the same
+      // identity the rest of the system compares, computed over the tree.
+      // Without it every `update` would see "changed" and reinstall forever.
+      // Measured on the ORIGINAL, before the copy, because the store's content
+      // is what the identity is OF.
+      LEntry.Sha256 := TAddonNet.Sha256OfTree(LStoreDir);
 
-    if TDirectory.Exists(LTempDir) then
-      TDirectory.Delete(LTempDir, True);
-    TAddonNet.ExtractZip(LTempZip, LTempDir);
+      // Then COPY it, and read the copy. Reading a store in place looks free
+      // and is not: adopting a foreign bundle STAGES normalised artifacts into
+      // <bundle>\_aefos\, so working in place would write into somebody else's
+      // store - which fails outright on a read-only share, and otherwise
+      // changes the very tree we just measured, so every later run would report
+      // an update that nobody made. Every other path already owned its tree;
+      // this restores that invariant instead of making the writer conditional.
+      LTempDir := TPath.Combine(TPath.GetTempPath,
+        'aefos-addon-' + ASlug + '-' + Copy(LEntry.Sha256, 1, 12));
+      if TDirectory.Exists(LTempDir) then
+        TDirectory.Delete(LTempDir, True);
+      LBundleDir := TPath.Combine(LTempDir, ASlug);
+      LScratch := TList<string>.Create;
+      try
+        _CopyTree(LStoreDir, LBundleDir, LScratch);
+      finally
+        LScratch.Free;
+      end;
+    end
+    else
+    begin
+      // Over the network the sha is the only thing between the user and
+      // whatever answered the request, so an entry without one is refused
+      // rather than installed unverified.
+      if Trim(LEntry.Sha256) = '' then
+        raise EAddonIntegrity.CreateFmt(
+          'store "%s" published no sha256 for "%s", so the download cannot be ' +
+          'verified.', [LRow.Source, ASlug]);
+      // The temp discriminator must not depend on a version that may be empty
+      // (evergreen). The sha256 is always present and IS the identity, so a
+      // short prefix of it is the stable temp key.
+      LShortSha := Copy(LEntry.Sha256, 1, 12);
+      LTempDir := TPath.Combine(TPath.GetTempPath,
+        'aefos-addon-' + ASlug + '-' + LShortSha);
+      LTempZip := LTempDir + '.zip';
 
-    // The archive must carry exactly one top-level <slug>\ folder.
-    LBundleDir := TPath.Combine(LTempDir, ASlug);
-    if not TDirectory.Exists(LBundleDir) then
-      raise EAddonIntegrity.CreateFmt(
-        'archive for "%s" has no top-level "%s\" folder.', [ASlug, ASlug]);
+      ALog(Format('Downloading %s %s ...', [ASlug, _VerLabel(LEntry.Version)]));
+      TAddonNet.DownloadFile(LEntry.Url, LTempZip);
+      ALog('Verifying integrity (sha256) ...');
+      TAddonNet.VerifySha256(LTempZip, LEntry.Sha256);
+
+      if TDirectory.Exists(LTempDir) then
+        TDirectory.Delete(LTempDir, True);
+      TAddonNet.ExtractZip(LTempZip, LTempDir);
+
+      // The archive must carry exactly one top-level <slug>\ folder.
+      LBundleDir := TPath.Combine(LTempDir, ASlug);
+      if not TDirectory.Exists(LBundleDir) then
+        raise EAddonIntegrity.CreateFmt(
+          'archive for "%s" has no top-level "%s\" folder.', [ASlug, ASlug]);
+    end;
     // An addon is a directory under a JSON manifest, and Aefos is not the only
     // one packaging that shape. addon.json stays native and keeps priority;
     // when it is absent the bundle may still be a perfectly good agent plugin -
@@ -627,6 +690,9 @@ begin
       LItem.Version := LEntry.Version;
       LItem.Trust := LEntry.Trust;
       LItem.Sha256 := LEntry.Sha256;
+      // Which store it came from, so update returns to the SAME one instead of
+      // whichever store happens to publish the name next time.
+      LItem.Source := LRow.Source;
       LItem.InstalledAt := _NowUtcIso;
       LItem.Artifacts := LArts;
       LItem.Files := LFiles.ToArray;
@@ -648,9 +714,12 @@ begin
       ALog(Format('  /%s is now available in Aefos chat.', [ASlug]));
   finally
     try
-      if TFile.Exists(LTempZip) then
+      // LTempDir is always OURS - a folder bundle was copied into it, never
+      // read in place - so this never reaches into a store. LStoreDir is not
+      // touched here, and must not be.
+      if (LTempZip <> '') and TFile.Exists(LTempZip) then
         TFile.Delete(LTempZip);
-      if TDirectory.Exists(LTempDir) then
+      if (LTempDir <> '') and TDirectory.Exists(LTempDir) then
         TDirectory.Delete(LTempDir, True);
     except
       // best-effort temp cleanup
@@ -691,22 +760,28 @@ class procedure TAddonInstaller.Update(const ASlug: string;
 var
   LItems: TArray<TInstalledAddon>;
   LItem: TInstalledAddon;
-  LRegistry: TArray<TAddonRegistryEntry>;
+  LRow: TAddonCatalogRow;
   LEntry: TAddonRegistryEntry;
+  LOpts: TInstallOptions;
 begin
   LItems := TAddonLedger.Load;
   if not TAddonLedger.TryFind(LItems, ASlug, LItem) then
     raise EAddonNotFound.CreateFmt('addon "%s" is not installed.', [ASlug]);
-  LRegistry := TAddonManifestParser.ParseRegistry(TAddonNet.DownloadText(TAddonNet.RegistryUrl));
-  LEntry := TAddonManifestParser.FindEntry(LRegistry, ASlug); // raises EAddonNotFound
+  LRow := TAddonCatalog.ResolveOne(ASlug, _PreferredSource(AOptions, LItem));
+  LEntry := LRow.Entry;
+  _EnsureIdentity(LEntry);
   case LItem.DecideUpdate(LEntry) of
     uaUpToDate:
       ALog(Format('%s is already current.', [ASlug]));
     uaUpdate:
       begin
         ALog(Format('Updating %s ...', [ASlug]));
-        // Clean-replace at the registry's current build (install re-verifies sha).
-        TAddonInstaller.Install(ASlug, AOptions, ALog);
+        // Clean-replace at the store's current build (install re-verifies sha).
+        // The store is PINNED to the one just resolved: re-resolving inside
+        // Install could land on a different store between the two calls.
+        LOpts := AOptions;
+        LOpts.Source := LRow.Source;
+        TAddonInstaller.Install(ASlug, LOpts, ALog);
       end;
   end;
 end;
@@ -715,10 +790,13 @@ class procedure TAddonInstaller.UpdateAll(const AOptions: TInstallOptions;
   const ALog: TAddonLog);
 var
   LItems: TArray<TInstalledAddon>;
-  LRegistry: TArray<TAddonRegistryEntry>;
+  LResults: TArray<TAddonCatalogResult>;
+  LRow: TAddonCatalogRow;
   LEntry: TAddonRegistryEntry;
+  LOpts: TInstallOptions;
   LIndex, LUpdated, LCurrent: Integer;
   LSlug: string;
+  LResolved: Boolean;
 begin
   LItems := TAddonLedger.Load;
   if Length(LItems) = 0 then
@@ -726,17 +804,29 @@ begin
     ALog('No addons installed.');
     Exit;
   end;
-  LRegistry := TAddonManifestParser.ParseRegistry(TAddonNet.DownloadText(TAddonNet.RegistryUrl));
+  // Every store is read ONCE for the whole run, not once per installed addon.
+  LResults := TAddonCatalog.ReadAll;
   LUpdated := 0;
   LCurrent := 0;
   for LIndex := 0 to High(LItems) do
   begin
     LSlug := LItems[LIndex].Slug;
-    if not _TryFindEntry(LRegistry, LSlug, LEntry) then
-    begin
-      ALog(Format('  ! %s is no longer in the registry - skipped.', [LSlug]));
-      Continue;
+    // One addon that cannot be resolved (store removed, name now ambiguous)
+    // must not take the other twenty with it.
+    LResolved := False;
+    LRow := Default(TAddonCatalogRow);
+    try
+      LRow := TAddonCatalog.Resolve(LResults, LSlug,
+        _PreferredSource(AOptions, LItems[LIndex]));
+      LResolved := True;
+    except
+      on E: EAddonError do
+        ALog(Format('  ! %s: %s - skipped.', [LSlug, E.Message]));
     end;
+    if not LResolved then
+      Continue;
+    LEntry := LRow.Entry;
+    _EnsureIdentity(LEntry);
     case LItems[LIndex].DecideUpdate(LEntry) of
       uaUpToDate:
         begin
@@ -746,7 +836,9 @@ begin
       uaUpdate:
         begin
           ALog(Format('Updating %s ...', [LSlug]));
-          TAddonInstaller.Install(LSlug, AOptions, ALog);
+          LOpts := AOptions;
+          LOpts.Source := LRow.Source;
+          TAddonInstaller.Install(LSlug, LOpts, ALog);
           Inc(LUpdated);
         end;
     end;
@@ -758,17 +850,29 @@ class procedure TAddonInstaller.CheckUpdates(const ASlug: string;
   const ALog: TAddonLog);
 var
   LItems: TArray<TInstalledAddon>;
-  LRegistry: TArray<TAddonRegistryEntry>;
+  LResults: TArray<TAddonCatalogResult>;
   LItem: TInstalledAddon;
   LIndex: Integer;
 
   procedure ReportOne(const AItem: TInstalledAddon);
   var
+    LRow: TAddonCatalogRow;
     LFound: TAddonRegistryEntry;
   begin
-    if not _TryFindEntry(LRegistry, AItem.Slug, LFound) then
-      ALog(Format('%s: no longer in the registry', [AItem.Slug]))
-    else if AItem.DecideUpdate(LFound) = uaUpToDate then
+    // A dry-run reports; it never fails the run. An unresolvable slug is a
+    // finding to print, exactly like "update available" is.
+    try
+      LRow := TAddonCatalog.Resolve(LResults, AItem.Slug, AItem.Source);
+    except
+      on E: EAddonError do
+      begin
+        ALog(Format('%s: %s', [AItem.Slug, E.Message]));
+        Exit;
+      end;
+    end;
+    LFound := LRow.Entry;
+    _EnsureIdentity(LFound);
+    if AItem.DecideUpdate(LFound) = uaUpToDate then
       ALog(Format('%s: current', [AItem.Slug]))
     else
       ALog(Format('%s: update available', [AItem.Slug]));
@@ -776,7 +880,7 @@ var
 
 begin
   LItems := TAddonLedger.Load;
-  LRegistry := TAddonManifestParser.ParseRegistry(TAddonNet.DownloadText(TAddonNet.RegistryUrl));
+  LResults := TAddonCatalog.ReadAll;
   if ASlug <> '' then
   begin
     if not TAddonLedger.TryFind(LItems, ASlug, LItem) then
@@ -814,10 +918,11 @@ begin
     if LItems[LIndex].Artifacts.HasMcp then LKinds := LKinds + 'mcp ';
     if LItems[LIndex].Artifacts.HasTools then LKinds := LKinds + 'tools ';
     // _VerLabel prints "current" for an evergreen (versionless) entry, never a
-    // bare "v".
-    ALog(Format('  %-28s %-11s [%s] %s',
+    // bare "v". The store is shown because with more than one configured, "which
+    // review is this?" is a real question the list has to answer.
+    ALog(Format('  %-28s %-11s [%s] %-10s %s',
       [LItems[LIndex].Slug, _VerLabel(LItems[LIndex].Version),
-       LItems[LIndex].Trust.ToStr, Trim(LKinds)]));
+       LItems[LIndex].Trust.ToStr, LItems[LIndex].Source, Trim(LKinds)]));
   end;
 end;
 

--- a/cli/Aefos.Addons.Ledger.pas
+++ b/cli/Aefos.Addons.Ledger.pas
@@ -75,6 +75,7 @@ begin
   Result.AddPair('trust', AItem.Trust.ToStr);
   Result.AddPair('sha256', AItem.Sha256);
   Result.AddPair('installedAt', AItem.InstalledAt);
+  Result.AddPair('source', AItem.Source);
   Result.AddPair('artifacts', _ArtifactsToJson(AItem.Artifacts));
   LFiles := TJSONArray.Create;
   for LIndex := 0 to High(AItem.Files) do
@@ -138,6 +139,9 @@ begin
   Result.Trust := TAddonTrust.Parse(_Str(AObj, 'trust'));
   Result.Sha256 := _Str(AObj, 'sha256');
   Result.InstalledAt := _Str(AObj, 'installedAt');
+  // Absent in a ledger written before stores existed. Empty means "wherever it
+  // can be found", which is what that older install actually meant.
+  Result.Source := _Str(AObj, 'source');
   LArt := AObj.Values['artifacts'];
   if LArt is TJSONObject then
   begin

--- a/cli/Aefos.Addons.Net.pas
+++ b/cli/Aefos.Addons.Net.pas
@@ -43,6 +43,19 @@ type
     { Lowercase hex SHA-256 of a file's bytes. }
     class function Sha256OfFile(const APath: string): string; static;
 
+    { Lowercase hex SHA-256 of a whole DIRECTORY, so a bundle that arrives as a
+      folder (a path store - a company share) still has the one identity the
+      rest of the system is built on: sha256 is what DecideUpdate compares, and
+      a folder with no sha would read as "changed" on every single run.
+
+      The digest is over a sorted "<relative path> <file sha>" listing, not over
+      concatenated bytes: that way a file MOVED between folders changes the
+      identity, which byte concatenation would miss. Paths are lowercased and
+      slash-normalised (Windows treats those as the same file), and the sort is
+      ORDINAL on purpose - a locale-aware collation would order the listing
+      differently on two machines and invent a difference that is not there. }
+    class function Sha256OfTree(const ADir: string): string; static;
+
     { Verifies AFile's SHA-256 equals AExpected (case-insensitive). Raises
       EAddonIntegrity on mismatch. }
     class procedure VerifySha256(const AFile, AExpected: string); static;
@@ -56,6 +69,7 @@ implementation
 
 uses
   SysUtils,
+  Classes,
   Aefos.Compat.IO,
   Aefos.Compat.Http,
   Aefos.Compat.Sha256,
@@ -167,6 +181,41 @@ end;
 class function TAddonNet.Sha256OfFile(const APath: string): string;
 begin
   Result := TAefosSha256.HexDigestFile(APath);
+end;
+
+// Ordinal comparison, deliberately NOT the locale-aware default: the digest
+// below depends on the ORDER, so two machines with different locales must not
+// sort the same listing differently.
+function _CompareOrdinal(AList: TStringList;
+  AIndex1, AIndex2: Integer): Integer;
+begin
+  Result := CompareStr(AList[AIndex1], AList[AIndex2]);
+end;
+
+class function TAddonNet.Sha256OfTree(const ADir: string): string;
+var
+  LFiles: TArray<string>;
+  LList: TStringList;
+  LIndex, LRootLen: Integer;
+  LRel: string;
+begin
+  if not TDirectory.Exists(ADir) then
+    raise EAddonError.CreateFmt('bundle folder not found: %s', [ADir]);
+  LFiles := TDirectory.GetFiles(ADir, '*', TSearchOption.soAllDirectories);
+  LRootLen := Length(IncludeTrailingPathDelimiter(TPath.GetFullPath(ADir)));
+  LList := TStringList.Create;
+  try
+    for LIndex := 0 to High(LFiles) do
+    begin
+      LRel := Copy(TPath.GetFullPath(LFiles[LIndex]), LRootLen + 1, MaxInt);
+      LRel := LowerCase(StringReplace(LRel, '\', '/', [rfReplaceAll]));
+      LList.Add(LRel + ' ' + TAefosSha256.HexDigestFile(LFiles[LIndex]));
+    end;
+    LList.CustomSort(_CompareOrdinal);
+    Result := TAefosSha256.HexDigest(LList.Text);
+  finally
+    LList.Free;
+  end;
 end;
 
 class procedure TAddonNet.VerifySha256(const AFile, AExpected: string);

--- a/cli/Aefos.Addons.PluginFormat.pas
+++ b/cli/Aefos.Addons.PluginFormat.pas
@@ -1,0 +1,426 @@
+unit Aefos.Addons.PluginFormat;
+{$IFDEF FPC}{$mode delphiunicode}{$ENDIF}
+
+(*
+  Aefos Addons - reading agent-plugin bundles that were not packaged for Aefos.
+
+  WHY. Aefos invented a bundle format (addon.json, contract docs/addons-contract.md)
+  before there was one to adopt. There is one now, and it is the same shape:
+  VS Code ships "agent plugins", Claude Code ships "plugins", and both are a
+  directory of skills, commands, MCP servers and hooks under a small manifest.
+  Keeping a private dialect buys nothing - the packaging was never the thing
+  Aefos is good at - and it costs the ability to install what already exists.
+
+  So this unit teaches the CLI to READ the other formats. VS Code auto-detects
+  four, and they differ only in where two files live:
+
+    Format             Manifest                      MCP config
+    Agent Plugins 1.0  plugin.json ($schema)         mcp.json
+    Copilot            plugin.json                   .mcp.json
+    Claude             .claude-plugin/plugin.json    .mcp.json
+    OpenPlugin (old)   .plugin/plugin.json           -
+
+  skills/ is discovered the same way in all of them. That is why supporting
+  several is a detection table rather than four implementations.
+
+  HOW IT LANDS. The installer already knows one way to place a bundle: the
+  install[] mappings (source directory -> path under ~/.aefos). Rather than
+  teach the installer a second placement engine, this unit ADAPTS a foreign
+  bundle into those mappings - normalising, in a staging folder inside the
+  extracted copy, only the two things the mapping engine cannot express:
+  a per-file command, and an MCP fragment that has to be unwrapped.
+
+  THREE DECISIONS worth stating, because they are not obvious:
+
+  1. The whole foreign tree is copied to ~/.aefos/addons/<slug>/, and THAT is
+     the plugin root. It has to be: an MCP server declared as
+     "${CLAUDE_PLUGIN_ROOT}/servers/db-server" only resolves if the scripts and
+     binaries beside it came along. Placing just the skills would install a
+     plugin whose tools cannot start - the worst kind of half-success.
+
+  2. Skills and commands are NAMESPACED BY SLUG. A plugin brings N of each,
+     Aefos historically had one per addon, and two plugins each shipping a
+     "review" command would otherwise silently overwrite one another.
+     skills/<n> becomes ~/.aefos/skills/<slug>.<n>.
+
+  3. What Aefos has no home for is REPORTED, not dropped in silence. Agents,
+     hooks, LSP servers and monitors are real parts of a plugin; a user whose
+     hook never runs deserves a line saying so at install time rather than a
+     mystery later.
+*)
+
+interface
+
+uses
+  SysUtils,
+  Aefos.Addons.Types;
+
+type
+  { Which bundle layout a directory is in. pfNone means no manifest we know. }
+  TPluginFormat = (pfNone, pfAefos, pfAgentPlugins, pfCopilot, pfClaude,
+    pfOpenPlugin);
+
+  { Called with one human-readable line per adoption decision. }
+{$IFDEF FPC}
+  TPluginFormatLog = procedure(const ALine: string);
+{$ELSE}
+  TPluginFormatLog = reference to procedure(const ALine: string);
+{$ENDIF}
+
+  { Static, sealed namespace: the class IS the namespace, never instantiated. }
+  TAddonPluginFormat = class sealed
+  public
+    { Which format the directory is in, by the documented manifest paths.
+      Aefos's own addon.json wins when present, so nothing about existing
+      bundles changes. }
+    class function Detect(const ABundleDir: string): TPluginFormat; static;
+
+    { Display name for messages ('Claude plugin', 'Agent Plugins 1.0', ...). }
+    class function FormatName(const AFormat: TPluginFormat): string; static;
+
+    { Turns a foreign bundle into a manifest the installer can already place:
+      metadata read from the foreign manifest, install[] mappings synthesised
+      from the layout, artifacts set from what was actually found. Normalises
+      into <bundle>\_aefos, which is inside the temp copy and never shipped.
+      Raises EAddonManifest when the bundle carries nothing installable. }
+    class function Adopt(const ABundleDir, ASlug: string;
+      const AFormat: TPluginFormat;
+      const ALog: TPluginFormatLog): TAddonManifest; static;
+  end;
+
+implementation
+
+uses
+  Classes,
+  IOUtils,
+  Types,
+  Generics.Collections,
+  Aefos.Compat.Json,
+  Aefos.Addons.Paths;
+
+const
+  CStageDir     = '_aefos';    // normalisation staging, inside the temp copy
+  CAgentSchema  = 'agent-plugins.org';
+
+function _ReadTextIfExists(const APath: string): string;
+begin
+  Result := '';
+  if not TFile.Exists(APath) then
+    Exit;
+  try
+    Result := TFile.ReadAllText(APath, TEncoding.UTF8);
+  except
+    Result := '';
+  end;
+end;
+
+function _JsonStr(const AObj: TJSONObject; const AKey: string): string;
+var
+  LVal: TJSONValue;
+begin
+  Result := '';
+  if AObj = nil then
+    Exit;
+  LVal := AObj.Values[AKey];
+  if LVal is TJSONString then
+    Result := TJSONString(LVal).Value;
+end;
+
+{ The manifest path for each format, relative to the bundle root. }
+function _ManifestPath(const ABundleDir: string;
+  const AFormat: TPluginFormat): string;
+begin
+  case AFormat of
+    pfAefos:      Result := TPath.Combine(ABundleDir, 'addon.json');
+    pfClaude:     Result := TPath.Combine(ABundleDir, TPath.Combine('.claude-plugin', 'plugin.json'));
+    pfOpenPlugin: Result := TPath.Combine(ABundleDir, TPath.Combine('.plugin', 'plugin.json'));
+  else
+    // Agent Plugins 1.0 and Copilot share the root manifest name; they are told
+    // apart by $schema, not by path.
+    Result := TPath.Combine(ABundleDir, 'plugin.json');
+  end;
+end;
+
+{ The MCP config, tried in the order the format prefers but accepting either
+  name. Both spellings mean the same file and a bundle in the wild may carry the
+  other one; refusing it would be pedantry paid for by the user. }
+function _FindMcpConfig(const ABundleDir: string;
+  const AFormat: TPluginFormat): string;
+var
+  LFirst, LSecond: string;
+begin
+  if AFormat = pfAgentPlugins then
+  begin
+    LFirst  := TPath.Combine(ABundleDir, 'mcp.json');
+    LSecond := TPath.Combine(ABundleDir, '.mcp.json');
+  end
+  else
+  begin
+    LFirst  := TPath.Combine(ABundleDir, '.mcp.json');
+    LSecond := TPath.Combine(ABundleDir, 'mcp.json');
+  end;
+  if TFile.Exists(LFirst) then
+    Result := LFirst
+  else if TFile.Exists(LSecond) then
+    Result := LSecond
+  else
+    Result := '';
+end;
+
+class function TAddonPluginFormat.Detect(const ABundleDir: string): TPluginFormat;
+var
+  LRoot, LJson: string;
+  LVal: TJSONValue;
+begin
+  // Aefos first: an existing bundle must keep behaving exactly as before.
+  if TFile.Exists(TPath.Combine(ABundleDir, 'addon.json')) then
+    Exit(pfAefos);
+  if TFile.Exists(TPath.Combine(ABundleDir,
+       TPath.Combine('.claude-plugin', 'plugin.json'))) then
+    Exit(pfClaude);
+  LRoot := TPath.Combine(ABundleDir, 'plugin.json');
+  if TFile.Exists(LRoot) then
+  begin
+    // $schema decides between the open standard and Copilot's reading of the
+    // same file name. VS Code does exactly this, and defaults to Copilot.
+    Result := pfCopilot;
+    LJson := _ReadTextIfExists(LRoot);
+    if LJson <> '' then
+    begin
+      LVal := TJSONObject.ParseJSONValue(LJson);
+      try
+        if (LVal is TJSONObject) and
+           (Pos(CAgentSchema, LowerCase(_JsonStr(TJSONObject(LVal), '$schema'))) > 0) then
+          Result := pfAgentPlugins;
+      finally
+        LVal.Free;
+      end;
+    end;
+    Exit;
+  end;
+  if TFile.Exists(TPath.Combine(ABundleDir,
+       TPath.Combine('.plugin', 'plugin.json'))) then
+    Exit(pfOpenPlugin);
+  Result := pfNone;
+end;
+
+class function TAddonPluginFormat.FormatName(
+  const AFormat: TPluginFormat): string;
+begin
+  case AFormat of
+    pfAefos:        Result := 'Aefos addon';
+    pfAgentPlugins: Result := 'Agent Plugins 1.0';
+    pfCopilot:      Result := 'Copilot plugin';
+    pfClaude:       Result := 'Claude plugin';
+    pfOpenPlugin:   Result := 'OpenPlugin (legacy)';
+  else
+    Result := 'unknown';
+  end;
+end;
+
+{ Appends one source -> target pair. }
+procedure _AddMapping(var AList: TArray<TAddonInstallMapping>;
+  const ASource, ATarget: string);
+var
+  LLen: Integer;
+begin
+  LLen := Length(AList);
+  SetLength(AList, LLen + 1);
+  AList[LLen].Source := ASource;
+  AList[LLen].TargetPath := ATarget;
+end;
+
+{ A plugin's own name for a skill/command folder, prefixed with the slug so two
+  plugins shipping the same name cannot collide under ~/.aefos. }
+function _Namespaced(const ASlug, AName: string): string;
+begin
+  Result := ASlug + '.' + AName;
+end;
+
+(* Writes the MCP fragment in the shape Aefos aggregates: a bare object of
+  servers (the aggregate iterates the pairs), with the plugin-root placeholders
+  already resolved to where this addon will actually live. Both spellings are
+  replaced - ${CLAUDE_PLUGIN_ROOT} is what a Claude plugin writes,
+  ${ADDON_ROOT} is what an Aefos addon writes, and they mean the same directory. *)
+function _NormaliseMcp(const ASrcFile, ADstFile, ASlug: string): Boolean;
+var
+  LJson, LOut, LRootAbs: string;
+  LVal, LServers: TJSONValue;
+  LObj: TJSONObject;
+begin
+  Result := False;
+  LJson := _ReadTextIfExists(ASrcFile);
+  if LJson = '' then
+    Exit;
+  LVal := TJSONObject.ParseJSONValue(LJson);
+  try
+    if not (LVal is TJSONObject) then
+      Exit;
+    LObj := TJSONObject(LVal);
+    LServers := LObj.Values['mcpServers'];
+    if LServers is TJSONObject then
+      LOut := TJSONObject(LServers).Format(2)
+    else
+      LOut := LObj.Format(2);   // already a bare server map
+  finally
+    LVal.Free;
+  end;
+  if Trim(LOut) = '' then
+    Exit;
+  LRootAbs := StringReplace(TAddonPaths.AddonDir(ASlug), '\', '\\', [rfReplaceAll]);
+  LOut := StringReplace(LOut, '${CLAUDE_PLUGIN_ROOT}', LRootAbs, [rfReplaceAll]);
+  LOut := StringReplace(LOut, '${ADDON_ROOT}', LRootAbs, [rfReplaceAll]);
+  ForceDirectories(ExtractFilePath(ADstFile));
+  TFile.WriteAllBytes(ADstFile, TEncoding.UTF8.GetBytes(LOut));
+  Result := True;
+end;
+
+{ Reports a component the standard has and Aefos does not, so the user learns it
+  at install time. Silence here is how a plugin comes to look installed while
+  half of it does nothing. }
+procedure _ReportUnsupported(const ABundleDir, ARelPath, AWhat: string;
+  const ALog: TPluginFormatLog);
+var
+  LPath: string;
+begin
+  LPath := TPath.Combine(ABundleDir, ARelPath);
+  if TDirectory.Exists(LPath) or TFile.Exists(LPath) then
+    ALog(Format('  ! %s present but Aefos has no home for it yet - ignored.',
+      [AWhat]));
+end;
+
+class function TAddonPluginFormat.Adopt(const ABundleDir, ASlug: string;
+  const AFormat: TPluginFormat;
+  const ALog: TPluginFormatLog): TAddonManifest;
+var
+  LManifestJson, LStage, LSkillsDir, LCommandsDir, LMcpSrc, LName: string;
+  LDirs, LFiles: TStringDynArray;
+  LIndex: Integer;
+  LVal: TJSONValue;
+  LObj: TJSONObject;
+  LFound: Boolean;
+begin
+  Result := Default(TAddonManifest);
+  Result.Slug := ASlug;
+  Result.Trust := atCommunity;   // a foreign bundle is never "official" to us
+  LFound := False;
+
+  // --- metadata (best effort: the standard makes the manifest optional) -----
+  LManifestJson := _ReadTextIfExists(_ManifestPath(ABundleDir, AFormat));
+  if LManifestJson <> '' then
+  begin
+    LVal := TJSONObject.ParseJSONValue(LManifestJson);
+    try
+      if LVal is TJSONObject then
+      begin
+        LObj := TJSONObject(LVal);
+        Result.Version     := _JsonStr(LObj, 'version');
+        Result.Description := _JsonStr(LObj, 'description');
+        Result.Name        := _JsonStr(LObj, 'displayName');
+        if Result.Name = '' then
+          Result.Name := _JsonStr(LObj, 'name');
+      end;
+    finally
+      LVal.Free;
+    end;
+  end;
+  if Result.Name = '' then
+    Result.Name := ASlug;
+
+  LStage := TPath.Combine(ABundleDir, CStageDir);
+
+  // --- the plugin root itself ----------------------------------------------
+  // Everything, because ${CLAUDE_PLUGIN_ROOT} points here and a bundled script
+  // or binary is reachable only if it travelled with the manifest.
+  _AddMapping(Result.Install, '.', 'addons/' + ASlug);
+  ALog('  + plugin root -> addons/' + ASlug);
+
+  // --- skills ---------------------------------------------------------------
+  LSkillsDir := TPath.Combine(ABundleDir, 'skills');
+  if TDirectory.Exists(LSkillsDir) then
+  begin
+    LDirs := TDirectory.GetDirectories(LSkillsDir);
+    for LIndex := 0 to High(LDirs) do
+    begin
+      if not TFile.Exists(TPath.Combine(LDirs[LIndex], 'SKILL.md')) then
+        Continue;
+      LName := TPath.GetFileName(ExcludeTrailingPathDelimiter(LDirs[LIndex]));
+      _AddMapping(Result.Install, 'skills/' + LName,
+        'skills/' + _Namespaced(ASlug, LName));
+      Result.Artifacts.HasSkill := True;
+      LFound := True;
+      ALog('  + skill    ' + _Namespaced(ASlug, LName));
+    end;
+  end;
+  // A plugin may instead carry a single SKILL.md at its root.
+  if (not Result.Artifacts.HasSkill) and
+     TFile.Exists(TPath.Combine(ABundleDir, 'SKILL.md')) then
+  begin
+    ForceDirectories(TPath.Combine(LStage, TPath.Combine('skills', ASlug)));
+    TFile.Copy(TPath.Combine(ABundleDir, 'SKILL.md'),
+      TPath.Combine(LStage, TPath.Combine('skills',
+        TPath.Combine(ASlug, 'SKILL.md'))), True);
+    _AddMapping(Result.Install, CStageDir + '/skills/' + ASlug, 'skills/' + ASlug);
+    Result.Artifacts.HasSkill := True;
+    LFound := True;
+    ALog('  + skill    ' + ASlug + ' (single SKILL.md at plugin root)');
+  end;
+
+  // --- commands -------------------------------------------------------------
+  // The standard keeps one flat .md per command; Aefos reads one FOLDER per
+  // command holding COMMAND.md, so each file is restaged into that shape. This
+  // is the one thing the mapping engine cannot express, which is why the
+  // staging folder exists at all.
+  LCommandsDir := TPath.Combine(ABundleDir, 'commands');
+  if TDirectory.Exists(LCommandsDir) then
+  begin
+    LFiles := TDirectory.GetFiles(LCommandsDir, '*.md');
+    for LIndex := 0 to High(LFiles) do
+    begin
+      LName := TPath.GetFileNameWithoutExtension(LFiles[LIndex]);
+      if LName = '' then
+        Continue;
+      ForceDirectories(TPath.Combine(LStage,
+        TPath.Combine('commands', _Namespaced(ASlug, LName))));
+      TFile.Copy(LFiles[LIndex],
+        TPath.Combine(LStage, TPath.Combine('commands',
+          TPath.Combine(_Namespaced(ASlug, LName), 'COMMAND.md'))), True);
+      _AddMapping(Result.Install,
+        CStageDir + '/commands/' + _Namespaced(ASlug, LName),
+        'commands/' + _Namespaced(ASlug, LName));
+      Result.Artifacts.HasCommand := True;
+      LFound := True;
+      ALog('  + command  /' + _Namespaced(ASlug, LName));
+    end;
+  end;
+
+  // --- MCP servers ----------------------------------------------------------
+  LMcpSrc := _FindMcpConfig(ABundleDir, AFormat);
+  if LMcpSrc <> '' then
+  begin
+    if _NormaliseMcp(LMcpSrc, TPath.Combine(LStage,
+         TPath.Combine('mcp', 'mcp.json')), ASlug) then
+    begin
+      // Target is the addon dir itself: the mapping engine copies a DIRECTORY,
+      // and the aggregate reads addons/<slug>/mcp.json.
+      _AddMapping(Result.Install, CStageDir + '/mcp', 'addons/' + ASlug);
+      Result.Artifacts.HasMcp := True;
+      LFound := True;
+      ALog('  + mcp      ' + TPath.GetFileName(LMcpSrc) + ' -> addons/' + ASlug + '/mcp.json');
+    end;
+  end;
+
+  // --- what we cannot host yet ---------------------------------------------
+  _ReportUnsupported(ABundleDir, 'agents', 'agents/', ALog);
+  _ReportUnsupported(ABundleDir, 'hooks', 'hooks/', ALog);
+  _ReportUnsupported(ABundleDir, 'hooks.json', 'hooks.json', ALog);
+  _ReportUnsupported(ABundleDir, '.lsp.json', 'LSP servers', ALog);
+  _ReportUnsupported(ABundleDir, 'monitors', 'monitors/', ALog);
+
+  if not LFound then
+    raise EAddonManifest.CreateFmt(
+      'bundle "%s" is a %s but carries no skill, command or MCP server that ' +
+      'Aefos can install.', [ASlug, FormatName(AFormat)]);
+end;
+
+end.

--- a/cli/Aefos.Addons.PluginFormat.pas
+++ b/cli/Aefos.Addons.PluginFormat.pas
@@ -78,6 +78,12 @@ type
     { Display name for messages ('Claude plugin', 'Agent Plugins 1.0', ...). }
     class function FormatName(const AFormat: TPluginFormat): string; static;
 
+    { Where that format keeps its manifest, so a catalogue can read a bundle's
+      name and version without adopting it. Exposed rather than duplicated: the
+      point of a detection table is that it exists in one place. }
+    class function ManifestPathOf(const ABundleDir: string;
+      const AFormat: TPluginFormat): string; static;
+
     { Turns a foreign bundle into a manifest the installer can already place:
       metadata read from the foreign manifest, install[] mappings synthesised
       from the layout, artifacts set from what was actually found. Normalises
@@ -165,6 +171,12 @@ begin
     Result := LSecond
   else
     Result := '';
+end;
+
+class function TAddonPluginFormat.ManifestPathOf(const ABundleDir: string;
+  const AFormat: TPluginFormat): string;
+begin
+  Result := _ManifestPath(ABundleDir, AFormat);
 end;
 
 class function TAddonPluginFormat.Detect(const ABundleDir: string): TPluginFormat;

--- a/cli/Aefos.Addons.Sources.pas
+++ b/cli/Aefos.Addons.Sources.pas
@@ -1,0 +1,241 @@
+unit Aefos.Addons.Sources;
+{$IFDEF FPC}{$mode delphiunicode}{$ENDIF}
+
+(*
+  Aefos Addons - where the catalogue comes from.
+
+  Until now there was exactly one place to install from: the Aefos gallery, its
+  URL compiled in. That is fine for a hobby install and useless at a company,
+  which keeps its own bundles in its own repository and cannot publish them to
+  a public gallery to use them.
+
+  So the sources are a LIST, not a setting. The official gallery and a private
+  store are not alternatives - a user wants both at once, and each row in the
+  catalogue remembers which store it came from. That is also what removes the
+  ambiguity a single flat namespace would create: two stores may each ship a
+  "review" addon, and with the source recorded they are simply two rows, not a
+  collision to guess about.
+
+  ONE FILE, TWO READERS. sources.json lives under ~/.aefos, which the CLI already
+  owns and creates. Tools -> Options writes it and this reads it: the same bytes,
+  no second copy of the truth to drift. It is deliberately NOT part of the shared
+  config.json - that file already has two writers, and a third would be asking
+  for the lossy-write bug we have already paid for once.
+
+  KINDS. A source says how to READ AN INDEX, not what format the bundles are in;
+  bundle format is measured from the bundle itself (Aefos.Addons.PluginFormat).
+
+    aefos  - a registry.json in the Aefos gallery shape, fetched over HTTP.
+    path   - a folder on disk (or a UNC share). Every subfolder carrying a
+             manifest we recognise is one entry. A company share is a store.
+    git    - a repository index fetched over HTTP. Kept in the enum so the
+             config format does not have to change when it lands, and reported
+             honestly as unsupported until then rather than failing obscurely.
+
+  Absent file = the gallery alone, which is exactly today's behaviour. Nobody
+  has to configure anything to keep what they already had.
+*)
+
+interface
+
+uses
+  SysUtils,
+  Aefos.Addons.Types;
+
+type
+  { How a source's index is read. Not the bundle format - that is measured. }
+  TAddonSourceKind = (askAefos, askPath, askGit);
+
+  { One configured store. }
+  TAddonSource = record
+    Name: string;      // short id, used by --source and shown in the catalogue
+    Kind: TAddonSourceKind;
+    Location: string;  // URL for aefos/git, directory for path
+    Enabled: Boolean;
+  end;
+
+  { One row of the merged catalogue: a registry entry plus where it came from. }
+  TAddonCatalogRow = record
+    Source: string;
+    Entry: TAddonRegistryEntry;
+  end;
+
+  { Static, sealed namespace; never instantiated. }
+  TAddonSources = class sealed
+  public
+    { Absolute path of sources.json (it may not exist). }
+    class function ConfigPath: string; static;
+
+    { The configured sources. A missing or unreadable file yields the single
+      built-in gallery, so the CLI keeps working with no configuration at all. }
+    class function Load: TArray<TAddonSource>; static;
+
+    { Writes the list. Used by `aefos source add/remove` and, later, by the
+      Options page - both go through here so the file has one writer shape. }
+    class procedure Save(const ASources: TArray<TAddonSource>); static;
+
+    { The built-in gallery row, which Load returns when nothing is configured.
+      Named Builtin rather than Default because Default() is an intrinsic: inside
+      the method the compiler resolved Default(TAddonSource) to the method itself. }
+    class function Builtin: TAddonSource; static;
+
+    { Parses "aefos"/"path"/"git"; anything else raises, because a source whose
+      kind we guessed would read the wrong thing silently. }
+    class function ParseKind(const AValue: string): TAddonSourceKind; static;
+    class function KindToStr(const AKind: TAddonSourceKind): string; static;
+  end;
+
+implementation
+
+uses
+  Classes,
+  IOUtils,
+  Aefos.Compat.Json,
+  Aefos.Compat.JsonFormat,
+  Aefos.Addons.Paths;
+
+const
+  CFileName = 'sources.json';
+  CDefaultName = 'aefos';
+
+class function TAddonSources.ConfigPath: string;
+begin
+  Result := TPath.Combine(TAddonPaths.UserRoot, CFileName);
+end;
+
+class function TAddonSources.KindToStr(const AKind: TAddonSourceKind): string;
+begin
+  case AKind of
+    askPath: Result := 'path';
+    askGit:  Result := 'git';
+  else
+    Result := 'aefos';
+  end;
+end;
+
+class function TAddonSources.ParseKind(const AValue: string): TAddonSourceKind;
+begin
+  if SameText(AValue, 'aefos') or (AValue = '') then
+    Result := askAefos
+  else if SameText(AValue, 'path') then
+    Result := askPath
+  else if SameText(AValue, 'git') then
+    Result := askGit
+  else
+    raise EAddonManifest.CreateFmt(
+      'unknown source kind "%s" in %s (use aefos, path or git).',
+      [AValue, ConfigPath]);
+end;
+
+class function TAddonSources.Builtin: TAddonSource;
+begin
+  Result := Default(TAddonSource);
+  Result.Name := CDefaultName;
+  Result.Kind := askAefos;
+  Result.Location := '';    // empty => TAddonNet.RegistryUrl, the built-in one
+  Result.Enabled := True;
+end;
+
+function _Str(const AObj: TJSONObject; const AKey: string): string;
+var
+  LVal: TJSONValue;
+begin
+  Result := '';
+  if AObj = nil then
+    Exit;
+  LVal := AObj.Values[AKey];
+  if LVal is TJSONString then
+    Result := TJSONString(LVal).Value;
+end;
+
+function _BoolOrTrue(const AObj: TJSONObject; const AKey: string): Boolean;
+var
+  LVal: TJSONValue;
+begin
+  // Absent means enabled: a source someone bothered to add is on unless they
+  // said otherwise, and a typo in the key must not silently hide a store.
+  Result := True;
+  if AObj = nil then
+    Exit;
+  LVal := AObj.Values[AKey];
+  if LVal is TJSONBool then
+    Result := TJSONBool(LVal).AsBoolean;
+end;
+
+class function TAddonSources.Load: TArray<TAddonSource>;
+var
+  LPath, LText: string;
+  LVal, LListVal: TJSONValue;
+  LArr: TJSONArray;
+  LObj: TJSONObject;
+  LIndex, LCount: Integer;
+begin
+  SetLength(Result, 0);
+  LPath := ConfigPath;
+  if not TFile.Exists(LPath) then
+    Exit(TArray<TAddonSource>.Create(Builtin));
+  try
+    LText := TFile.ReadAllText(LPath, TEncoding.UTF8);
+  except
+    Exit(TArray<TAddonSource>.Create(Builtin));
+  end;
+  LVal := TJSONObject.ParseJSONValue(LText);
+  try
+    if not (LVal is TJSONObject) then
+      Exit(TArray<TAddonSource>.Create(Builtin));
+    LListVal := TJSONObject(LVal).Values['sources'];
+    if not (LListVal is TJSONArray) then
+      Exit(TArray<TAddonSource>.Create(Builtin));
+    LArr := TJSONArray(LListVal);
+    LCount := 0;
+    SetLength(Result, LArr.Count);
+    for LIndex := 0 to LArr.Count - 1 do
+    begin
+      if not (LArr.Items[LIndex] is TJSONObject) then
+        Continue;
+      LObj := TJSONObject(LArr.Items[LIndex]);
+      Result[LCount].Name := _Str(LObj, 'name');
+      if Result[LCount].Name = '' then
+        Continue;                       // a nameless store cannot be referred to
+      Result[LCount].Kind := ParseKind(_Str(LObj, 'kind'));
+      Result[LCount].Location := _Str(LObj, 'location');
+      if Result[LCount].Location = '' then
+        Result[LCount].Location := _Str(LObj, 'url');   // friendlier alias
+      Result[LCount].Enabled := _BoolOrTrue(LObj, 'enabled');
+      Inc(LCount);
+    end;
+    SetLength(Result, LCount);
+  finally
+    LVal.Free;
+  end;
+  if Length(Result) = 0 then
+    Result := TArray<TAddonSource>.Create(Builtin);
+end;
+
+class procedure TAddonSources.Save(const ASources: TArray<TAddonSource>);
+var
+  LRoot, LItem: TJSONObject;
+  LArr: TJSONArray;
+  LIndex: Integer;
+begin
+  LRoot := TJSONObject.Create;
+  try
+    LArr := TJSONArray.Create;
+    LRoot.AddPair('sources', LArr);
+    for LIndex := 0 to High(ASources) do
+    begin
+      LItem := TJSONObject.Create;
+      LItem.AddPair('name', ASources[LIndex].Name);
+      LItem.AddPair('kind', KindToStr(ASources[LIndex].Kind));
+      LItem.AddPair('location', ASources[LIndex].Location);
+      LItem.AddPair('enabled', TJSONBool.Create(ASources[LIndex].Enabled));
+      LArr.AddElement(LItem);
+    end;
+    ForceDirectories(TAddonPaths.UserRoot);
+    TFile.WriteAllBytes(ConfigPath, TEncoding.UTF8.GetBytes(LRoot.Format(2)));
+  finally
+    LRoot.Free;
+  end;
+end;
+
+end.

--- a/cli/Aefos.Addons.Types.pas
+++ b/cli/Aefos.Addons.Types.pas
@@ -98,6 +98,12 @@ type
     Trust: TAddonTrust;
     Sha256: string;
     InstalledAt: string;    // ISO-8601 UTC
+    { Which configured store this came from. Recorded so update goes back to the
+      SAME store: with two stores a bare slug stops being an identity, and an
+      update that silently switched a company addon for a same-named gallery one
+      would be a supply-chain swap performed by us. Empty on a ledger written
+      before sources existed, which reads as "wherever it can be found". }
+    Source: string;
     Artifacts: TAddonArtifacts;
     Files: TArray<string>;
     Roots: TArray<string>;  // absolute ~/.aefos target dirs to remove on uninstall

--- a/cli/aefos.dpr
+++ b/cli/aefos.dpr
@@ -1,4 +1,4 @@
-program aefos;
+﻿program aefos;
 {$IFDEF FPC}{$mode delphiunicode}{$ENDIF}
 
 {$APPTYPE CONSOLE}
@@ -32,6 +32,8 @@ uses
   Aefos.Addons.Paths in 'Aefos.Addons.Paths.pas',
   Aefos.Addons.Manifest in 'Aefos.Addons.Manifest.pas',
   Aefos.Addons.PluginFormat in 'Aefos.Addons.PluginFormat.pas',
+  Aefos.Addons.Sources in 'Aefos.Addons.Sources.pas',
+  Aefos.Addons.Catalog in 'Aefos.Addons.Catalog.pas',
   Aefos.Addons.Ledger in 'Aefos.Addons.Ledger.pas',
   Aefos.Addons.Net in 'Aefos.Addons.Net.pas',
   Aefos.Addons.Installer in 'Aefos.Addons.Installer.pas',
@@ -54,6 +56,7 @@ var
   GArgv: TArray<string>;
   GArgs: TAddonCliArgs;
   GOpts: TInstallOptions;
+  GCatalog: TArray<TAddonCatalogResult>;
   LIndex: Integer;
 
 procedure Log(const ALine: string);
@@ -71,6 +74,8 @@ begin
   Writeln('  aefos uninstall <slug>         remove an installed addon');
   Writeln('  aefos update [<slug>] [--check]  refresh changed addons (no slug = all)');
   Writeln('  aefos list                     list installed addons');
+  Writeln('  aefos catalog [--json]         what can be installed, from every source');
+  Writeln('  aefos sources                  the configured stores');
   Writeln('');
   Writeln('Options:');
   Writeln('  -y, --yes            consent to third-party code (mcp/tools) up front');
@@ -80,6 +85,52 @@ begin
   Writeln('  -v, --version        version');
   Writeln('');
   Writeln('Addons install under ~/.aefos (commands, skills, addons).');
+end;
+
+procedure PrintSources;
+var
+  LSources: TArray<TAddonSource>;
+  LIndex: Integer;
+  LWhere: string;
+begin
+  LSources := TAddonSources.Load;
+  Writeln('Sources (', TAddonSources.ConfigPath, '):');
+  for LIndex := 0 to High(LSources) do
+  begin
+    LWhere := LSources[LIndex].Location;
+    if Trim(LWhere) = '' then
+      LWhere := '(built-in gallery)';
+    if not LSources[LIndex].Enabled then
+      LWhere := LWhere + '   (disabled)';
+    Writeln(Format('  %-12s %-6s %s', [LSources[LIndex].Name,
+      TAddonSources.KindToStr(LSources[LIndex].Kind), LWhere]));
+  end;
+end;
+
+// The human view of the catalogue. --json is the one the IDE dialog reads; this
+// is for the person at a prompt, and it prints the SOURCE first because with
+// more than one store the name alone stops identifying anything.
+procedure PrintCatalog(const AResults: TArray<TAddonCatalogResult>);
+var
+  LI, LJ, LTotal: Integer;
+begin
+  LTotal := 0;
+  for LI := 0 to High(AResults) do
+  begin
+    if AResults[LI].Error <> '' then
+    begin
+      Writeln(Format('  ! %s: %s', [AResults[LI].Source.Name, AResults[LI].Error]));
+      Continue;
+    end;
+    for LJ := 0 to High(AResults[LI].Rows) do
+    begin
+      Writeln(Format('  %-10s %-22s %-10s %s', [AResults[LI].Rows[LJ].Source,
+        AResults[LI].Rows[LJ].Entry.Slug, AResults[LI].Rows[LJ].Entry.Version,
+        AResults[LI].Rows[LJ].Entry.Name]));
+      Inc(LTotal);
+    end;
+  end;
+  Writeln(Format('%d addon(s) available.', [LTotal]));
 end;
 
 function AefosVersion: string;
@@ -141,6 +192,15 @@ begin
           TAddonInstaller.Update(GArgs.Slug, GOpts, Log);
       acUninstall: TAddonInstaller.Uninstall(GArgs.Slug, Log);
       acList:    TAddonInstaller.List(Log);
+      acSources: PrintSources;
+      acCatalog:
+        begin
+          GCatalog := TAddonCatalog.ReadAll;
+          if GArgs.Json then
+            Writeln(TAddonCatalog.ToJson(GCatalog))
+          else
+            PrintCatalog(GCatalog);
+        end;
     end;
     Halt(0);
   except

--- a/cli/aefos.dpr
+++ b/cli/aefos.dpr
@@ -31,6 +31,7 @@ uses
   Aefos.Addons.Types in 'Aefos.Addons.Types.pas',
   Aefos.Addons.Paths in 'Aefos.Addons.Paths.pas',
   Aefos.Addons.Manifest in 'Aefos.Addons.Manifest.pas',
+  Aefos.Addons.PluginFormat in 'Aefos.Addons.PluginFormat.pas',
   Aefos.Addons.Ledger in 'Aefos.Addons.Ledger.pas',
   Aefos.Addons.Net in 'Aefos.Addons.Net.pas',
   Aefos.Addons.Installer in 'Aefos.Addons.Installer.pas',

--- a/cli/aefos.dpr
+++ b/cli/aefos.dpr
@@ -80,6 +80,7 @@ begin
   Writeln('Options:');
   Writeln('  -y, --yes            consent to third-party code (mcp/tools) up front');
   Writeln('  --check              dry-run: report what would update, install nothing');
+  Writeln('  --source <name>      take the addon from THAT store (see: aefos sources)');
   Writeln('  --registry <url>     override the registry URL');
   Writeln('  -h, --help           this help');
   Writeln('  -v, --version        version');
@@ -179,7 +180,7 @@ begin
       SetEnvironmentVariable('AEFOS_ADDONS_REGISTRY', PChar(GArgs.Registry));
       {$ENDIF}
 
-    GOpts := TInstallOptions.Create(GArgs.Yes, AefosVersion);
+    GOpts := TInstallOptions.Create(GArgs.Yes, AefosVersion, GArgs.Source);
 
     case GArgs.Command of
       acInstall: TAddonInstaller.Install(GArgs.Slug, GOpts, Log);


### PR DESCRIPTION
The engine behind the addon store dialog that will open from Aefos chat: the CLI
learns to read bundles somebody else packaged, to list more than one store, and
to install from the store the user actually meant.

Three commits, each true on its own.

**1. Read a bundle packaged by somebody else.** An addon is a directory under a
JSON manifest, and Aefos is not the only one packaging that shape. VS Code ships
"agent plugins", Claude Code ships "plugins" — same object, different word. The
four formats differ only in where two files sit, so support is a detection table,
not four implementations. `addon.json` stays native and keeps priority; every
existing bundle behaves exactly as before.

**2. More than one store.** A compiled-in URL is fine for a hobby install and
useless at a company, which keeps its bundles in its own repository and cannot
publish them publicly in order to use them. Sources are a list in
`~/.aefos/sources.json` — the file Tools ▸ Options will write and this reads,
same bytes, deliberately NOT inside `config.json`, which already has two writers.
`aefos catalog [--json]` and `aefos sources`. A store that is down becomes an
entry in `errors`, never an exception: one unreachable store and an empty dialog
looks exactly like "there is nothing to install".

**3. Install from the store the user chose.** Until this commit the catalogue
could list every store and install could reach none of them — the button in the
dialog would only have worked for some of the rows it displayed. Resolution now
goes through the catalogue, the store is recorded in the ledger so `update`
returns to the same one, and ambiguity is refused rather than guessed.

Two findings worth naming, both caught by running it:

- Adopting a foreign bundle **stages into `<bundle>\_aefos\`**, so installing a
  folder in place would write into somebody else's store — fatal on a read-only
  share. Folder bundles are now copied into temp and read there.
- That same write changed the tree the identity was measured from, so a
  freshly installed addon reported "update available" on the very next command.
  The proof caught it; the fix is above.

## Proof

Ten scenarios against a sandbox `%USERPROFILE%`, so no real `~/.aefos` was
touched: two formats installed from a folder store with no download, `list`
showing the store, `--check` current with nothing touched, one file changed and
the next `--check` seeing exactly that, a duplicate slug refused and then
resolved with `--source`, a down store leaving the catalogue standing and its
failure quoted inside the not-found message. The store folders were byte-checked
afterwards — nothing written into them.

Regression against the real gallery: `janus-orm` downloaded, sha verified,
installed, and reported current — the old path, unchanged, now naming its source.

## What is NOT in this PR

The dialog itself. It is a WebView2 page fed by `aefos catalog --json`, with the
Install button spawning `aefos.exe`, hosted in a one-control form — which is
Designer work, so it goes in live with the IDE open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)