### PR TITLE
The addon store page, and the two answers it needs from the CLI

### DIFF
--- a/cli/Aefos.Addons.Catalog.pas
+++ b/cli/Aefos.Addons.Catalog.pas
@@ -69,6 +69,15 @@ type
 
     { Resolve over a freshly read catalogue - the single-shot form. }
     class function ResolveOne(const ASlug, APreferSource: string): TAddonCatalogRow; static;
+
+    { Gives an entry the sha256 the rest of the system compares, when the store
+      published none. Only a FOLDER bundle can be in that position - it is a
+      directory, not a release - and the answer is measured from the tree.
+
+      Lives here rather than in the installer because the catalogue needs the
+      same answer to say whether an installed addon is current, and one
+      measurement with two owners is how the two drift apart. }
+    class procedure EnsureIdentity(var AEntry: TAddonRegistryEntry); static;
   end;
 
 implementation
@@ -80,6 +89,7 @@ uses
   Aefos.Compat.Json,
   Aefos.Compat.JsonFormat,
   Aefos.Addons.Manifest,
+  Aefos.Addons.Ledger,
   Aefos.Addons.Net,
   Aefos.Addons.PluginFormat;
 
@@ -114,6 +124,17 @@ begin
   AEntry.Url := ADir;                       // a path store installs from disk
   AEntry.Trust := atCommunity;              // never "official" unless we said so
   AEntry.Name := AEntry.Slug;
+  // A folder store has no registry to declare a type, so the type is MEASURED
+  // from what the bundle actually carries - the same instinct as everywhere
+  // else here. An MCP config makes it an MCP server, a tools folder makes it
+  // tools, and anything else is a plain addon.
+  if TAddonPluginFormat.McpConfigPathOf(ADir, LFormat) <> '' then
+    AEntry.Kind := akMcp
+  else if TDirectory.Exists(TPath.Combine(ADir, 'tools')) then
+    AEntry.Kind := akTool
+  else
+    AEntry.Kind := akCommand;
+  AEntry.KindName := AEntry.Kind.ToStr;
   LJson := '';
   try
     if TFile.Exists(TAddonPluginFormat.ManifestPathOf(ADir, LFormat)) then
@@ -291,13 +312,68 @@ begin
   Result := Resolve(ReadAll, ASlug, APreferSource);
 end;
 
+class procedure TAddonCatalog.EnsureIdentity(var AEntry: TAddonRegistryEntry);
+begin
+  if (Trim(AEntry.Sha256) = '') and TDirectory.Exists(AEntry.Url) then
+    AEntry.Sha256 := TAddonNet.Sha256OfTree(AEntry.Url);
+end;
+
+// The button's own answer: available / installed / update. Computed here and
+// not in the dialog, because deciding it needs the sha comparison and a folder
+// bundle's MEASURED identity - logic that must not exist twice.
+//
+// The identity is measured only for rows that are actually installed, so the
+// cost is bounded by what the user has rather than by how big the store is.
+procedure _AddState(const AObj: TJSONObject;
+  const AInstalled: TArray<TInstalledAddon>; const ARow: TAddonCatalogRow);
+var
+  LIndex: Integer;
+  LItem: TInstalledAddon;
+  LEntry: TAddonRegistryEntry;
+  LHit: Boolean;
+begin
+  LHit := False;
+  LItem := Default(TInstalledAddon);
+  for LIndex := 0 to High(AInstalled) do
+  begin
+    if not SameText(AInstalled[LIndex].Slug, ARow.Entry.Slug) then
+      Continue;
+    // Slug alone is not identity once there are stores: the same name in two
+    // stores is two different addons, and only the one actually installed may
+    // claim the row. An empty recorded source is a pre-stores ledger, which
+    // matched by slug and still does.
+    if (AInstalled[LIndex].Source <> '') and
+       not SameText(AInstalled[LIndex].Source, ARow.Source) then
+      Continue;
+    LItem := AInstalled[LIndex];
+    LHit := True;
+    Break;
+  end;
+  AObj.AddPair('installed', TJSONBool.Create(LHit));
+  if not LHit then
+  begin
+    AObj.AddPair('state', 'available');
+    Exit;
+  end;
+  AObj.AddPair('installedVersion', LItem.Version);
+  LEntry := ARow.Entry;
+  TAddonCatalog.EnsureIdentity(LEntry);
+  if LItem.DecideUpdate(LEntry) = uaUpToDate then
+    AObj.AddPair('state', 'installed')
+  else
+    AObj.AddPair('state', 'update');
+end;
+
 class function TAddonCatalog.ToJson(
   const AResults: TArray<TAddonCatalogResult>): string;
 var
   LRoot, LObj: TJSONObject;
   LAddons, LErrors: TJSONArray;
+  LInstalled: TArray<TInstalledAddon>;
+  LEntry: TAddonRegistryEntry;
   LI, LJ: Integer;
 begin
+  LInstalled := TAddonLedger.Load;
   LRoot := TJSONObject.Create;
   try
     LAddons := TJSONArray.Create;
@@ -316,13 +392,21 @@ begin
       end;
       for LJ := 0 to High(AResults[LI].Rows) do
       begin
+        LEntry := AResults[LI].Rows[LJ].Entry;
         LObj := TJSONObject.Create;
         LObj.AddPair('source', AResults[LI].Rows[LJ].Source);
-        LObj.AddPair('slug', AResults[LI].Rows[LJ].Entry.Slug);
-        LObj.AddPair('name', AResults[LI].Rows[LJ].Entry.Name);
-        LObj.AddPair('version', AResults[LI].Rows[LJ].Entry.Version);
-        LObj.AddPair('description', AResults[LI].Rows[LJ].Entry.Description);
-        LObj.AddPair('trust', AResults[LI].Rows[LJ].Entry.Trust.ToStr);
+        LObj.AddPair('slug', LEntry.Slug);
+        LObj.AddPair('name', LEntry.Name);
+        LObj.AddPair('version', LEntry.Version);
+        LObj.AddPair('description', LEntry.Description);
+        LObj.AddPair('trust', LEntry.Trust.ToStr);
+        // The type as the store spelled it: the dialog builds one group per
+        // distinct value, so a store publishing a type nobody has seen gets a
+        // group of its own with nothing here to change.
+        LObj.AddPair('kind', LEntry.KindName);
+        // What the user would see on the button. Answering it HERE means the
+        // dialog makes one call and never has to reconcile two lists itself.
+        _AddState(LObj, LInstalled, AResults[LI].Rows[LJ]);
         LAddons.AddElement(LObj);
       end;
     end;

--- a/cli/Aefos.Addons.Installer.pas
+++ b/cli/Aefos.Addons.Installer.pas
@@ -242,11 +242,11 @@ end;
 // A folder bundle publishes no sha - it is a directory, not a release - so one
 // is MEASURED before any comparison. Without this every update run would find
 // an empty sha against a recorded one, call it "changed", and reinstall an
-// addon that has not moved.
+// addon that has not moved. The measurement itself lives on the catalogue,
+// which needs the same answer to say whether a row is current.
 procedure _EnsureIdentity(var AEntry: TAddonRegistryEntry);
 begin
-  if (Trim(AEntry.Sha256) = '') and TDirectory.Exists(AEntry.Url) then
-    AEntry.Sha256 := TAddonNet.Sha256OfTree(AEntry.Url);
+  TAddonCatalog.EnsureIdentity(AEntry);
 end;
 
 // Recursively copies ASrcDir into ADstDir, appending every written file to

--- a/cli/Aefos.Addons.Manifest.pas
+++ b/cli/Aefos.Addons.Manifest.pas
@@ -85,6 +85,11 @@ begin
   Result.Version := _Str(AObj, 'version');
   Result.Description := _Str(AObj, 'description');
   Result.Kind := TAddonKind.Parse(_Str(AObj, 'type'));
+  // Kept as the store wrote it, so a type this build has never heard of still
+  // reaches the UI under its own name instead of Parse's akCommand fallback.
+  Result.KindName := LowerCase(Trim(_Str(AObj, 'type')));
+  if Result.KindName = '' then
+    Result.KindName := Result.Kind.ToStr;
   Result.Trust := TAddonTrust.Parse(_Str(AObj, 'trust'));
   Result.Url := _Str(AObj, 'url');
   Result.Sha256 := LowerCase(Trim(_Str(AObj, 'sha256')));

--- a/cli/Aefos.Addons.PluginFormat.pas
+++ b/cli/Aefos.Addons.PluginFormat.pas
@@ -84,6 +84,13 @@ type
     class function ManifestPathOf(const ABundleDir: string;
       const AFormat: TPluginFormat): string; static;
 
+    { Where that format keeps its MCP config, or '' when it carries none - so a
+      catalogue can tell what TYPE a bundle is without adopting it. Exposed for
+      the same reason as ManifestPathOf: a detection table that gets copied is
+      no longer a table. }
+    class function McpConfigPathOf(const ABundleDir: string;
+      const AFormat: TPluginFormat): string; static;
+
     { Turns a foreign bundle into a manifest the installer can already place:
       metadata read from the foreign manifest, install[] mappings synthesised
       from the layout, artifacts set from what was actually found. Normalises
@@ -177,6 +184,12 @@ class function TAddonPluginFormat.ManifestPathOf(const ABundleDir: string;
   const AFormat: TPluginFormat): string;
 begin
   Result := _ManifestPath(ABundleDir, AFormat);
+end;
+
+class function TAddonPluginFormat.McpConfigPathOf(const ABundleDir: string;
+  const AFormat: TPluginFormat): string;
+begin
+  Result := _FindMcpConfig(ABundleDir, AFormat);
 end;
 
 class function TAddonPluginFormat.Detect(const ABundleDir: string): TPluginFormat;

--- a/cli/Aefos.Addons.Types.pas
+++ b/cli/Aefos.Addons.Types.pas
@@ -65,6 +65,12 @@ type
     Version: string;
     Description: string;
     Kind: TAddonKind;
+    { The type as the STORE spelled it, kept beside the parsed enum on purpose.
+      Kind.Parse folds anything it does not know into akCommand, which is right
+      for behaviour and wrong for display: a store that starts publishing a new
+      type would have it silently filed under an old one. The UI groups by this
+      string, so a new type becomes a new group with nothing here to rebuild. }
+    KindName: string;
     Trust: TAddonTrust;
     Url: string;            // the versioned .zip
     Sha256: string;         // lowercase hex of the .zip

--- a/source/chat/UI/assets/addon-store.html
+++ b/source/chat/UI/assets/addon-store.html
@@ -1,0 +1,322 @@
+<meta charset="utf-8">
+<title>Aefos Addons</title>
+<style>
+  /* The IDE decides light or dark; every colour is a variable so the host can
+     hand us its own palette without this file knowing which theme it is in. */
+  :root {
+    --bg:        #1e1e1e;
+    --fg:        #e7e7e7;
+    --muted:     #9a9a9a;
+    --line:      #333333;
+    --panel:     #252526;
+    --accent:    #2f6fd0;
+    --accent-fg: #ffffff;
+    --ok:        #4a9a58;
+    --warn:      #c98a2b;
+    --err:       #d05a5a;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    background: var(--bg); color: var(--fg);
+    font: 13px/1.45 "Segoe UI", system-ui, sans-serif;
+    display: flex; flex-direction: column; overflow: hidden;
+  }
+
+  /* ---- header: search + store filter + refresh ------------------------- */
+  header { padding: 10px 12px 0; flex: 0 0 auto; }
+  .row1 { display: flex; gap: 8px; align-items: center; }
+  input[type=search], select {
+    background: var(--panel); color: var(--fg);
+    border: 1px solid var(--line); border-radius: 4px;
+    padding: 5px 8px; font: inherit; outline: none;
+  }
+  input[type=search] { flex: 1 1 auto; }
+  input[type=search]:focus, select:focus { border-color: var(--accent); }
+  .iconbtn {
+    background: transparent; color: var(--muted); border: 1px solid transparent;
+    border-radius: 4px; padding: 4px 8px; cursor: pointer; font: inherit;
+  }
+  .iconbtn:hover { color: var(--fg); border-color: var(--line); }
+
+  /* ---- tabs: one per TYPE, built from the data ------------------------- */
+  nav {
+    display: flex; gap: 2px; margin-top: 10px;
+    border-bottom: 1px solid var(--line);
+  }
+  nav button {
+    background: none; border: none; border-bottom: 2px solid transparent;
+    color: var(--muted); font: inherit; padding: 7px 12px; cursor: pointer;
+    white-space: nowrap;
+  }
+  nav button:hover { color: var(--fg); }
+  nav button[aria-selected=true] { color: var(--fg); border-bottom-color: var(--accent); }
+  nav .count { color: var(--muted); font-size: 11px; margin-left: 5px; }
+
+  /* ---- the list -------------------------------------------------------- */
+  main { flex: 1 1 auto; overflow-y: auto; padding: 4px 0 12px; }
+  .item {
+    display: flex; align-items: flex-start; gap: 12px;
+    padding: 9px 12px; border-bottom: 1px solid var(--line);
+  }
+  .item:hover { background: var(--panel); }
+  .meta { flex: 1 1 auto; min-width: 0; }
+  .name { font-weight: 600; }
+  .desc, .sub {
+    color: var(--muted); font-size: 12px;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .sub { font-size: 11px; margin-top: 1px; }
+  .act { flex: 0 0 auto; display: flex; align-items: center; gap: 6px; padding-top: 2px; }
+  button.primary {
+    background: var(--accent); color: var(--accent-fg); border: none;
+    border-radius: 3px; padding: 4px 12px; font: inherit; cursor: pointer;
+  }
+  button.primary:hover { filter: brightness(1.12); }
+  button.ghost {
+    background: transparent; color: var(--muted);
+    border: 1px solid var(--line); border-radius: 3px;
+    padding: 3px 9px; font: inherit; cursor: pointer;
+  }
+  button.ghost:hover { color: var(--fg); }
+  button:disabled { opacity: .55; cursor: default; filter: none; }
+  .done { color: var(--ok); font-size: 12px; }
+
+  .banner {
+    margin: 8px 12px 0; padding: 7px 10px; border-radius: 4px;
+    border: 1px solid var(--warn); color: var(--warn); font-size: 12px;
+  }
+  .empty { color: var(--muted); padding: 28px 12px; text-align: center; }
+
+  /* ---- the log strip, only while something is running ------------------ */
+  #log {
+    flex: 0 0 auto; max-height: 34vh; overflow-y: auto; display: none;
+    border-top: 1px solid var(--line); background: var(--panel);
+    padding: 8px 12px; font-family: Consolas, "Cascadia Mono", monospace;
+    font-size: 12px; white-space: pre-wrap;
+  }
+  #log.on { display: block; }
+  #log .bad { color: var(--err); }
+</style>
+
+<header>
+  <div class="row1">
+    <input type="search" id="q" placeholder="Search addons" autocomplete="off">
+    <select id="store"><option value="">All stores</option></select>
+    <button class="iconbtn" id="refresh" title="Reload every store">Refresh</button>
+    <button class="iconbtn" id="sources" title="Tools &gt; Options &gt; Aefos">Stores&hellip;</button>
+  </div>
+  <nav id="tabs"></nav>
+</header>
+<div id="banners"></div>
+<main id="list"></main>
+<div id="log"></div>
+
+<script>
+"use strict";
+(function () {
+  // The host speaks to this page through window.aefosStore, and the page speaks
+  // back through postMessage. Nothing here fetches anything: the CLI is the only
+  // thing that knows how to read a store, and it runs on the Delphi side.
+  var state = { addons: [], errors: [], tab: null, q: "", store: "", busy: null };
+
+  function post(msg) {
+    if (window.chrome && window.chrome.webview) {
+      window.chrome.webview.postMessage(JSON.stringify(msg));
+    } else {
+      console.log("[aefos-store]", JSON.stringify(msg));   // browser preview
+    }
+  }
+
+  function esc(s) {
+    return String(s == null ? "" : s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  }
+
+  // Type -> tab label. Unknown types are NOT dropped and NOT folded into a
+  // neighbour: they get a tab under their own name, which is the whole reason
+  // the type travels as a string.
+  var LABEL = { command: "Addons", mcp: "MCP", tool: "Tools", skill: "Skills" };
+  function label(kind) {
+    if (LABEL[kind]) return LABEL[kind];
+    return kind ? kind.charAt(0).toUpperCase() + kind.slice(1) : "Other";
+  }
+
+  function kinds() {
+    var seen = [], i;
+    for (i = 0; i < state.addons.length; i++) {
+      var k = state.addons[i].kind || "other";
+      if (seen.indexOf(k) < 0) seen.push(k);
+    }
+    // A stable order for the ones we know, then whatever else arrived, so the
+    // tabs do not jump around between refreshes.
+    var known = ["command", "mcp", "tool", "skill"];
+    seen.sort(function (a, b) {
+      var ia = known.indexOf(a), ib = known.indexOf(b);
+      if (ia < 0 && ib < 0) return a < b ? -1 : 1;
+      if (ia < 0) return 1;
+      if (ib < 0) return -1;
+      return ia - ib;
+    });
+    return seen;
+  }
+
+  function matches(a) {
+    if (state.store && a.source !== state.store) return false;
+    if (!state.q) return true;
+    var hay = (a.slug + " " + a.name + " " + (a.description || "") + " " +
+               a.source).toLowerCase();
+    return hay.indexOf(state.q) >= 0;
+  }
+
+  function renderTabs() {
+    var ks = kinds(), nav = document.getElementById("tabs"), html = "", i;
+    if (ks.indexOf(state.tab) < 0) state.tab = ks.length ? ks[0] : null;
+    for (i = 0; i < ks.length; i++) {
+      var n = 0, j;
+      for (j = 0; j < state.addons.length; j++) {
+        if ((state.addons[j].kind || "other") === ks[i] && matches(state.addons[j])) n++;
+      }
+      html += '<button data-kind="' + esc(ks[i]) + '" aria-selected="' +
+        (ks[i] === state.tab) + '">' + esc(label(ks[i])) +
+        '<span class="count">' + n + "</span></button>";
+    }
+    nav.innerHTML = html;
+  }
+
+  function renderStores() {
+    var sel = document.getElementById("store"), seen = [], i;
+    for (i = 0; i < state.addons.length; i++) {
+      if (seen.indexOf(state.addons[i].source) < 0) seen.push(state.addons[i].source);
+    }
+    var html = '<option value="">All stores</option>';
+    for (i = 0; i < seen.length; i++) {
+      html += '<option value="' + esc(seen[i]) + '"' +
+        (seen[i] === state.store ? " selected" : "") + ">" + esc(seen[i]) + "</option>";
+    }
+    sel.innerHTML = html;
+  }
+
+  function renderBanners() {
+    // A store that could not be read is shown, never swallowed: an unreachable
+    // store and an empty list look identical, and one of them is a lie.
+    var html = "", i;
+    for (i = 0; i < state.errors.length; i++) {
+      html += '<div class="banner">' + esc(state.errors[i].source) + ": " +
+        esc(state.errors[i].message) + "</div>";
+    }
+    document.getElementById("banners").innerHTML = html;
+  }
+
+  function actionHtml(a) {
+    var id = esc(a.source + "/" + a.slug);
+    // Non-ASCII travels as \u escapes: this page is embedded in a Delphi build
+    // that eight compilers read, and a literal glyph is one encoding surprise
+    // away from being mojibake on somebody's screen.
+    if (state.busy === a.source + "/" + a.slug) {
+      return '<button class="primary" disabled>Working\u2026</button>';
+    }
+    if (a.state === "update") {
+      return '<button class="primary" data-do="update" data-id="' + id + '">Update</button>' +
+             '<button class="ghost" data-do="remove" data-id="' + id + '">Remove</button>';
+    }
+    if (a.state === "installed") {
+      return '<span class="done">\u2713 Installed</span>' +
+             '<button class="ghost" data-do="remove" data-id="' + id + '">Remove</button>';
+    }
+    return '<button class="primary" data-do="install" data-id="' + id + '">Install</button>';
+  }
+
+  function renderList() {
+    var out = "", i, shown = 0;
+    for (i = 0; i < state.addons.length; i++) {
+      var a = state.addons[i];
+      if ((a.kind || "other") !== state.tab || !matches(a)) continue;
+      shown++;
+      var sub = a.source;
+      if (a.version) sub += " \u00b7 v" + a.version;
+      if (a.installed && a.installedVersion && a.installedVersion !== a.version) {
+        sub += " \u00b7 installed v" + a.installedVersion;
+      }
+      if (a.trust === "official") sub += " \u00b7 official";
+      out += '<div class="item"><div class="meta">' +
+        '<div class="name">' + esc(a.name || a.slug) + "</div>" +
+        '<div class="desc">' + esc(a.description || a.slug) + "</div>" +
+        '<div class="sub">' + esc(sub) + "</div></div>" +
+        '<div class="act">' + actionHtml(a) + "</div></div>";
+    }
+    if (!shown) {
+      out = '<div class="empty">' +
+        (state.addons.length ? "Nothing matches that." :
+         "No addons available. Add a store under Tools \u203a Options \u203a Aefos.") +
+        "</div>";
+    }
+    document.getElementById("list").innerHTML = out;
+  }
+
+  function render() { renderStores(); renderTabs(); renderBanners(); renderList(); }
+
+  // ---- events ------------------------------------------------------------
+  document.getElementById("q").addEventListener("input", function (e) {
+    state.q = e.target.value.trim().toLowerCase();
+    renderTabs(); renderList();
+  });
+  document.getElementById("store").addEventListener("change", function (e) {
+    state.store = e.target.value; renderTabs(); renderList();
+  });
+  document.getElementById("refresh").addEventListener("click", function () {
+    post({ action: "refresh" });
+  });
+  document.getElementById("sources").addEventListener("click", function () {
+    post({ action: "openSources" });
+  });
+  document.getElementById("tabs").addEventListener("click", function (e) {
+    var b = e.target.closest("button[data-kind]");
+    if (!b) return;
+    state.tab = b.getAttribute("data-kind"); render();
+  });
+  document.getElementById("list").addEventListener("click", function (e) {
+    var b = e.target.closest("button[data-do]");
+    if (!b) return;
+    var id = b.getAttribute("data-id");
+    var cut = id.indexOf("/");
+    state.busy = id;
+    document.getElementById("log").innerHTML = "";
+    document.getElementById("log").className = "on";
+    renderList();
+    post({ action: b.getAttribute("data-do"),
+           source: id.slice(0, cut), slug: id.slice(cut + 1) });
+  });
+
+  // ---- what the host calls ----------------------------------------------
+  window.aefosStore = {
+    data: function (payload) {
+      state.addons = (payload && payload.addons) || [];
+      state.errors = (payload && payload.errors) || [];
+      state.busy = null;
+      render();
+    },
+    theme: function (vars) {
+      for (var k in vars) {
+        if (Object.prototype.hasOwnProperty.call(vars, k)) {
+          document.documentElement.style.setProperty("--" + k, vars[k]);
+        }
+      }
+    },
+    log: function (line, bad) {
+      var el = document.getElementById("log");
+      el.className = "on";
+      var d = document.createElement("div");
+      if (bad) d.className = "bad";
+      d.textContent = line;
+      el.appendChild(d);
+      el.scrollTop = el.scrollHeight;
+    },
+    done: function () { state.busy = null; renderList(); }
+  };
+
+  if (window.__AEFOS_STORE__) window.aefosStore.data(window.__AEFOS_STORE__);
+  post({ action: "ready" });
+})();
+</script>


### PR DESCRIPTION
The store dialog that opens from Aefos chat: a WebView2 page listing what every
configured store offers, with an Install button. This PR is the page and the
data behind it; the host form and the command that opens it land next, in the
designer.

## Why WebView2

It is already in the product, and it turns the host form into a shell around
ONE control — the difference between a dialog we draw in the designer and a
dialog we design.

## Tabs come from the data

One tab per distinct type, built from the rows themselves. A store that starts
publishing a type this build has never heard of gets a tab under its own name
instead of being folded into a neighbour or dropped — which only works if the
type survives the trip, so the registry's `"type"` is now carried verbatim
beside the parsed enum (`Parse` folds the unknown into `akCommand`: right for
behaviour, wrong for a label). A folder store has no registry to declare a
type, so it is **measured** from the bundle.

## The button's own answer

`catalog --json` now carries install state per row:

```json
{ "slug": "janus-orm", "kind": "command",
  "installed": true, "installedVersion": "1.0.1", "state": "installed" }
```

`available | installed | update`, decided CLI-side. It needs the sha comparison
and a folder bundle's measured identity; a dialog that reconciled two lists
itself would be a second implementation of the rule, in another language, free
to disagree with the first. Rows match by slug **and** store, because with
stores configured the same name in two places is two different addons.

## Seen, not assumed

Rendered against the real catalogue — ten gallery addons, a local company
store, and one store deliberately pointed at a missing drive — and read back
from a screenshot: tabs `Addons 11 / MCP 1`, the installed row showing a tick
and Remove, the unreachable store in its banner rather than silently missing.
The CLI proof from #36 was re-run whole afterwards, all ten scenarios unchanged.

## Not in this PR

The host form, the message bridge that spawns `aefos.exe`, and embedding the
page in the BPL. The page is a plain file here on purpose — where it gets
embedded is a decision that belongs with the form that shows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)