### PR TITLE
One official store nobody can move, and the custom ones beside it

### DIFF
--- a/cli/Aefos.Addons.Catalog.pas
+++ b/cli/Aefos.Addons.Catalog.pas
@@ -164,6 +164,55 @@ begin
   Result := True;
 end;
 
+function _IsHttp(const ARef: string): Boolean;
+begin
+  Result := SameText(Copy(ARef, 1, 7), 'http://') or
+            SameText(Copy(ARef, 1, 8), 'https://');
+end;
+
+// A registry may publish a RELATIVE url ("addons/x/x-1.0.0.zip"), and relative
+// to WHAT was never asked while there was only one registry. With stores it has
+// to be asked, and there is only one defensible answer: relative to the store
+// that published it. Anchoring on the built-in gallery instead - which is what
+// happened before this - pointed a company store's bundle at our download
+// directory, and the error it produced named a path that never existed
+// anywhere ("D:\repo\https:\raw.githubusercontent.com\...").
+function _AbsolutizeUrl(const ABase, AUrl: string): string;
+var
+  LCut: Integer;
+begin
+  Result := AUrl;
+  if (Result = '') or _IsHttp(Result) or
+     SameText(Copy(Result, 1, 7), 'file://') then
+    Exit;
+  if TPath.IsPathRooted(Result) then
+    Exit;
+  if _IsHttp(ABase) then
+  begin
+    LCut := LastDelimiter('/', ABase);
+    if LCut > 0 then
+      Result := Copy(ABase, 1, LCut) + Result;
+    Exit;
+  end;
+  if ABase <> '' then
+    Result := TPath.GetFullPath(TPath.Combine(ExtractFileDir(ABase), Result));
+end;
+
+// "Official" is a fact about WHERE an addon came from, and until now it was a
+// word the publisher wrote about itself. That mattered beyond the badge: the
+// install consent gate skips the prompt for official-trust bundles, so any
+// store whose registry.json said "trust": "official" could install an MCP
+// server or a tools folder - code that then runs on the machine - without ever
+// asking. So trust is clamped at the door: only the official store may hand
+// out atOfficial, and every other store's rows are community whatever they
+// claim. A store can still be trusted by the user; it just cannot self-declare.
+procedure _ClampTrust(var AEntry: TAddonRegistryEntry;
+  const ASource: TAddonSource);
+begin
+  if not ASource.Builtin then
+    AEntry.Trust := atCommunity;
+end;
+
 // A store that could not be read may be the store that HAS the slug, so the
 // not-found message has to carry it. Silence here would send the user hunting
 // for a typo in a name that is perfectly correct.
@@ -201,6 +250,9 @@ begin
           begin
             Result.Rows[LIndex].Source := ASource.Name;
             Result.Rows[LIndex].Entry := LEntries[LIndex];
+            Result.Rows[LIndex].Entry.Url :=
+              _AbsolutizeUrl(LUrl, Result.Rows[LIndex].Entry.Url);
+            _ClampTrust(Result.Rows[LIndex].Entry, ASource);
           end;
         end;
       askPath:
@@ -386,6 +438,10 @@ begin
       begin
         LObj := TJSONObject.Create;
         LObj.AddPair('source', AResults[LI].Source.Name);
+        if AResults[LI].Source.Builtin then
+          LObj.AddPair('origin', 'official')
+        else
+          LObj.AddPair('origin', 'custom');
         LObj.AddPair('message', AResults[LI].Error);
         LErrors.AddElement(LObj);
         Continue;
@@ -395,6 +451,13 @@ begin
         LEntry := AResults[LI].Rows[LJ].Entry;
         LObj := TJSONObject.Create;
         LObj.AddPair('source', AResults[LI].Rows[LJ].Source);
+        // Where it came from, as a fact rather than a claim: the dialog splits
+        // Official from Custom on this, and only the official store can be on
+        // the left of that line.
+        if AResults[LI].Source.Builtin then
+          LObj.AddPair('origin', 'official')
+        else
+          LObj.AddPair('origin', 'custom');
         LObj.AddPair('slug', LEntry.Slug);
         LObj.AddPair('name', LEntry.Name);
         LObj.AddPair('version', LEntry.Version);

--- a/cli/Aefos.Addons.Sources.pas
+++ b/cli/Aefos.Addons.Sources.pas
@@ -46,12 +46,16 @@ type
   { How a source's index is read. Not the bundle format - that is measured. }
   TAddonSourceKind = (askAefos, askPath, askGit);
 
-  { One configured store. }
+  { One store. }
   TAddonSource = record
     Name: string;      // short id, used by --source and shown in the catalogue
     Kind: TAddonSourceKind;
     Location: string;  // URL for aefos/git, directory for path
     Enabled: Boolean;
+    { True for the ONE official store, which is not configured and cannot be
+      repointed. Everything else is a store somebody added, and the difference
+      is load-bearing rather than cosmetic - see Load. }
+    Builtin: Boolean;
   end;
 
   { One row of the merged catalogue: a registry entry plus where it came from. }
@@ -66,18 +70,31 @@ type
     { Absolute path of sources.json (it may not exist). }
     class function ConfigPath: string; static;
 
-    { The configured sources. A missing or unreadable file yields the single
-      built-in gallery, so the CLI keeps working with no configuration at all. }
+    { Every store: the OFFICIAL one first, always, then whatever sources.json
+      adds. The official store is not part of the file and cannot be removed
+      from it - configuring a company store must not cost you the gallery,
+      which is exactly what a list that REPLACED the default used to do.
+
+      An entry named "aefos" may only turn the official store OFF. It cannot
+      repoint it: a store you can silently repoint is the whole supply-chain
+      risk, and "official" has to mean "came from the official store" rather
+      than "said it was official". (The offline installer's escape hatch stays
+      where it was, in %AEFOS_ADDONS_REGISTRY%, which is deliberate and local.) }
     class function Load: TArray<TAddonSource>; static;
 
     { Writes the list. Used by `aefos source add/remove` and, later, by the
       Options page - both go through here so the file has one writer shape. }
     class procedure Save(const ASources: TArray<TAddonSource>); static;
 
-    { The built-in gallery row, which Load returns when nothing is configured.
+    { The official gallery row, which Load always returns first.
       Named Builtin rather than Default because Default() is an intrinsic: inside
       the method the compiler resolved Default(TAddonSource) to the method itself. }
     class function Builtin: TAddonSource; static;
+
+    { The reserved name of the official store. Exposed so the Options page can
+      refuse it as a name for a custom store instead of writing a file the CLI
+      would then quietly ignore. }
+    class function BuiltinName: string; static;
 
     { Parses "aefos"/"path"/"git"; anything else raises, because a source whose
       kind we guessed would read the wrong thing silently. }
@@ -134,6 +151,12 @@ begin
   Result.Kind := askAefos;
   Result.Location := '';    // empty => TAddonNet.RegistryUrl, the built-in one
   Result.Enabled := True;
+  Result.Builtin := True;
+end;
+
+class function TAddonSources.BuiltinName: string;
+begin
+  Result := CDefaultName;
 end;
 
 function _Str(const AObj: TJSONObject; const AKey: string): string;
@@ -164,52 +187,64 @@ end;
 
 class function TAddonSources.Load: TArray<TAddonSource>;
 var
-  LPath, LText: string;
+  LPath, LText, LName: string;
   LVal, LListVal: TJSONValue;
   LArr: TJSONArray;
   LObj: TJSONObject;
   LIndex, LCount: Integer;
 begin
-  SetLength(Result, 0);
+  // The official store is position zero, before anything is read. Nothing in
+  // the file can remove it; one thing in the file can switch it off.
+  SetLength(Result, 1);
+  Result[0] := Builtin;
+  LCount := 1;
+
   LPath := ConfigPath;
   if not TFile.Exists(LPath) then
-    Exit(TArray<TAddonSource>.Create(Builtin));
+    Exit;
   try
     LText := TFile.ReadAllText(LPath, TEncoding.UTF8);
   except
-    Exit(TArray<TAddonSource>.Create(Builtin));
+    Exit;                               // unreadable config => official alone
   end;
   LVal := TJSONObject.ParseJSONValue(LText);
   try
     if not (LVal is TJSONObject) then
-      Exit(TArray<TAddonSource>.Create(Builtin));
+      Exit;
     LListVal := TJSONObject(LVal).Values['sources'];
     if not (LListVal is TJSONArray) then
-      Exit(TArray<TAddonSource>.Create(Builtin));
+      Exit;
     LArr := TJSONArray(LListVal);
-    LCount := 0;
-    SetLength(Result, LArr.Count);
+    SetLength(Result, LArr.Count + 1);
     for LIndex := 0 to LArr.Count - 1 do
     begin
       if not (LArr.Items[LIndex] is TJSONObject) then
         Continue;
       LObj := TJSONObject(LArr.Items[LIndex]);
-      Result[LCount].Name := _Str(LObj, 'name');
-      if Result[LCount].Name = '' then
+      LName := _Str(LObj, 'name');
+      if LName = '' then
         Continue;                       // a nameless store cannot be referred to
+      if SameText(LName, CDefaultName) then
+      begin
+        // The reserved name. It may say enabled:false and nothing else: a
+        // location here would silently REPLACE the official store, and every
+        // addon it published would then wear the official badge.
+        Result[0].Enabled := _BoolOrTrue(LObj, 'enabled');
+        Continue;
+      end;
+      Result[LCount].Name := LName;
       Result[LCount].Kind := ParseKind(_Str(LObj, 'kind'));
       Result[LCount].Location := _Str(LObj, 'location');
       if Result[LCount].Location = '' then
         Result[LCount].Location := _Str(LObj, 'url');   // friendlier alias
       Result[LCount].Enabled := _BoolOrTrue(LObj, 'enabled');
+      Result[LCount].Builtin := False;
       Inc(LCount);
     end;
     SetLength(Result, LCount);
   finally
     LVal.Free;
   end;
-  if Length(Result) = 0 then
-    Result := TArray<TAddonSource>.Create(Builtin);
 end;
 
 class procedure TAddonSources.Save(const ASources: TArray<TAddonSource>);
@@ -224,6 +259,20 @@ begin
     LRoot.AddPair('sources', LArr);
     for LIndex := 0 to High(ASources) do
     begin
+      if ASources[LIndex].Builtin then
+      begin
+        // The official store is not configuration, so it is not written back -
+        // round-tripping it would put a location in the file, and Load refuses
+        // to read one. The single thing worth persisting is it being OFF.
+        if not ASources[LIndex].Enabled then
+        begin
+          LItem := TJSONObject.Create;
+          LItem.AddPair('name', ASources[LIndex].Name);
+          LItem.AddPair('enabled', TJSONBool.Create(False));
+          LArr.AddElement(LItem);
+        end;
+        Continue;
+      end;
       LItem := TJSONObject.Create;
       LItem.AddPair('name', ASources[LIndex].Name);
       LItem.AddPair('kind', KindToStr(ASources[LIndex].Kind));

--- a/cli/aefos.dpr
+++ b/cli/aefos.dpr
@@ -88,6 +88,14 @@ begin
   Writeln('Addons install under ~/.aefos (commands, skills, addons).');
 end;
 
+function _OriginOf(const ASource: TAddonSource): string;
+begin
+  if ASource.Builtin then
+    Result := 'official'
+  else
+    Result := 'custom';
+end;
+
 procedure PrintSources;
 var
   LSources: TArray<TAddonSource>;
@@ -95,15 +103,16 @@ var
   LWhere: string;
 begin
   LSources := TAddonSources.Load;
-  Writeln('Sources (', TAddonSources.ConfigPath, '):');
+  Writeln('Sources (custom ones live in ', TAddonSources.ConfigPath, '):');
   for LIndex := 0 to High(LSources) do
   begin
     LWhere := LSources[LIndex].Location;
-    if Trim(LWhere) = '' then
-      LWhere := '(built-in gallery)';
+    if LSources[LIndex].Builtin then
+      LWhere := '(official gallery - not configurable)';
     if not LSources[LIndex].Enabled then
       LWhere := LWhere + '   (disabled)';
-    Writeln(Format('  %-12s %-6s %s', [LSources[LIndex].Name,
+    Writeln(Format('  %-12s %-8s %-6s %s', [LSources[LIndex].Name,
+      _OriginOf(LSources[LIndex]),
       TAddonSources.KindToStr(LSources[LIndex].Kind), LWhere]));
   end;
 end;

--- a/source/chat/UI/assets/addon-store.html
+++ b/source/chat/UI/assets/addon-store.html
@@ -39,7 +39,11 @@
   }
   .iconbtn:hover { color: var(--fg); border-color: var(--line); }
 
-  /* ---- tabs: one per TYPE, built from the data ------------------------- */
+  /* ---- two levels of tabs ---------------------------------------------
+     WHERE it comes from on top (Official / Custom), WHAT it is underneath
+     (built from the data). Origin is the OUTER question because it is the one
+     with consequences: the official store is ours and cannot be repointed;
+     everything else is a store somebody added. */
   nav {
     display: flex; gap: 2px; margin-top: 10px;
     border-bottom: 1px solid var(--line);
@@ -52,6 +56,15 @@
   nav button:hover { color: var(--fg); }
   nav button[aria-selected=true] { color: var(--fg); border-bottom-color: var(--accent); }
   nav .count { color: var(--muted); font-size: 11px; margin-left: 5px; }
+  #origins { margin-top: 8px; border-bottom: none; }
+  #origins button { font-weight: 600; padding: 5px 12px; border-radius: 4px; }
+  #origins button[aria-selected=true] {
+    background: var(--panel); color: var(--fg); border-bottom-color: transparent;
+  }
+  .hint {
+    color: var(--muted); font-size: 12px; padding: 22px 12px; text-align: center;
+  }
+  .hint button { margin-top: 10px; }
 
   /* ---- the list -------------------------------------------------------- */
   main { flex: 1 1 auto; overflow-y: auto; padding: 4px 0 12px; }
@@ -106,6 +119,7 @@
     <button class="iconbtn" id="refresh" title="Reload every store">Refresh</button>
     <button class="iconbtn" id="sources" title="Tools &gt; Options &gt; Aefos">Stores&hellip;</button>
   </div>
+  <nav id="origins"></nav>
   <nav id="tabs"></nav>
 </header>
 <div id="banners"></div>
@@ -118,7 +132,8 @@
   // The host speaks to this page through window.aefosStore, and the page speaks
   // back through postMessage. Nothing here fetches anything: the CLI is the only
   // thing that knows how to read a store, and it runs on the Delphi side.
-  var state = { addons: [], errors: [], tab: null, q: "", store: "", busy: null };
+  var state = { addons: [], errors: [], origin: "official", tab: null,
+                q: "", store: "", busy: null };
 
   function post(msg) {
     if (window.chrome && window.chrome.webview) {
@@ -146,6 +161,7 @@
   function kinds() {
     var seen = [], i;
     for (i = 0; i < state.addons.length; i++) {
+      if (!inOrigin(state.addons[i])) continue;
       var k = state.addons[i].kind || "other";
       if (seen.indexOf(k) < 0) seen.push(k);
     }
@@ -162,7 +178,12 @@
     return seen;
   }
 
+  // Origin is not a filter the user can widen: an addon from a store somebody
+  // added never appears among the official ones, whatever it calls itself.
+  function inOrigin(a) { return (a.origin || "custom") === state.origin; }
+
   function matches(a) {
+    if (!inOrigin(a)) return false;
     if (state.store && a.source !== state.store) return false;
     if (!state.q) return true;
     var hay = (a.slug + " " + a.name + " " + (a.description || "") + " " +
@@ -185,9 +206,30 @@
     nav.innerHTML = html;
   }
 
+  // The two outer tabs always BOTH exist, even when one is empty: "Custom" that
+  // vanishes when you have no store of your own is a feature you never find out
+  // about, and finding it is the whole point of the tab.
+  function renderOrigins() {
+    var nav = document.getElementById("origins"), html = "", i, k;
+    var names = { official: "Official", custom: "Custom" };
+    var order = ["official", "custom"];
+    for (i = 0; i < order.length; i++) {
+      k = order[i];
+      var n = 0, j;
+      for (j = 0; j < state.addons.length; j++) {
+        if ((state.addons[j].origin || "custom") === k) n++;
+      }
+      html += '<button data-origin="' + k + '" aria-selected="' +
+        (k === state.origin) + '">' + names[k] +
+        '<span class="count">' + n + "</span></button>";
+    }
+    nav.innerHTML = html;
+  }
+
   function renderStores() {
     var sel = document.getElementById("store"), seen = [], i;
     for (i = 0; i < state.addons.length; i++) {
+      if (!inOrigin(state.addons[i])) continue;
       if (seen.indexOf(state.addons[i].source) < 0) seen.push(state.addons[i].source);
     }
     var html = '<option value="">All stores</option>';
@@ -203,6 +245,7 @@
     // store and an empty list look identical, and one of them is a lie.
     var html = "", i;
     for (i = 0; i < state.errors.length; i++) {
+      if ((state.errors[i].origin || "custom") !== state.origin) continue;
       html += '<div class="banner">' + esc(state.errors[i].source) + ": " +
         esc(state.errors[i].message) + "</div>";
     }
@@ -246,16 +289,31 @@
         '<div class="sub">' + esc(sub) + "</div></div>" +
         '<div class="act">' + actionHtml(a) + "</div></div>";
     }
-    if (!shown) {
-      out = '<div class="empty">' +
-        (state.addons.length ? "Nothing matches that." :
-         "No addons available. Add a store under Tools \u203a Options \u203a Aefos.") +
-        "</div>";
-    }
+    if (!shown) out = emptyHtml();
     document.getElementById("list").innerHTML = out;
   }
 
-  function render() { renderStores(); renderTabs(); renderBanners(); renderList(); }
+  // An empty Custom tab is not a failure, it is the normal state of a fresh
+  // install - so it says what a custom store IS and offers the way to add one,
+  // instead of the blank "nothing here" that reads like something broke.
+  function emptyHtml() {
+    var i, anyHere = false;
+    for (i = 0; i < state.addons.length; i++) {
+      if (inOrigin(state.addons[i])) { anyHere = true; break; }
+    }
+    if (anyHere) return '<div class="empty">Nothing matches that.</div>';
+    if (state.origin === "custom") {
+      return '<div class="hint">A custom store is a folder, a share or a ' +
+        'registry your team keeps.<br>Addons published there install exactly ' +
+        'like the official ones.<br>' +
+        '<button class="primary" id="addstore">Add a store\u2026</button></div>';
+    }
+    return '<div class="empty">The official gallery could not be read.</div>';
+  }
+
+  function render() {
+    renderOrigins(); renderStores(); renderTabs(); renderBanners(); renderList();
+  }
 
   // ---- events ------------------------------------------------------------
   document.getElementById("q").addEventListener("input", function (e) {
@@ -271,12 +329,20 @@
   document.getElementById("sources").addEventListener("click", function () {
     post({ action: "openSources" });
   });
+  document.getElementById("origins").addEventListener("click", function (e) {
+    var b = e.target.closest("button[data-origin]");
+    if (!b) return;
+    state.origin = b.getAttribute("data-origin");
+    state.store = "";            // a store filter cannot survive its own tab
+    render();
+  });
   document.getElementById("tabs").addEventListener("click", function (e) {
     var b = e.target.closest("button[data-kind]");
     if (!b) return;
     state.tab = b.getAttribute("data-kind"); render();
   });
   document.getElementById("list").addEventListener("click", function (e) {
+    if (e.target.id === "addstore") { post({ action: "openSources" }); return; }
     var b = e.target.closest("button[data-do]");
     if (!b) return;
     var id = b.getAttribute("data-id");


### PR DESCRIPTION
Your shape — the official gallery fixed and unconfigurable, custom stores in
Tools ▸ Options ▸ Aefos, a tab for each. Implementing it turned up two things
that were already wrong and one that was a hole.

## The shape

The official gallery is position zero, put there before `sources.json` is read.
The file holds the **custom** stores only. One name is reserved: an entry called
`aefos` may say `enabled: false` and nothing else — it can switch the official
store off, never point it somewhere else.

```
$ aefos sources
  aefos     official  aefos  (official gallery - not configurable)
  empresa   custom    path   \fileserver\aefos-addons
  vpn       custom    path   Z:\loja-da-empresa
```

## Fix 1 — adding a store no longer costs you the gallery

The list **replaced** the default, so the first person to add a company store
silently lost the official one and would have had no reason to connect the two.

## Fix 2 — a hole, and it was open

The consent gate skips the prompt for official-trust bundles, and trust was
whatever the publisher wrote about itself. Any store could declare
`"trust": "official"` and install an MCP server or tools folder — code that runs
on the machine — **without asking**.

Proven by mutation, not by reading. Same local store, same bundle, no `--yes`:

| | result |
|---|---|
| with the clamp | `error: addon "totally-legit" is community-trust and ships runnable code (mcp/tools). Re-run with --yes …` |
| clamp removed | `! totally-legit ships runnable code (official-trust)` → `Installed totally-legit v1.0.0.` — no prompt |

Trust is now clamped at the door: only the official store may hand out
`atOfficial`. A custom store can be trusted by the user; it cannot elect itself.

## Fix 3 — "relative to what?"

A registry may publish a relative `url`, and it was being resolved against the
**built-in gallery** — so a company store's bundle pointed into our download
directory and produced a path that exists nowhere:

```
local addon file not found: D:\repo\https:\raw.githubusercontent.com\...
```

Each entry's url is now made absolute against the store that published it.

## On screen

Origin is the outer question, above the type tabs, because it is the one with
consequences. Both tabs always exist — a "Custom" tab that appears only once you
have a custom store is a feature you never discover. Empty, it says what a
custom store is and offers the way to add one.

## Proof

The ten-scenario custom-store run re-run whole (with the official store switched
off, which exercises the one thing the reserved name may do); the gallery
unchanged — `janus-orm` still official, still current; both tabs read back from
screenshots — `Official 10 / Custom 2`, with the failing store's banner
appearing only under the tab it belongs to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)