### PR TITLE
The store window opens: shown modeless, the WebView2 controller completes

### DIFF
--- a/source/chat/UI/Aefos.OTA.Chat.UI.AddonStoreForm.pas
+++ b/source/chat/UI/Aefos.OTA.Chat.UI.AddonStoreForm.pas
@@ -52,6 +52,11 @@ type
       BEFORE the handle exists", "wire events BEFORE Parent"); doing it in the
       constructor is the only way to be sure nothing got there first. }
     constructor Create(AOwner: TComponent); override;
+    destructor Destroy; override;
+
+    { The window frees itself on close, because it is shown MODELESS - see
+      Execute for why it cannot be modal. }
+    procedure DoClose(var AAction: TCloseAction); override;
 
     { Opens the store. One window at a time on purpose: two of them would show
       two catalogues that disagree the moment either one installs something. }
@@ -78,15 +83,16 @@ var
   // place that creates it.
   GStoreForm: TAefosAddonStoreForm = nil;
 
-// TEMPORARY diagnostic — writes into the same file and behind the same switch as
-// the WebView control/host traces, so the whole open reads as one timeline.
+// Joins the WebView control/host trace, in the same file and behind the same
+// switch (AEFOS_WEBVIEW_TRACE), so an open reads top to bottom as one story:
+// this window, then the control, then the host.
 procedure _StoreLog(const S: string);
 begin
   if GetEnvironmentVariable('AEFOS_WEBVIEW_TRACE') = '' then
     Exit;
   try
-    TFile.AppendAllText(TPath.Combine(TPath.GetTempPath, 'aefos_comp.log'),
-      'store: ' + S + sLineBreak, TEncoding.UTF8);
+    TFile.AppendAllText(WebViewTraceFile, 'store: ' + S + sLineBreak,
+      TEncoding.UTF8);
   except
     // tracing is best-effort; never let it break the pipeline
   end;
@@ -149,14 +155,26 @@ begin
   // empty, which sends WebView2 to keep its user data beside bds.exe, and
   // sharing the chat's would couple this window to the chat's browser
   // arguments (see TWebViewConfig.ForPane).
-  _StoreLog(Format('ctor: after dfm stream, wv assigned=%d handle=%d',
-    [Ord(Assigned(AefosWebView1)),
-     Ord(Assigned(AefosWebView1) and AefosWebView1.HandleAllocated)]));
   AefosWebView1.Configure(TWebViewConfig.ForPane('AddonStore'));
   AefosWebView1.OnReady := _WebViewReady;
   AefosWebView1.OnMessageReceived := _WebViewMessage;
   AefosWebView1.OnFailed := _WebViewFailed;
-  _StoreLog('ctor: configured');
+  _StoreLog('configured');
+end;
+
+destructor TAefosAddonStoreForm.Destroy;
+begin
+  // The single-instance check in Execute reads this, so it has to be cleared by
+  // whoever actually dies - the window frees itself now, not the caller.
+  if GStoreForm = Self then
+    GStoreForm := nil;
+  inherited;
+end;
+
+procedure TAefosAddonStoreForm.DoClose(var AAction: TCloseAction);
+begin
+  inherited DoClose(AAction);
+  AAction := caFree;
 end;
 
 class procedure TAefosAddonStoreForm.Execute;
@@ -166,23 +184,21 @@ begin
     GStoreForm.BringToFront;
     Exit;
   end;
-  _StoreLog('Execute: creating form');
+  _StoreLog('opening');
   GStoreForm := TAefosAddonStoreForm.Create(nil);
-  try
-    _StoreLog(Format('  form created, wv handle=%d',
-      [Ord(GStoreForm.AefosWebView1.HandleAllocated)]));
-    TThemeHelper.ApplyPremiumTheme(GStoreForm);
-    _StoreLog(Format('  theme applied, wv handle=%d',
-      [Ord(GStoreForm.AefosWebView1.HandleAllocated)]));
-    GStoreForm.AefosWebView1.Navigate('file:///' +
-      StringReplace(_MaterialisePage, '\', '/', [rfReplaceAll]));
-    _StoreLog('  navigate issued; showing modal');
-    GStoreForm.ShowModal;
-    _StoreLog('  modal closed');
-  finally
-    GStoreForm.Free;
-    GStoreForm := nil;
-  end;
+  TThemeHelper.ApplyPremiumTheme(GStoreForm);
+  GStoreForm.AefosWebView1.Navigate('file:///' +
+    StringReplace(_MaterialisePage, '\', '/', [rfReplaceAll]));
+  // MODELESS, and that is not a preference. Shown with ShowModal, the WebView2
+  // composition controller never completed: the environment was created and
+  // CreateCoreWebView2CompositionController returned S_OK, but its completion
+  // handler was never called, so the window sat on "Loading Aefos..." forever
+  // with nothing failing (traced 2026-08-08). The modal loop disables the
+  // application's other top-level windows, and the host's composition anchor is
+  // one of them - a WS_POPUP created next to the control. Shown modeless, the
+  // callback arrives. The store is a browsing window anyway; nothing about it
+  // wants to block the IDE, and a single instance is still enforced above.
+  GStoreForm.Show;
 end;
 
 procedure TAefosAddonStoreForm._CallPage(const AFunc, AJsonArg: string);

--- a/source/chat/UI/Aefos.OTA.Chat.UI.AddonStoreForm.pas
+++ b/source/chat/UI/Aefos.OTA.Chat.UI.AddonStoreForm.pas
@@ -78,6 +78,20 @@ var
   // place that creates it.
   GStoreForm: TAefosAddonStoreForm = nil;
 
+// TEMPORARY diagnostic — writes into the same file and behind the same switch as
+// the WebView control/host traces, so the whole open reads as one timeline.
+procedure _StoreLog(const S: string);
+begin
+  if GetEnvironmentVariable('AEFOS_WEBVIEW_TRACE') = '' then
+    Exit;
+  try
+    TFile.AppendAllText(TPath.Combine(TPath.GetTempPath, 'aefos_comp.log'),
+      'store: ' + S + sLineBreak, TEncoding.UTF8);
+  except
+    // tracing is best-effort; never let it break the pipeline
+  end;
+end;
+
 // The page is embedded, but WebView2 navigates to a URL, so it has to exist as
 // a file somewhere. Written fresh on every open: the copy on disk is a cache of
 // the resource, never a thing a user is expected to edit, and rewriting it is
@@ -135,10 +149,14 @@ begin
   // empty, which sends WebView2 to keep its user data beside bds.exe, and
   // sharing the chat's would couple this window to the chat's browser
   // arguments (see TWebViewConfig.ForPane).
+  _StoreLog(Format('ctor: after dfm stream, wv assigned=%d handle=%d',
+    [Ord(Assigned(AefosWebView1)),
+     Ord(Assigned(AefosWebView1) and AefosWebView1.HandleAllocated)]));
   AefosWebView1.Configure(TWebViewConfig.ForPane('AddonStore'));
   AefosWebView1.OnReady := _WebViewReady;
   AefosWebView1.OnMessageReceived := _WebViewMessage;
   AefosWebView1.OnFailed := _WebViewFailed;
+  _StoreLog('ctor: configured');
 end;
 
 class procedure TAefosAddonStoreForm.Execute;
@@ -148,12 +166,19 @@ begin
     GStoreForm.BringToFront;
     Exit;
   end;
+  _StoreLog('Execute: creating form');
   GStoreForm := TAefosAddonStoreForm.Create(nil);
   try
+    _StoreLog(Format('  form created, wv handle=%d',
+      [Ord(GStoreForm.AefosWebView1.HandleAllocated)]));
     TThemeHelper.ApplyPremiumTheme(GStoreForm);
+    _StoreLog(Format('  theme applied, wv handle=%d',
+      [Ord(GStoreForm.AefosWebView1.HandleAllocated)]));
     GStoreForm.AefosWebView1.Navigate('file:///' +
       StringReplace(_MaterialisePage, '\', '/', [rfReplaceAll]));
+    _StoreLog('  navigate issued; showing modal');
     GStoreForm.ShowModal;
+    _StoreLog('  modal closed');
   finally
     GStoreForm.Free;
     GStoreForm := nil;
@@ -196,6 +221,7 @@ end;
 
 procedure TAefosAddonStoreForm._WebViewReady;
 begin
+  _StoreLog('OnReady');
   _SendTheme;
 end;
 
@@ -205,6 +231,7 @@ end;
 // with nothing anywhere saying why.
 procedure TAefosAddonStoreForm._WebViewFailed(const AHResult: HRESULT);
 begin
+  _StoreLog(Format('OnFailed hr=%.8x', [Cardinal(AHResult)]));
   Caption := Format('Aefos Addons - WebView2 could not start (0x%.8x)',
     [Cardinal(AHResult)]);
 end;

--- a/source/webview/Aefos.WebView.CompositionHost.pas
+++ b/source/webview/Aefos.WebView.CompositionHost.pas
@@ -133,8 +133,8 @@ begin
   if GetEnvironmentVariable('AEFOS_WEBVIEW_TRACE') = '' then
     Exit;
   try
-    TFile.AppendAllText(TPath.Combine(TPath.GetTempPath, 'aefos_comp.log'),
-      S + sLineBreak, TEncoding.UTF8);
+    TFile.AppendAllText(WebViewTraceFile, 'host: ' + S + sLineBreak,
+      TEncoding.UTF8);
   except
     // tracing is best-effort; never let it break the pipeline
   end;

--- a/source/webview/Aefos.WebView.Control.pas
+++ b/source/webview/Aefos.WebView.Control.pas
@@ -78,17 +78,16 @@ type
 
 implementation
 
-// TEMPORARY diagnostic — same switch and same file as the composition host's
-// _CompLog (env var AEFOS_WEBVIEW_TRACE, %TEMP%\aefos_comp.log), so the control
-// side and the host side interleave in ONE timeline. Remove once the store window
-// is understood.
+// Off unless AEFOS_WEBVIEW_TRACE is set, and shares the composition host's file so
+// the control side and the host side read as ONE timeline — which is what finally
+// showed the store window's controller callback never arriving.
 procedure _CtlLog(const S: string);
 begin
   if GetEnvironmentVariable('AEFOS_WEBVIEW_TRACE') = '' then
     Exit;
   try
-    TFile.AppendAllText(TPath.Combine(TPath.GetTempPath, 'aefos_comp.log'),
-      'ctl: ' + S + sLineBreak, TEncoding.UTF8);
+    TFile.AppendAllText(WebViewTraceFile, 'ctl: ' + S + sLineBreak,
+      TEncoding.UTF8);
   except
     // tracing is best-effort; never let it break the pipeline
   end;
@@ -119,27 +118,26 @@ end;
 
 procedure TAefosWebView._EnsureHost;
 begin
-  _CtlLog(Format('_EnsureHost enter: name=%s designing=%d handle=%d host=%d '
-    + 'configured=%d udf="%s"',
-    [Name, Ord(csDesigning in ComponentState), Ord(HandleAllocated),
-     Ord(Assigned(FHost)), Ord(FConfigured), FConfig.UserDataFolder]));
+  _CtlLog(Format('ensure(dsg=%d,h=%d,host=%d,cfg=%d)',
+    [Ord(csDesigning in ComponentState), Ord(HandleAllocated),
+     Ord(Assigned(FHost)), Ord(FConfigured)]));
   // Never spin up a real WebView2 inside the form designer — just paint a
   // placeholder (see Paint). Keeps the component droppable without freezing the IDE.
   if (csDesigning in ComponentState) or not HandleAllocated then
   begin
-    _CtlLog('  EXIT: designing or no handle');
+    _CtlLog('EXIT-no-handle');
     Exit;
   end;
   if Assigned(FHost) then
   begin
-    _CtlLog('  reparent existing host');
+    _CtlLog('reparent');
     FHost.Reparent(Handle);
     FHost.SetBounds(ClientRect);
     Exit;
   end;
-  _CtlLog('  creating host');
+  _CtlLog('creating');
   FHost := TCompositionWebViewHost.Create(Handle, FConfig);
-  _CtlLog('  host created');
+  _CtlLog('created');
   FHost.OnReady := procedure
     begin
       Invalidate; // clear the "Loading…" placeholder; the WebView frame takes over
@@ -160,9 +158,9 @@ begin
   // Start AFTER the callbacks are wired: a synchronous failure (e.g. WebView2 runtime
   // missing -> E_FAIL) must reach OnFailed so the host can show its text fallback
   // instead of hanging on a black panel forever.
-  _CtlLog('  calling Start');
+  _CtlLog('start');
   FHost.Start;
-  _CtlLog('  Start returned');
+  _CtlLog('started');
   FHost.SetBounds(ClientRect);
   if FPendingUrl <> '' then
   begin
@@ -176,14 +174,15 @@ begin
   inherited CreateWnd;
   _CtlLog('CreateWnd');
   // Created on first show; on later recreates (dock/undock) this re-binds the host.
-  // The try/except is TEMPORARY: it exists to prove whether an exception on this
-  // path is being swallowed somewhere above (it re-raises, so behaviour is unchanged).
+  // The try/except only NAMES a failure on the way past (it re-raises, so nothing
+  // is swallowed): a host that dies here leaves a control that looks merely slow,
+  // and "looks slow" is the single most expensive symptom this unit produces.
   try
     _EnsureHost;
   except
     on E: Exception do
     begin
-      _CtlLog(Format('  EXCEPTION %s: %s', [E.ClassName, E.Message]));
+      _CtlLog(Format('EXC %s: %s', [E.ClassName, E.Message]));
       raise;
     end;
   end;

--- a/source/webview/Aefos.WebView.Control.pas
+++ b/source/webview/Aefos.WebView.Control.pas
@@ -19,8 +19,8 @@ interface
 
 uses
   Winapi.Windows, Winapi.Messages, System.Classes, System.SysUtils,
-  System.Types, Vcl.Controls, Vcl.Graphics, Aefos.Win.WebView2, Aefos.WebView.Types,
-  Aefos.WebView.CompositionHost;
+  System.IOUtils, System.Types, Vcl.Controls, Vcl.Graphics, Aefos.Win.WebView2,
+  Aefos.WebView.Types, Aefos.WebView.CompositionHost;
 
 type
   TAefosWebView = class(TCustomControl)
@@ -78,6 +78,22 @@ type
 
 implementation
 
+// TEMPORARY diagnostic — same switch and same file as the composition host's
+// _CompLog (env var AEFOS_WEBVIEW_TRACE, %TEMP%\aefos_comp.log), so the control
+// side and the host side interleave in ONE timeline. Remove once the store window
+// is understood.
+procedure _CtlLog(const S: string);
+begin
+  if GetEnvironmentVariable('AEFOS_WEBVIEW_TRACE') = '' then
+    Exit;
+  try
+    TFile.AppendAllText(TPath.Combine(TPath.GetTempPath, 'aefos_comp.log'),
+      'ctl: ' + S + sLineBreak, TEncoding.UTF8);
+  except
+    // tracing is best-effort; never let it break the pipeline
+  end;
+end;
+
 { TAefosWebView }
 
 constructor TAefosWebView.Create(AOwner: TComponent);
@@ -103,17 +119,27 @@ end;
 
 procedure TAefosWebView._EnsureHost;
 begin
+  _CtlLog(Format('_EnsureHost enter: name=%s designing=%d handle=%d host=%d '
+    + 'configured=%d udf="%s"',
+    [Name, Ord(csDesigning in ComponentState), Ord(HandleAllocated),
+     Ord(Assigned(FHost)), Ord(FConfigured), FConfig.UserDataFolder]));
   // Never spin up a real WebView2 inside the form designer — just paint a
   // placeholder (see Paint). Keeps the component droppable without freezing the IDE.
   if (csDesigning in ComponentState) or not HandleAllocated then
+  begin
+    _CtlLog('  EXIT: designing or no handle');
     Exit;
+  end;
   if Assigned(FHost) then
   begin
+    _CtlLog('  reparent existing host');
     FHost.Reparent(Handle);
     FHost.SetBounds(ClientRect);
     Exit;
   end;
+  _CtlLog('  creating host');
   FHost := TCompositionWebViewHost.Create(Handle, FConfig);
+  _CtlLog('  host created');
   FHost.OnReady := procedure
     begin
       Invalidate; // clear the "Loading…" placeholder; the WebView frame takes over
@@ -134,7 +160,9 @@ begin
   // Start AFTER the callbacks are wired: a synchronous failure (e.g. WebView2 runtime
   // missing -> E_FAIL) must reach OnFailed so the host can show its text fallback
   // instead of hanging on a black panel forever.
+  _CtlLog('  calling Start');
   FHost.Start;
+  _CtlLog('  Start returned');
   FHost.SetBounds(ClientRect);
   if FPendingUrl <> '' then
   begin
@@ -146,8 +174,19 @@ end;
 procedure TAefosWebView.CreateWnd;
 begin
   inherited CreateWnd;
+  _CtlLog('CreateWnd');
   // Created on first show; on later recreates (dock/undock) this re-binds the host.
-  _EnsureHost;
+  // The try/except is TEMPORARY: it exists to prove whether an exception on this
+  // path is being swallowed somewhere above (it re-raises, so behaviour is unchanged).
+  try
+    _EnsureHost;
+  except
+    on E: Exception do
+    begin
+      _CtlLog(Format('  EXCEPTION %s: %s', [E.ClassName, E.Message]));
+      raise;
+    end;
+  end;
 end;
 
 procedure TAefosWebView.Resize;

--- a/source/webview/Aefos.WebView.Types.pas
+++ b/source/webview/Aefos.WebView.Types.pas
@@ -77,7 +77,34 @@ type
     class function ForPane(const APane: string): TWebViewConfig; static;
   end;
 
+{ Where the WebView trace lands when AEFOS_WEBVIEW_TRACE is set - shared, so the
+  window, the control and the host all append to ONE file and an open reads in
+  order. Deliberately NOT %TEMP%: inside bds.exe a run that provably created the
+  host and called Start left nothing whatsoever under %TEMP%, and reading that
+  silence as "the code never ran" sent a whole morning down the wrong hole.
+  %APPDATA%\Aefos is where these panes already write successfully. }
+function WebViewTraceFile: string;
+
 implementation
+
+uses
+  {$IFDEF FPC}
+  SysUtils;
+  {$ELSE}
+  System.SysUtils;
+  {$ENDIF}
+
+function WebViewTraceFile: string;
+var
+  LDir: string;
+begin
+  // SysUtils only, no IOUtils: this unit compiles under FPC too.
+  LDir := IncludeTrailingPathDelimiter(GetEnvironmentVariable('APPDATA'))
+    + 'Aefos';
+  if not DirectoryExists(LDir) then
+    ForceDirectories(LDir);
+  Result := IncludeTrailingPathDelimiter(LDir) + 'webview-trace.log';
+end;
 
 { TWebViewConfig }
 


### PR DESCRIPTION
The store window opened to "Loading Aefos..." and stayed there — no error, no
`OnFailed`, nothing in the log. It now opens for real, verified live in the IDE:
Official/Custom tabs, Addons and MCP, search, store filter, and Install /
Installed+Remove per row.

## What it actually was

`ShowModal`. The environment was created and
`CreateCoreWebView2CompositionController` returned `S_OK` — and its completion
handler was never called. There was no failure to report, which is why nothing
fired.

The modal loop disables the application's other top-level windows, and the host's
composition anchor is one of them: a `WS_POPUP` created next to the control.
Shown modeless, the callback arrives.

The store is a browsing window anyway; nothing about it wants to block the IDE.

## Lifetime

Modeless moves ownership: the window frees itself (`DoClose` -> `caFree`) and
clears `GStoreForm` in its destructor. The single-instance check reads that
global, so it has to be cleared by whoever actually dies — not by the caller.

## The trace stays

It is what named the bug, so it is no longer temporary: off unless
`AEFOS_WEBVIEW_TRACE` is set, and window + control + host now append to **one**
file so an open reads top to bottom as a single story.

It moved out of `%TEMP%` deliberately. Inside `bds.exe`, a run that provably
created the host and called `Start` left nothing at all under `%TEMP%` — and
reading that silence as "the code never ran" cost a morning.
`%APPDATA%\Aefos` is where these panes already write successfully.

## Notes

- The standalone harness in `scratchpad/storeapp` could never have caught this:
  its window is not modal.
- Two earlier commits on this branch are the diagnostic ones that led here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
