### PR TITLE
One log type for the addon stack, so the CLI builds on Delphi 11 and down

### DIFF
--- a/cli/Aefos.Addons.Installer.pas
+++ b/cli/Aefos.Addons.Installer.pas
@@ -20,19 +20,15 @@ uses
   Aefos.Addons.Types;
 
 type
-  // The progress line sink. On Delphi a `reference to` (so a standalone or
-  // captured proc binds). FPC 3.2.2 has no anonymous methods; a plain
-  // procedural type is enough here - every call site passes a standalone
-  // procedure and the installer never builds a closure for it.
+  // The progress line sink. Alias of the one declaration in Aefos.Addons.Types
+  // (which carries the FPC branch): on Delphi a `reference to` so a standalone
+  // or captured proc binds, on FPC 3.2.2 a plain procedural type because it has
+  // no anonymous methods.
   // KNOWN DIVERGENCE: the two branches are DIFFERENT types. Passing a
   // capturing anonymous method on the Delphi side compiles there but will
   // break the FPC build - keep call sites on plain procedures (or convert
   // this to a carrier-object callback when a closure becomes necessary).
-  {$IFDEF FPC}
-  TAddonLog = procedure(const ALine: string);
-  {$ELSE}
-  TAddonLog = reference to procedure(const ALine: string);
-  {$ENDIF}
+  TAddonLog = TAddonLogProc;
 
   TInstallOptions = record
     Yes: Boolean;       // --yes: pre-consent third-party (mcp/tools) code

--- a/cli/Aefos.Addons.PluginFormat.pas
+++ b/cli/Aefos.Addons.PluginFormat.pas
@@ -60,12 +60,10 @@ type
   TPluginFormat = (pfNone, pfAefos, pfAgentPlugins, pfCopilot, pfClaude,
     pfOpenPlugin);
 
-  { Called with one human-readable line per adoption decision. }
-{$IFDEF FPC}
-  TPluginFormatLog = procedure(const ALine: string);
-{$ELSE}
-  TPluginFormatLog = reference to procedure(const ALine: string);
-{$ENDIF}
+  { Called with one human-readable line per adoption decision. Alias of the one
+    declaration in Aefos.Addons.Types - re-declaring it here would make it a
+    DIFFERENT type from the installer's, which older compilers reject outright. }
+  TPluginFormatLog = TAddonLogProc;
 
   { Static, sealed namespace: the class IS the namespace, never instantiated. }
   TAddonPluginFormat = class sealed

--- a/cli/Aefos.Addons.Types.pas
+++ b/cli/Aefos.Addons.Types.pas
@@ -17,6 +17,25 @@ uses
   SysUtils;
 
 type
+  { Called with one human-readable line of progress. ONE declaration for the
+    whole addon stack - every other unit ALIASES this one instead of repeating
+    the declaration.
+
+    Why it has to live here: two structurally identical "reference to procedure"
+    declarations are two DIFFERENT types, and a compiler older than Athens
+    refuses to pass one where the other is expected (E2010 Incompatible types,
+    measured on Delphi 11 / compiler 35.0). Athens and up happen to accept it,
+    so the duplicate only breaks where nobody looks. An alias is the same type
+    everywhere, which is what makes the handler cross unit boundaries at all.
+
+    FPC 3.2.2 has no anonymous methods, so there it stays a plain procedural
+    type - see the KNOWN DIVERGENCE note in Aefos.Addons.Installer. }
+{$IFDEF FPC}
+  TAddonLogProc = procedure(const ALine: string);
+{$ELSE}
+  TAddonLogProc = reference to procedure(const ALine: string);
+{$ENDIF}
+
   { The primary kind used for portal filtering. A bundle may still carry more
     than one artifact regardless of its declared primary type. }
   TAddonKind = (akCommand, akMcp, akTool);


### PR DESCRIPTION
The store engine (`aefos.exe`) did not compile below Athens:

```
cli\Aefos.Addons.Installer.pas(620)
Error: E2010 Incompatible types: 'TPluginFormatLog' and 'TAddonLog'
```

Two structurally identical `reference to procedure(const ALine: string)` declarations are two **different** types. Athens and up accept passing one where the other is expected; Delphi 11 (compiler 35.0) and older refuse. The CLI is the one binary compiled **once** instead of per IDE, so no old `dcc32` had ever seen it.

Fix: declare the sink once in `Aefos.Addons.Types` (it already carries the FPC branch, which has no anonymous methods) and alias it from `Aefos.Addons.PluginFormat` and `Aefos.Addons.Installer`. An alias is the same type on every compiler.

### Proof
Full `scripts\build-packages.ps1 -Version all` inside the D10/D11 VM (BDS 17.0 through 22.0):

- 6 IDEs x 10 BPLs, suffixes 230/240/250/260/270/280 — all green, including the whole WebView2 store (#40–#43) on 10 Seattle
- `AefosAgent.exe`, `aefos.exe`, `AefosDesktopMcp.exe`, desktop addon dist — all green
- the D11-built `aefos.exe` runs and lists the official gallery
- rebuilt on Delphi 13 as well, so the new compiler did not regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)