### PR TITLE
addon.json v1: one bundle can carry several commands and skills

### DIFF
--- a/cli/Aefos.Addons.Installer.pas
+++ b/cli/Aefos.Addons.Installer.pas
@@ -360,11 +360,139 @@ end;
 procedure _RemoveSlugDirs(const ASlug: string);
 var
   LDir: string;
+  LNamed: TArray<string>;
+  LIndex: Integer;
 begin
   for LDir in [TAddonPaths.CommandDir(ASlug), TAddonPaths.SkillDir(ASlug), TAddonPaths.TemplateDir(ASlug),
     TAddonPaths.AddonDir(ASlug)] do
     if TDirectory.Exists(LDir) then
       TDirectory.Delete(LDir, True);
+  // A multi-artifact bundle spreads over <root>\<slug>.<name>, which is not one
+  // directory this can name up front. Sweeping the pattern is what makes a
+  // reinstall clean-replace: an addon that DROPPED a command or skill in its
+  // new version would otherwise leave the old one behind, still loaded, forever.
+  for LDir in [TAddonPaths.CommandsRoot, TAddonPaths.SkillsRoot] do
+  begin
+    if not TDirectory.Exists(LDir) then
+      Continue;
+    LNamed := TDirectory.GetDirectories(LDir, ASlug + '.*');
+    for LIndex := 0 to High(LNamed) do
+      if TDirectory.Exists(LNamed[LIndex]) then
+        TDirectory.Delete(LNamed[LIndex], True);
+  end;
+end;
+
+// The trigger names the chat will really show, taken from the directories that
+// were laid down under commands\ rather than from the slug. An install[]-mapped
+// bundle is covered by the same walk, so the announcement follows whatever the
+// mapping chose to create.
+function _CommandNamesFrom(const ARoots: TList<string>): string;
+var
+  LIndex: Integer;
+  LParent: string;
+begin
+  Result := '';
+  LParent := ExcludeTrailingPathDelimiter(TAddonPaths.CommandsRoot);
+  for LIndex := 0 to ARoots.Count - 1 do
+    if SameText(ExcludeTrailingPathDelimiter(ExtractFileDir(
+      ExcludeTrailingPathDelimiter(ARoots[LIndex]))), LParent) then
+    begin
+      if Result <> '' then
+        Result := Result + ', ';
+      Result := Result + '/' +
+        ExtractFileName(ExcludeTrailingPathDelimiter(ARoots[LIndex]));
+    end;
+end;
+
+// Lays down the addon's command(s). TWO bundle layouts are accepted on purpose:
+//
+//   command\COMMAND.md      one command - every addon in the gallery today
+//                           -> commands\<slug>\COMMAND.md        (/<slug>)
+//   commands\<name>\        SEVERAL commands, a folder each
+//                           -> commands\<slug>.<name>\COMMAND.md (/<slug>.<name>)
+//
+// The plural is a FOLDER per command, not a file per command, because that is
+// what the chat's command registry reads: it keys a command by its directory
+// name and loads <dir>\COMMAND.md, with an optional references\ beside it
+// (Aefos.OTA.Chat.Core.CommandRegistry). Copying loose .md files here would
+// install commands the picker never shows - present on disk, dead in the IDE.
+procedure _InstallCommands(const ABundleDir, ASlug: string;
+  const AFiles, ARoots: TList<string>; const ALog: TAddonLog);
+var
+  LPluralDir, LTargetDir: string;
+  LDirs: TArray<string>;
+  LIndex, LBefore: Integer;
+begin
+  LBefore := AFiles.Count;
+  LPluralDir := TPath.Combine(ABundleDir, 'commands');
+  if TDirectory.Exists(LPluralDir) then
+  begin
+    LDirs := TDirectory.GetDirectories(LPluralDir);
+    for LIndex := 0 to High(LDirs) do
+    begin
+      LTargetDir := TAddonPaths.CommandDirNamed(ASlug, ExtractFileName(LDirs[LIndex]));
+      // The whole folder, so an optional references\ travels with its command.
+      _CopyTree(LDirs[LIndex], LTargetDir, AFiles);
+      ARoots.Add(LTargetDir);
+      ALog('  + command  ' + LTargetDir);
+    end;
+  end
+  else
+  begin
+    LTargetDir := TAddonPaths.CommandDir(ASlug);
+    _CopyOneFile(TPath.Combine(ABundleDir, 'command\COMMAND.md'),
+      TPath.Combine(LTargetDir, 'COMMAND.md'), AFiles);
+    ARoots.Add(LTargetDir);
+    ALog('  + command  ' + LTargetDir);
+  end;
+  // Declared and empty is never a success - it means addon.json disagrees with
+  // the bundle, and a silent no-op would be recorded in the ledger as installed.
+  if AFiles.Count = LBefore then
+    raise EAddonIntegrity.CreateFmt(
+      'addon "%s" declares a command but the bundle carries neither ' +
+      'command\COMMAND.md nor any commands\<name>\.', [ASlug]);
+end;
+
+// Lays down the addon's skill(s), same two-layout rule as the commands above:
+//
+//   skill\                one skill  -> skills\<slug>\
+//   skills\<name>\        SEVERAL    -> skills\<slug>.<name>\
+//
+// The prefix on the plural form is what keeps two addons from overwriting each
+// other in the flat skills root (see TAddonPaths.SkillDirNamed).
+procedure _InstallSkills(const ABundleDir, ASlug: string;
+  const AFiles, ARoots: TList<string>; const ALog: TAddonLog);
+var
+  LPluralDir, LTargetDir: string;
+  LDirs: TArray<string>;
+  LIndex, LBefore: Integer;
+begin
+  LBefore := AFiles.Count;
+  LPluralDir := TPath.Combine(ABundleDir, 'skills');
+  if TDirectory.Exists(LPluralDir) then
+  begin
+    LDirs := TDirectory.GetDirectories(LPluralDir);
+    for LIndex := 0 to High(LDirs) do
+    begin
+      // ExtractFileName over a directory path with no trailing separator is the
+      // folder's own name - the skill name the bundle chose.
+      LTargetDir := TAddonPaths.SkillDirNamed(ASlug, ExtractFileName(LDirs[LIndex]));
+      _CopyTree(LDirs[LIndex], LTargetDir, AFiles);
+      ARoots.Add(LTargetDir);
+      ALog('  + skill    ' + LTargetDir);
+    end;
+  end
+  else
+  begin
+    LTargetDir := TAddonPaths.SkillDir(ASlug);
+    _CopyTree(TPath.Combine(ABundleDir, 'skill'), LTargetDir, AFiles);
+    ARoots.Add(LTargetDir);
+    ALog('  + skill    ' + LTargetDir);
+  end;
+  if AFiles.Count = LBefore then
+    raise EAddonIntegrity.CreateFmt(
+      'addon "%s" declares a skill but the bundle carries neither skill\ ' +
+      'nor any skills\<name>\.', [ASlug]);
 end;
 
 procedure _RequireConsent(const AEntry: TAddonRegistryEntry;
@@ -487,6 +615,7 @@ var
   LFiles, LRoots, LScratch: TList<string>;
   LArts: TAddonArtifacts;
   LItem: TInstalledAddon;
+  LCommands: string;
 begin
   if not TAddonPaths.IsValidSlug(ASlug) then
     raise EAddonError.CreateFmt('invalid addon slug "%s".', [ASlug]);
@@ -645,18 +774,9 @@ begin
         _RemoveSlugDirs(ASlug);
         LArts := LManifest.Artifacts;
         if LArts.HasCommand then
-        begin
-          _CopyOneFile(TPath.Combine(LBundleDir, 'command\COMMAND.md'),
-            TPath.Combine(TAddonPaths.CommandDir(ASlug), 'COMMAND.md'), LFiles);
-          LRoots.Add(TAddonPaths.CommandDir(ASlug));
-          ALog('  + command  ' + TAddonPaths.CommandDir(ASlug));
-        end;
+          _InstallCommands(LBundleDir, ASlug, LFiles, LRoots, ALog);
         if LArts.HasSkill then
-        begin
-          _CopyTree(TPath.Combine(LBundleDir, 'skill'), TAddonPaths.SkillDir(ASlug), LFiles);
-          LRoots.Add(TAddonPaths.SkillDir(ASlug));
-          ALog('  + skill    ' + TAddonPaths.SkillDir(ASlug));
-        end;
+          _InstallSkills(LBundleDir, ASlug, LFiles, LRoots, ALog);
         if LArts.HasMcp then
         begin
           // Resolve ${ADDON_ROOT} to the absolute install dir so a raw MCP
@@ -698,6 +818,10 @@ begin
       LItem.Files := LFiles.ToArray;
       LItem.Roots := LRoots.ToArray;
       TAddonLedger.Save(TAddonLedger.Upsert(TAddonLedger.Load, LItem));
+      // Read the trigger names off what was actually laid down, while the roots
+      // are still alive - a multi-command bundle installs /<slug>.<name>, so
+      // announcing "/<slug>" would name a command that does not exist.
+      LCommands := _CommandNamesFrom(LRoots);
     finally
       LRoots.Free;
       LFiles.Free;
@@ -710,8 +834,8 @@ begin
     end;
 
     ALog(Format('Installed %s %s.', [ASlug, _VerLabel(LEntry.Version)]));
-    if LManifest.Artifacts.HasCommand then
-      ALog(Format('  /%s is now available in Aefos chat.', [ASlug]));
+    if LCommands <> '' then
+      ALog('  Now available in Aefos chat: ' + LCommands);
   finally
     try
       // LTempDir is always OURS - a folder bundle was copied into it, never

--- a/cli/Aefos.Addons.Paths.pas
+++ b/cli/Aefos.Addons.Paths.pas
@@ -28,12 +28,23 @@ type
 
     { ~/.aefos\commands }
     class function CommandsRoot: string; static;
-    { ~/.aefos\commands\<slug> }
+    { ~/.aefos\commands\<slug> - where a single-command bundle lands. }
     class function CommandDir(const ASlug: string): string; static;
+    { ~/.aefos\commands\<slug>.<name> - ONE command of a multi-command bundle.
+      The command registry keys a command by its FOLDER name (it reads
+      <name>\COMMAND.md), and that root is flat and shared, so the slug prefix
+      is what stops two addons shipping a "review" command from colliding. }
+    class function CommandDirNamed(const ASlug, AName: string): string; static;
     { ~/.aefos\skills }
     class function SkillsRoot: string; static;
-    { ~/.aefos\skills\<slug> }
+    { ~/.aefos\skills\<slug> - where a single-skill bundle lands. }
     class function SkillDir(const ASlug: string): string; static;
+    { ~/.aefos\skills\<slug>.<name> - where ONE skill of a multi-skill bundle
+      lands. The slug prefix is not decoration: skills share one flat root, so
+      two addons each shipping a "review" skill would otherwise overwrite each
+      other, and which one survived would depend on install order. Both parts
+      are slug-validated, so neither can traverse out of the skills tree. }
+    class function SkillDirNamed(const ASlug, AName: string): string; static;
     { ~/.aefos\templates }
     class function TemplatesRoot: string; static;
     { ~/.aefos\templates\<slug> }
@@ -97,6 +108,11 @@ begin
   Result := TPath.Combine(CommandsRoot, _RequireSlug(ASlug));
 end;
 
+class function TAddonPaths.CommandDirNamed(const ASlug, AName: string): string;
+begin
+  Result := TPath.Combine(CommandsRoot, _RequireSlug(ASlug) + '.' + _RequireSlug(AName));
+end;
+
 class function TAddonPaths.SkillsRoot: string;
 begin
   Result := TPath.Combine(UserRoot, 'skills');
@@ -105,6 +121,11 @@ end;
 class function TAddonPaths.SkillDir(const ASlug: string): string;
 begin
   Result := TPath.Combine(SkillsRoot, _RequireSlug(ASlug));
+end;
+
+class function TAddonPaths.SkillDirNamed(const ASlug, AName: string): string;
+begin
+  Result := TPath.Combine(SkillsRoot, _RequireSlug(ASlug) + '.' + _RequireSlug(AName));
 end;
 
 class function TAddonPaths.TemplatesRoot: string;

--- a/docs/addons-contract.md
+++ b/docs/addons-contract.md
@@ -97,6 +97,51 @@ Canonical tree — every folder is **optional** except `addon.json`:
 The zip MUST contain exactly one top-level `<slug>/` folder matching the
 registry slug (the CLI validates this before extracting).
 
+### 3.2 Several commands / several skills in one bundle
+
+`command/` and `skill/` above are the **single** form: one of each. A bundle
+that carries **more than one** uses the plural folder instead, a directory per
+artifact:
+
+```
+<slug>/
+├── addon.json
+├── commands/                  # instead of command/
+│   ├── build/
+│   │   ├── COMMAND.md         # required — the trigger body
+│   │   └── references/…       # optional, travels with its command
+│   └── review/COMMAND.md
+└── skills/                    # instead of skill/
+    ├── test-runner/
+    │   ├── SKILL.md
+    │   └── okf/…
+    └── lint/SKILL.md
+```
+
+| bundle | installs to | trigger |
+|---|---|---|
+| `command/COMMAND.md` | `~/.aefos/commands/<slug>/` | `/<slug>` |
+| `commands/<name>/` | `~/.aefos/commands/<slug>.<name>/` | `/<slug>.<name>` |
+| `skill/` | `~/.aefos/skills/<slug>/` | — |
+| `skills/<name>/` | `~/.aefos/skills/<slug>.<name>/` | — |
+
+Rules that are not arbitrary:
+
+- **The plural is a folder per command, never a loose `.md`.** The chat's
+  command registry keys a command by its *directory* name and loads
+  `<dir>/COMMAND.md`; loose files would install commands the picker never shows.
+- **`<slug>.` prefix on the plural form.** `commands/` and `skills/` are flat,
+  shared roots. Two addons each shipping a `review` would otherwise overwrite
+  one another, and which survived would depend on install order.
+- **`artifacts` does not change.** `"command": true` covers both layouts — the
+  plural is discovered on disk, so the manifest cannot disagree with the bundle
+  about how many there are.
+- **Declared and empty fails the install.** `"command": true` with neither
+  `command/COMMAND.md` nor any `commands/<name>/` aborts instead of recording a
+  no-op as installed.
+- **Reinstall clean-replaces**, including artifacts the new version dropped:
+  install sweeps `<root>/<slug>.*` before laying the new set down.
+
 ### 3.1 `templates/` — carry-along scaffolds (optional, NOT a separate addon type)
 
 `templates/` is **not** an addon type — it is an **optional folder** an addon may
@@ -138,8 +183,8 @@ is no global, un-scoped template namespace to collide.
   "trust": "official",
   "requirements": { "aefos_version": ">=0.30.0" },
   "artifacts": {
-    "command":   true,        // command/COMMAND.md present -> ~/.aefos/commands/<slug>/
-    "skill":     true,        // skill/ present             -> ~/.aefos/skills/<slug>/
+    "command":   true,        // command/COMMAND.md OR commands/<name>/ (§3.2)
+    "skill":     true,        // skill/ OR skills/<name>/             (§3.2)
     "mcp":       false,        // mcp/server.json present   -> aggregated (§5)
     "tools":     false,        // tools/ present            -> ~/.aefos/addons/<slug>/tools/
     "templates": false         // templates/ present (§3.1) -> ~/.aefos/templates/<slug>/


### PR DESCRIPTION
A bundle was **one** command and **one** skill. A real plugin is several of each, so the layout gained a plural form — and nothing else did.

| bundle | installs to | trigger |
|---|---|---|
| `command/COMMAND.md` | `commands/<slug>/` | `/<slug>` |
| `commands/<name>/` | `commands/<slug>.<name>/` | `/<slug>.<name>` |
| `skill/` | `skills/<slug>/` | — |
| `skills/<name>/` | `skills/<slug>.<name>/` | — |

The singular stays valid, so the ten published addons and `registry.json` are untouched. `artifacts` keeps its booleans: **how many** is discovered on disk, which is one fewer thing `addon.json` can be wrong about.

### Three decisions worth stating

- **A folder per command, not a loose `.md`.** The chat registry keys a command by its *directory* name and loads `<dir>/COMMAND.md` (`CommandRegistry.pas:8`). Loose files would install commands the picker never shows — present on disk, dead in the IDE. Measured before writing the copy loop.
- **The `<slug>.` prefix.** `commands/` and `skills/` are flat shared roots; two addons each shipping `review` would overwrite one another and the survivor would depend on directory order. Same namespacing the foreign-format reader already proved.
- **Reinstall sweeps `<root>/<slug>.*` first**, so a version that DROPPED a skill actually loses it instead of leaving it loaded forever.

### Also fixes a wrong announcement that predates this
The installer said `/<slug> is now available` — but `janus-orm` installs its command as `/janus`. The names now come from what was laid down: `Now available in Aefos chat: /multi.build, /multi.review`.

### Proof (headless, fake `%USERPROFILE%` — the real `~/.aefos` never touched)
- two bundles both shipping `review` + `lint` install side by side as `multi.review` / `rival.review`
- `references/` travels with its command
- reinstall without `lint` removes `multi.lint`, leaves `rival.lint`
- uninstall takes only its own
- regression: `janus-orm` still installs from the live gallery

Contract updated: `docs/addons-contract.md` §3.2 — the section that will feed the store's "our format" tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)