### PR TITLE
CLA + trademark policy: keep the project relicensable as a whole

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,57 @@
+# Contributor License Agreement gate.
+#
+# Why it exists: Aefos AI is GPL v3 in public AND licensable commercially, and
+# that second half only works while ONE holder can relicense the whole tree.
+# A single unsigned contribution locks every file it touched to the GPL for
+# good. This check is what keeps that from happening quietly - see CLA.md.
+#
+# How a contributor signs: the bot comments on their first PR; they reply with
+# the exact sentence below, once, and every future PR of theirs is covered.
+#
+# Signatures are stored as JSON on the orphan branch `cla-signatures` of this
+# repository, so the record lives with the project and needs no external
+# service and no extra secret.
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check or record the CLA signature
+        if: >-
+          (github.event.comment.body == 'recreate-cla' ||
+           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+          github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: signatures/v1/cla.json
+          path-to-document: https://github.com/ModernDelphiWorks/Aefos/blob/main/CLA.md
+          branch: cla-signatures
+          # The copyright holder does not sign an agreement with himself, and
+          # bots have no copyright to grant.
+          allowlist: isaquepinheiro,dependabot[bot],github-actions[bot]
+          custom-notsigned-prcomment: >-
+            Thank you for the pull request. Before it can be merged, please sign the
+            [Contributor License Agreement](https://github.com/ModernDelphiWorks/Aefos/blob/main/CLA.md).
+            **You keep the copyright to your work** — the CLA grants a licence broad
+            enough that Aefos AI can also be licensed commercially, which is what
+            keeps the project GPL v3 in public and self-sustaining at the same time.
+            It takes one comment, once, and covers all your future contributions.
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: >-
+            CLA signed — thank you. Nothing else to do here, now or on any future
+            pull request.

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,137 @@
+# Aefos AI — Contributor License Agreement
+
+Thank you for contributing to **Aefos AI**.
+
+This agreement lets the project stay open **and** stay sustainable. It is the
+standard arrangement used by projects that are both free software and a
+business — Qt, MySQL and Grafana among them — and it is adapted from the widely
+used Apache Individual Contributor License Agreement.
+
+**You keep the copyright to what you write.** Nothing here transfers ownership.
+
+Read it once, sign it once. It then covers every contribution you make to this
+project.
+
+---
+
+## 1. Definitions
+
+**"Owner"** means Isaque de Souza Pinheiro, the copyright holder of Aefos AI.
+
+**"You"** means the individual signing below, or the legal entity on whose
+behalf it is signed.
+
+**"Contribution"** means any work of authorship you intentionally submit to this
+project — code, documentation, translations, configuration, artwork — whether by
+pull request, patch, issue comment, or any other means.
+
+---
+
+## 2. What you grant
+
+### 2.1 Copyright licence
+
+You grant the Owner a **perpetual, worldwide, non-exclusive, royalty-free,
+irrevocable** licence to reproduce, prepare derivative works of, publicly
+display, publicly perform, sublicense and distribute your Contribution and
+derivative works of it.
+
+**This licence includes the right to distribute your Contribution under any
+licence terms, including the GNU GPL v3 and including proprietary or commercial
+licences.**
+
+That last sentence is the whole point of this document, so it is worth being
+plain about what it means:
+
+- The public Aefos AI stays under the **GNU GPL v3**, and your Contribution goes
+  out under the GPL v3 like everything else.
+- The Owner may **also** license the same code commercially — for example to a
+  company that needs to embed it in a closed product — and may release future
+  versions under different terms.
+- Without this grant, that would be impossible for any file you touched: the
+  Owner would have to remove your work or track you down for permission years
+  later. This paragraph is what keeps the project relicensable **as a whole**.
+
+### 2.2 Patent licence
+
+You grant the Owner and every recipient of the software a perpetual, worldwide,
+non-exclusive, royalty-free, irrevocable patent licence to make, use, sell,
+offer to sell, import and otherwise transfer your Contribution — limited to
+those patent claims you own or control that are necessarily infringed by your
+Contribution alone or by its combination with the project.
+
+If you begin patent litigation alleging that the project or a Contribution
+infringes a patent, the patent licences granted to you under this agreement
+terminate as of the date the litigation is filed.
+
+### 2.3 What you keep
+
+You keep all other rights to your Contribution. You may use it elsewhere, sell
+it, relicense it, or build on it however you like. This agreement is
+**non-exclusive** — you are lending, not selling.
+
+---
+
+## 3. What you promise
+
+By signing, you confirm that:
+
+1. **The work is yours to give.** You wrote it, or you otherwise have the right
+   to submit it under this agreement.
+2. **Your employer is not in the way.** If your employer has rights to work you
+   produce — because of an employment contract or because you used their
+   equipment or time — you have either obtained permission to contribute, or
+   your employer has waived those rights, or your employer has signed this
+   agreement as an entity.
+3. **Third-party material is declared.** If your Contribution includes work you
+   did not write, you have the right to include it, and you have identified it
+   (source and licence) in the pull request.
+4. **You are not knowingly infringing.** To the best of your knowledge, your
+   Contribution does not violate anyone else's rights.
+
+---
+
+## 4. What you do not promise
+
+Your Contribution is provided **as is**, without warranty of any kind. You are
+not required to support it, fix it, or keep working on the project.
+
+---
+
+## 5. Attribution
+
+Signing this does not make your work anonymous. Your commits keep your name and
+your authorship in the Git history, and that history is public and permanent.
+
+---
+
+## 6. How to sign
+
+The CLA bot comments on your first pull request with a link. Reply to that
+comment with exactly:
+
+```
+I have read the CLA Document and I hereby sign the CLA
+```
+
+Your signature is recorded against your GitHub account and covers all your
+future pull requests to this repository. You never have to do it again.
+
+**Contributing on behalf of a company?** Have someone authorised to bind the
+company email **tecsisinfo.com.br@gmail.com** before you open the pull request, so
+the entity signature can be recorded instead of an individual one.
+
+---
+
+## 7. Questions
+
+If any of this is unclear, or the terms do not work for your situation, open a
+[Discussion](../../discussions) or email **tecsisinfo.com.br@gmail.com** *before*
+writing code — it is far easier to sort out first than after the work exists.
+
+This document is not legal advice, and its author is not a lawyer. If you need
+certainty, have your own counsel read it.
+
+---
+
+Copyright © 2026 Isaque de Souza Pinheiro.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,11 +60,30 @@ New to the codebase? [`docs/architecture.md`](docs/architecture.md) is the map, 
    ```
    Open `docs/manual/_html/README.html` (PT) or `docs/manual/_html-en/README.html` (EN).
 
-## Licensing of your contribution
+## Licensing of your contribution — the CLA
 
-Aefos is GPL v3. By contributing code you agree it is licensed under the same terms,
-and you confirm you have the right to contribute it — that it is yours to give, and
-not your employer's.
+Before your first pull request can be merged, you sign the
+[Contributor License Agreement](CLA.md). A bot comments on the PR with a link; you
+reply to it once, and every future PR of yours is covered.
+
+**You keep the copyright to what you write.** What you grant is a licence — one
+broad enough that Aefos AI can also be licensed commercially. That is what lets the
+project stay GPL v3 in public *and* pay for itself, the same arrangement Qt, MySQL
+and Grafana use.
+
+Without it, any file a contributor touched would be locked to the GPL for good: the
+maintainer would have to remove that work or hunt down its author years later to
+release anything under other terms.
+
+You also confirm the work is **yours to give** — not your employer's — and that any
+third-party material in it is declared. The details are in [CLA.md](CLA.md), and it
+is short.
+
+## The name "Aefos AI"
+
+The code is GPL v3; the **name and logo are not**. You are free to fork, modify and
+redistribute under the GPL, but a fork is not "Aefos AI" — see
+[TRADEMARK.md](TRADEMARK.md) before naming a derivative.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,10 @@ design-time package cannot exist without is expressly allowed.
 The licence that governed the software before 5 August 2026, when it was
 proprietary, is kept for the record in [`EULA-historical.md`](EULA-historical.md).
 
+The **code** is GPL v3; the **name and logo are not** — a fork is welcome, but it
+is not "Aefos AI". See [`TRADEMARK.md`](TRADEMARK.md). Contributors sign a short
+[CLA](CLA.md) and keep the copyright to their own work.
+
 ## Updating, reinstalling & moving to another machine
 
 Close RAD Studio and run the new `Aefos-Setup-*.exe` over the old one. That is the

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -1,0 +1,67 @@
+# Aefos AI — Trademark Policy
+
+The **code** of Aefos AI is free software under the GNU GPL v3.
+
+The **name "Aefos AI", the name "Aefos", and the Aefos logo** are not. They
+identify the official project, and that is the whole point of a name: when
+someone downloads "Aefos AI", they should get the thing this project actually
+released.
+
+A software licence and a trademark are two different things. The GPL v3 gives
+you broad rights over the source — to use it, study it, change it, and
+redistribute it. It does not give anyone the right to use the project's name to
+present something else as the official product.
+
+---
+
+## What you may do without asking
+
+- **Say what your software is built on.** "Based on Aefos AI", "a fork of
+  Aefos AI", "compatible with Aefos AI" — accurate, factual references are fine
+  and always will be.
+- **Redistribute Aefos AI unmodified**, under the GPL v3, with its name intact.
+- **Write about the project** — articles, tutorials, videos, courses, talks,
+  reviews. Praise it or tear it apart; both are fair use of the name.
+- **Use the name in an issue, a pull request, a package description, or an
+  academic paper.**
+
+## What needs a different name
+
+- **A modified version distributed to others.** Change the code and ship it, and
+  it is your product, not this one. Give it your own name. You may (and should)
+  state that it derives from Aefos AI.
+- **Anything that implies official status** — "Aefos AI Pro", "Aefos AI
+  Enterprise", "Aefos AI for X" — unless we have agreed to it in writing.
+- **Domains, social accounts, app-store listings, or company names** built around
+  "Aefos".
+- **The logo, modified.** Use it as published or not at all.
+
+The rule behind all of it: **do not let a user think your build is ours.** If a
+reasonable person could be misled about where the software came from or who
+stands behind it, the name has gone too far.
+
+---
+
+## Why this exists
+
+The GPL guarantees that anyone can fork Aefos AI. This document is not an
+attempt to walk that back — the fork is your right, and it is protected.
+
+What it protects is the other side of the same freedom: that a user who
+downloads a broken or malicious build cannot be told it is the official Aefos
+AI, and that this project remains answerable only for what it actually shipped.
+
+---
+
+## Asking
+
+Anything not covered here, or a use you would like permission for, goes to
+**tecsisinfo.com.br@gmail.com**. Reasonable requests are usually granted, and
+saying yes in writing costs nothing.
+
+This document is not legal advice, and its author is not a lawyer.
+
+---
+
+Copyright © 2026 Isaque de Souza Pinheiro. "Aefos" and "Aefos AI" are
+trademarks of Isaque de Souza Pinheiro.


### PR DESCRIPTION
Aefos is GPL v3 in public **and** licensable commercially — and the second half only works while **one holder can relicense the whole tree**.

Today `CONTRIBUTING.md` says a contribution is "licensed under the same terms". That is exactly the arrangement that makes dual licensing impossible: the contributor keeps their copyright, the file is locked to the GPL, and releasing anything under other terms later means deleting their work or tracking them down years afterwards.

**One unsigned contribution is enough to do it**, and the repo has been public since 5 August 2026. Right now every commit is yours, so this costs nothing. It stops being cheap the day someone else's PR lands.

### What lands

- **`CLA.md`** — adapted from the Apache ICLA. The contributor **keeps copyright** and grants a *non-exclusive* licence that includes the right to distribute under other terms, including proprietary ones. Plus the patent grant, the employer-rights promise, and the third-party-material declaration.
- **`.github/workflows/cla.yml`** — the bot asks on the first PR; the contributor replies with one sentence, once, and it covers all their future PRs. Signatures are stored as JSON on an orphan `cla-signatures` branch **of this repo** — no external service, no extra secret (`GITHUB_TOKEN` + `contents: write`). You and the bots are allowlisted; nobody signs an agreement with himself.
- **`TRADEMARK.md`** — the other half, and a *different right entirely*. The GPL covers the **code**; it grants no one the use of the **name** to present a fork as the official product. It says plainly what needs no permission (forking, writing about it, "based on Aefos AI") and what needs a new name.
- `CONTRIBUTING.md` / `README.md` point at both.

### Checks
YAML parses; the action version `v2.6.1` is the current release. Both documents state they are not legal advice.

### After merge
The workflow only takes effect for PRs opened after it is on `main`. Nothing to configure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)