### PR TITLE
A store pointed at an addon says so, instead of reading as empty

### DIFF
--- a/cli/Aefos.Addons.Catalog.pas
+++ b/cli/Aefos.Addons.Catalog.pas
@@ -271,6 +271,20 @@ begin
             Inc(LCount);
           end;
           SetLength(Result.Rows, LCount);
+          // A store is the folder that CONTAINS addons, one per subfolder. Point
+          // it at an addon itself - the obvious mistake, and the one a folder
+          // picker practically invites - and every subfolder is that bundle's
+          // own commands/, payload/, tools/, so the store reads as EMPTY.
+          // Measured live: the maintainer browsed to the bundle, got a silent
+          // "Custom 0", and had no way to tell that from a store with nothing
+          // published in it. Say which one it is, and name the folder to use.
+          if (LCount = 0) and
+             TFile.Exists(TPath.Combine(ASource.Location, 'addon.json')) then
+            raise EAddonError.CreateFmt(
+              'folder "%s" IS an addon, not a store. A store is the folder that ' +
+              'holds addons - point it at "%s".',
+              [ASource.Location,
+               ExtractFileDir(ExcludeTrailingPathDelimiter(ASource.Location))]);
         end;
     else
       // Named in the config format from the start so adding it later needs no


### PR DESCRIPTION
Watched live, minutes after the Browse button shipped. Browsing to the bundle — `D:\Ecossistema-Skills\setup-aefos-studio` — and adding it as a store produced **"Custom 0"**. No banner, no error: *a store with nothing published in it* and *a store pointed one folder too deep* look identical.

A `path` store is the folder that **contains** addons, one per subfolder. Point it at an addon and every subfolder is that bundle's own `commands/`, `payload/`, `tools/` — none carrying an `addon.json`. The catalogue comes back empty, correct, and useless.

The folder picker makes this the **natural** mistake rather than a rare one: what you see and click is the addon, not its parent.

### The fix
When a path store yields nothing **and** the folder itself carries an `addon.json`, it refuses with the sentence that ends the confusion — naming the folder to use:

```
folder "...\setup-aefos-studio" IS an addon, not a store. A store is the
folder that holds addons - point it at "D:\Ecossistema-Skills".
```

The store window already renders a source error as a banner, so nothing changes on the page.

**Deliberately narrow:** a folder with no `addon.json` and no bundles stays silent — an empty store is a legitimate state (a share nobody has published to yet), and turning that into an error would be the opposite mistake.

### Proof
On the real folders: pointed at the bundle it refuses by name; pointed at the parent the addon lists; pointed at an empty temp dir it says nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)