### PR TITLE
Install from a folder store REGISTERS the bundle; it no longer copies it

### DIFF
--- a/cli/Aefos.Addons.Installer.pas
+++ b/cli/Aefos.Addons.Installer.pas
@@ -386,6 +386,47 @@ begin
   AFiles.Add(ADstFile);
 end;
 
+// Rebuilds ~/.aefos\addons\command-roots.json from every LINKED addon in the
+// ledger: the folders the plugin should read commands from besides
+// ~/.aefos\commands.
+//
+// Same arrangement as the MCP aggregate, and for the same reason: the CLI owns
+// what it knows (which addons are installed and where they came from), the
+// plugin owns what IT knows (how to read a command), and neither has to guess
+// at the other's file format.
+//
+// A linked addon that no longer has its folder is written out anyway. Dropping
+// it here would make a moved folder look like an addon that was never
+// installed; the plugin skips a root it cannot read, and `aefos list` is where
+// the user sees it is still expected.
+procedure _RefreshCommandRoots;
+var
+  LItems: TArray<TInstalledAddon>;
+  LIndex: Integer;
+  LRoot: TJSONObject;
+  LArr: TJSONArray;
+  LDir: string;
+begin
+  LItems := TAddonLedger.Load;
+  LRoot := TJSONObject.Create;
+  try
+    LArr := TJSONArray.Create;
+    LRoot.AddPair('commandRoots', LArr);
+    for LIndex := 0 to High(LItems) do
+    begin
+      if LItems[LIndex].Origin = '' then
+        Continue;                          // copied: already under ~/.aefos
+      LDir := TPath.Combine(LItems[LIndex].Origin, 'commands');
+      LArr.Add(LDir);
+    end;
+    ForceDirectories(TAddonPaths.AddonsRoot);
+    TFile.WriteAllBytes(TAddonPaths.CommandRootsPath,
+      TEncoding.UTF8.GetBytes(LRoot.Format(2)));
+  finally
+    LRoot.Free;
+  end;
+end;
+
 // Rebuilds ~/.aefos\addons\mcp-servers.json from every ledger addon that ships
 // an mcp.json fragment. The plugin merges this file into aefos-mcp.json; the
 // CLI never writes aefos-mcp.json itself (contract §5).
@@ -482,6 +523,28 @@ begin
       Result := Result + '/' +
         ExtractFileName(ExcludeTrailingPathDelimiter(ARoots[LIndex]));
     end;
+end;
+
+// The trigger names a LINKED addon makes available: the folders under its own
+// commands\ directory, which is where they stay. Same sentence as the copied
+// case, read from the other side.
+function _CommandNamesIn(const ACommandsDir: string): string;
+var
+  LDirs: TArray<string>;
+  LIndex: Integer;
+begin
+  Result := '';
+  if not TDirectory.Exists(ACommandsDir) then
+    Exit;
+  LDirs := TDirectory.GetDirectories(ACommandsDir);
+  for LIndex := 0 to High(LDirs) do
+  begin
+    if not TFile.Exists(TPath.Combine(LDirs[LIndex], 'COMMAND.md')) then
+      Continue;
+    if Result <> '' then
+      Result := Result + ', ';
+    Result := Result + '/' + ExtractFileName(ExcludeTrailingPathDelimiter(LDirs[LIndex]));
+  end;
 end;
 
 // Lays down the addon's command(s). TWO bundle layouts are accepted on purpose:
@@ -695,6 +758,7 @@ var
   LArts: TAddonArtifacts;
   LItem: TInstalledAddon;
   LCommands: string;
+  LLinked: Boolean;
 begin
   if not TAddonPaths.IsValidSlug(ASlug) then
     raise EAddonError.CreateFmt('invalid addon slug "%s".', [ASlug]);
@@ -816,10 +880,38 @@ begin
     // actually go - before the new copy can add more.
     _SweepMovedAside(TAddonPaths.AddonDir(ASlug));
 
+    // LINK, don't copy, when the bundle lives somewhere permanent and carries
+    // nothing that has to run from a stable path.
+    //
+    // WHY. A folder store IS the install: the commands are already on disk, in
+    // a folder the user maintains. Copying them makes a second copy that is
+    // stale the moment the first is edited, and - measured, the hard way - an
+    // install that overwrites same-named commands ADOPTS them, so uninstalling
+    // the addon deletes files another installer had put there. Recording the
+    // folder avoids both.
+    //
+    // WHY NOT ALWAYS. mcp and tools are code Aefos launches. Those need a path
+    // that survives the bundle folder being moved, so a bundle carrying either
+    // is still copied - and says so, rather than half-linking in silence.
+    LLinked := (LStoreDir <> '') and
+               (not LManifest.Artifacts.HasMcp) and (not LManifest.Artifacts.HasTools);
+    if LLinked then
+    begin
+      _RemoveSlugDirs(ASlug);            // clear a previous COPIED install
+      LArts := LManifest.Artifacts;
+      ALog(Format('  = linked   %s', [LStoreDir]));
+      ALog('    (nothing copied - the chat reads the commands where they are)');
+    end;
+
     LFiles := TList<string>.Create;
     LRoots := TList<string>.Create;
     try
-      if Length(LManifest.Install) > 0 then
+      if LLinked then
+      begin
+        // Nothing to lay down. The ledger records the folder and the aggregate
+        // publishes it; that IS the install.
+      end
+      else if Length(LManifest.Install) > 0 then
       begin
         // Portal manifest: explicit source -> ~/.aefos\target_path mappings.
         _ApplyInstallMappings(LBundleDir, LManifest.Install, LFiles, LRoots,
@@ -881,11 +973,18 @@ begin
       LItem.Artifacts := LArts;
       LItem.Files := LFiles.ToArray;
       LItem.Roots := LRoots.ToArray;
+      // Set only when linked, and it is what tells uninstall to remove a record
+      // rather than files, and the aggregate which folder to publish.
+      if LLinked then
+        LItem.Origin := LStoreDir;
       TAddonLedger.Save(TAddonLedger.Upsert(TAddonLedger.Load, LItem));
       // Read the trigger names off what was actually laid down, while the roots
       // are still alive - a multi-command bundle installs /<slug>.<name>, so
       // announcing "/<slug>" would name a command that does not exist.
-      LCommands := _CommandNamesFrom(LRoots);
+      if LLinked then
+        LCommands := _CommandNamesIn(TPath.Combine(LStoreDir, 'commands'))
+      else
+        LCommands := _CommandNamesFrom(LRoots);
     finally
       LRoots.Free;
       LFiles.Free;
@@ -896,6 +995,10 @@ begin
       _RefreshMcpAggregate;
       ALog('  * MCP server registered (plugin picks it up on next provision).');
     end;
+    // Always, not only when this install linked: a COPIED install over a
+    // previously linked one has to drop the stale root, or the chat would keep
+    // reading commands from a folder this addon no longer uses.
+    _RefreshCommandRoots;
 
     if AOptions.Updating then
       ALog(Format('Updated %s to %s.', [ASlug, _VerLabel(LEntry.Version)]))
@@ -930,9 +1033,15 @@ begin
   LItems := TAddonLedger.Load;
   if not TAddonLedger.TryFind(LItems, ASlug, LItem) then
     raise EAddonNotFound.CreateFmt('addon "%s" is not installed.', [ASlug]);
+  // A LINKED addon put nothing on disk, so uninstalling it deletes nothing: it
+  // drops the record, and the aggregate stops publishing the folder. The bundle
+  // is the user's own working directory - deleting from there would be us
+  // removing their files because they pressed Remove on ours.
+  if LItem.Origin <> '' then
+    ALog(Format('  = unlinked %s (left untouched)', [LItem.Origin]))
   // Remove exactly the target dirs recorded at install (guarded under ~/.aefos);
   // fall back to the slug dirs for a pre-Roots ledger entry.
-  if Length(LItem.Roots) > 0 then
+  else if Length(LItem.Roots) > 0 then
   begin
     for LRoot in LItem.Roots do
       if _UnderUserRoot(LRoot) and TDirectory.Exists(LRoot) then
@@ -943,6 +1052,7 @@ begin
   TAddonLedger.Save(TAddonLedger.Remove(LItems, ASlug));
   if LItem.Artifacts.HasMcp then
     _RefreshMcpAggregate;
+  _RefreshCommandRoots;
   ALog(Format('Removed %s %s.', [ASlug, _VerLabel(LItem.Version)]));
 end;
 

--- a/cli/Aefos.Addons.Ledger.pas
+++ b/cli/Aefos.Addons.Ledger.pas
@@ -76,6 +76,10 @@ begin
   Result.AddPair('sha256', AItem.Sha256);
   Result.AddPair('installedAt', AItem.InstalledAt);
   Result.AddPair('source', AItem.Source);
+  // Only written when the addon was linked, so a copied one's record keeps the
+  // shape it has always had.
+  if AItem.Origin <> '' then
+    Result.AddPair('origin', AItem.Origin);
   Result.AddPair('artifacts', _ArtifactsToJson(AItem.Artifacts));
   LFiles := TJSONArray.Create;
   for LIndex := 0 to High(AItem.Files) do
@@ -142,6 +146,9 @@ begin
   // Absent in a ledger written before stores existed. Empty means "wherever it
   // can be found", which is what that older install actually meant.
   Result.Source := _Str(AObj, 'source');
+  // Absent for a copied addon, which is every record written before linking
+  // existed - so empty keeps meaning exactly what it meant: this one was copied.
+  Result.Origin := _Str(AObj, 'origin');
   LArt := AObj.Values['artifacts'];
   if LArt is TJSONObject then
   begin

--- a/cli/Aefos.Addons.Paths.pas
+++ b/cli/Aefos.Addons.Paths.pas
@@ -57,6 +57,12 @@ type
     class function LedgerPath: string; static;
     { ~/.aefos\addons\mcp-servers.json - the aggregate the plugin merges. }
     class function McpAggregatePath: string; static;
+    { ~/.aefos\addons\command-roots.json - the folders the plugin should read
+      commands from BESIDES ~/.aefos\commands. Written by install for a LINKED
+      addon (one taken from a folder store and never copied), so the chat sees
+      the commands where they already live. Same arrangement as the MCP
+      aggregate: the CLI writes it, the plugin reads it, neither guesses. }
+    class function CommandRootsPath: string; static;
   end;
 
 implementation
@@ -156,6 +162,11 @@ end;
 class function TAddonPaths.McpAggregatePath: string;
 begin
   Result := TPath.Combine(AddonsRoot, 'mcp-servers.json');
+end;
+
+class function TAddonPaths.CommandRootsPath: string;
+begin
+  Result := TPath.Combine(AddonsRoot, 'command-roots.json');
 end;
 
 end.

--- a/cli/Aefos.Addons.Types.pas
+++ b/cli/Aefos.Addons.Types.pas
@@ -129,6 +129,18 @@ type
       would be a supply-chain swap performed by us. Empty on a ledger written
       before sources existed, which reads as "wherever it can be found". }
     Source: string;
+    { Where the bundle LIVES, for an addon that was LINKED instead of copied.
+      Empty for a copied one.
+
+      A folder store is somewhere permanent, so an addon taken from one needs no
+      second copy of itself under ~/.aefos: install RECORDS the folder, and the
+      plugin reads the commands where they already are. Editing the bundle is
+      then live, and there is exactly one copy on disk to keep straight.
+
+      The cost is paid where it is stated: move or delete that folder and the
+      commands stop resolving. An archive store has no such folder, so bundles
+      from one are still copied. }
+    Origin: string;
     Artifacts: TAddonArtifacts;
     Files: TArray<string>;
     Roots: TArray<string>;  // absolute ~/.aefos target dirs to remove on uninstall

--- a/source/chat/Core/Aefos.OTA.Chat.Core.CommandRegistry.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.CommandRegistry.pas
@@ -64,10 +64,33 @@ type
     // wins). Returns False when the command is in neither catalogue.
     function _FindCommandRoot(const ACommandName: string; out ARoot: string;
       out AScope: TCommandScope): Boolean;
+    { The folders an installed LINKED addon publishes: bundles that were
+      registered where they live instead of being copied under ~/.aefos. Read
+      from the aggregate `~/.aefos\addons\command-roots.json`, which the CLI
+      writes on install/uninstall - the same arrangement as the MCP aggregate,
+      and for the same reason: neither side parses the other's private files. }
+    function _LinkedCommandsDirs: TArray<string>;
+    { The same three path rules as _CommandsDir/_CommandDir/_CommandFile, but
+      taking the commands FOLDER directly. A linked addon's folder is already
+      the commands directory, with no `.aefos\commands` under it. }
+    function _CommandDirIn(const ACommandsDir, ACommandName: string): string;
+    function _CommandFileIn(const ACommandsDir, ACommandName: string): string;
+    function _ReferenceFileIn(const ACommandsDir, ACommandName,
+      AReferenceName: string): string;
+    { Resolves the commands FOLDER holding ACommandName: project, then global,
+      then the linked addons. Reading sees linked commands; WRITING does not -
+      SaveCommand/SaveReference keep using _FindCommandRoot, because a linked
+      folder is the user's own working directory and Aefos does not edit it. }
+    function _FindCommandsDir(const ACommandName: string;
+      out ACommandsDir: string; out AScope: TCommandScope): Boolean;
     function _BuildMetadata(const ACommandDir, ACommandFile: string): TCommandMetadata;
     function _DiscoverReferences(
       const ACommandDir: string): TArray<TCommandReference>;
     procedure _CollectFromRoot(const ARoot: string; const AScope: TCommandScope;
+      const ACollected: TList<TCommandMetadata>;
+      const ASeen: TDictionary<string, Byte>);
+    procedure _CollectFromCommandsDir(const ACommandsDir: string;
+      const AScope: TCommandScope;
       const ACollected: TList<TCommandMetadata>;
       const ASeen: TDictionary<string, Byte>);
     procedure _TryAppendCommand(const ACommandDir: string;
@@ -178,11 +201,14 @@ implementation
 uses
   System.Classes,
   System.Types,
+  System.JSON,
   System.IOUtils;
 
 const
   COMMAND_FILE_NAME = 'COMMAND.md';
   COMMANDS_FOLDER_REL = '.aefos\commands';
+  // Written by aefos.exe on install/uninstall of a LINKED addon; read here.
+  LINKED_ROOTS_REL = '.aefos\addons\command-roots.json';
   REFERENCES_FOLDER_NAME = 'references';
   MD_EXTENSION = '.md';
   COMMAND_NAME_MAX_LEN = 64;
@@ -548,6 +574,106 @@ begin
   Result := TPath.Combine(AProjectRoot, COMMANDS_FOLDER_REL);
 end;
 
+function TCommandRegistry._LinkedCommandsDirs: TArray<string>;
+var
+  LPath, LJson: string;
+  LVal, LItem: TJSONValue;
+  LArr: TJSONArray;
+  LIndex: Integer;
+  LList: TList<string>;
+begin
+  SetLength(Result, 0);
+  LPath := _ResolveGlobalRoot;
+  if LPath = '' then
+    Exit;
+  LPath := TPath.Combine(LPath, LINKED_ROOTS_REL);
+  if not TFile.Exists(LPath) then
+    Exit;                                  // no linked addon: the normal case
+  try
+    LJson := _ReadAllTextUtf8(LPath);
+  except
+    Exit;                                  // unreadable: behave as none
+  end;
+  LVal := TJSONObject.ParseJSONValue(LJson);
+  if LVal = nil then
+    Exit;
+  LList := TList<string>.Create;
+  try
+    if (LVal is TJSONObject) and
+       (TJSONObject(LVal).Values['commandRoots'] is TJSONArray) then
+    begin
+      LArr := TJSONArray(TJSONObject(LVal).Values['commandRoots']);
+      for LIndex := 0 to LArr.Count - 1 do
+      begin
+        LItem := LArr.Items[LIndex];
+        // A root whose folder is gone is SKIPPED, not an error: the bundle may
+        // have been moved, and one missing addon must not cost the user every
+        // other command in the picker.
+        if (LItem is TJSONString) and TDirectory.Exists(TJSONString(LItem).Value) then
+          LList.Add(TJSONString(LItem).Value);
+      end;
+    end;
+    Result := LList.ToArray;
+  finally
+    LList.Free;
+    LVal.Free;
+  end;
+end;
+
+function TCommandRegistry._CommandDirIn(const ACommandsDir,
+  ACommandName: string): string;
+begin
+  Result := TPath.Combine(ACommandsDir, CommandFolderSlug(ACommandName));
+end;
+
+function TCommandRegistry._CommandFileIn(const ACommandsDir,
+  ACommandName: string): string;
+begin
+  Result := TPath.Combine(_CommandDirIn(ACommandsDir, ACommandName),
+    COMMAND_FILE_NAME);
+end;
+
+function TCommandRegistry._ReferenceFileIn(const ACommandsDir, ACommandName,
+  AReferenceName: string): string;
+var
+  LFileName: string;
+begin
+  LFileName := AReferenceName;
+  if not LFileName.EndsWith(MD_EXTENSION, True) then
+    LFileName := LFileName + MD_EXTENSION;
+  Result := TPath.Combine(_CommandDirIn(ACommandsDir, ACommandName),
+    TPath.Combine(REFERENCES_FOLDER_NAME, LFileName));
+end;
+
+// Project first, then global, then the linked addons - the same precedence the
+// listing uses, so what the picker shows and what running it loads can never
+// disagree.
+function TCommandRegistry._FindCommandsDir(const ACommandName: string;
+  out ACommandsDir: string; out AScope: TCommandScope): Boolean;
+var
+  LRoot: string;
+  LDirs: TArray<string>;
+  LIndex: Integer;
+begin
+  if _FindCommandRoot(ACommandName, LRoot, AScope) then
+  begin
+    ACommandsDir := _CommandsDir(LRoot);
+    Exit(True);
+  end;
+  LDirs := _LinkedCommandsDirs;
+  for LIndex := 0 to High(LDirs) do
+    if TFile.Exists(_CommandFileIn(LDirs[LIndex], ACommandName)) then
+    begin
+      ACommandsDir := LDirs[LIndex];
+      // Reported as global because that is what it IS to the user: available in
+      // every project, not owned by this one. The enum stays a two-value type
+      // and no consumer of TCommandMetadata.Scope has to learn a third case.
+      AScope := csGlobal;
+      Exit(True);
+    end;
+  Result := False;
+end;
+
 function TCommandRegistry._CommandDir(const AProjectRoot,
   ACommandName: string): string;
 begin
@@ -653,37 +779,52 @@ begin
   ACollected.Add(LMeta);
 end;
 
-procedure TCommandRegistry._CollectFromRoot(const ARoot: string;
+procedure TCommandRegistry._CollectFromCommandsDir(const ACommandsDir: string;
   const AScope: TCommandScope;
   const ACollected: TList<TCommandMetadata>;
   const ASeen: TDictionary<string, Byte>);
 var
-  LCommandsDir: string;
   LDirs: TStringDynArray;
   LDirIndex: Integer;
 begin
-  if ARoot = '' then
+  if (ACommandsDir = '') or (not TDirectory.Exists(ACommandsDir)) then
     Exit;
-  LCommandsDir := _CommandsDir(ARoot);
-  if not TDirectory.Exists(LCommandsDir) then
-    Exit;
-  LDirs := TDirectory.GetDirectories(LCommandsDir);
+  LDirs := TDirectory.GetDirectories(ACommandsDir);
   for LDirIndex := 0 to High(LDirs) do
     _TryAppendCommand(LDirs[LDirIndex], AScope, ACollected, ASeen);
+end;
+
+procedure TCommandRegistry._CollectFromRoot(const ARoot: string;
+  const AScope: TCommandScope;
+  const ACollected: TList<TCommandMetadata>;
+  const ASeen: TDictionary<string, Byte>);
+begin
+  if ARoot = '' then
+    Exit;
+  _CollectFromCommandsDir(_CommandsDir(ARoot), AScope, ACollected, ASeen);
 end;
 
 function TCommandRegistry.List: TArray<TCommandMetadata>;
 var
   LCollected: TList<TCommandMetadata>;
   LSeen: TDictionary<string, Byte>;
+  LLinked: TArray<string>;
+  LIndex: Integer;
 begin
   LCollected := TList<TCommandMetadata>.Create;
   LSeen := TDictionary<string, Byte>.Create;
   try
     // Project pass first so it wins on name collisions, then the per-user
-    // global catalogue fills in commands the project does not override.
+    // global catalogue fills in commands the project does not override, and
+    // finally the linked addons - which come last for the same reason: a
+    // command the user wrote outranks one an installed bundle brought, and two
+    // bundles publishing the same name resolve by install order rather than by
+    // whichever the filesystem happened to enumerate first.
     _CollectFromRoot(_ResolveProjectRoot, csProject, LCollected, LSeen);
     _CollectFromRoot(_ResolveGlobalRoot, csGlobal, LCollected, LSeen);
+    LLinked := _LinkedCommandsDirs;
+    for LIndex := 0 to High(LLinked) do
+      _CollectFromCommandsDir(LLinked[LIndex], csGlobal, LCollected, LSeen);
     Result := LCollected.ToArray;
   finally
     LSeen.Free;
@@ -693,14 +834,14 @@ end;
 
 function TCommandRegistry.Get(const ACommandName: string): TCommandMetadata;
 var
-  LRoot: string;
+  LDir: string;
   LScope: TCommandScope;
   LCommandFile: string;
   LCommandDir: string;
 begin
-  if not _FindCommandRoot(ACommandName, LRoot, LScope) then
+  if not _FindCommandsDir(ACommandName, LDir, LScope) then
     raise ECommandNotFound.CreateFmt('Command "%s" not found', [ACommandName]);
-  LCommandFile := _CommandFile(LRoot, ACommandName);
+  LCommandFile := _CommandFileIn(LDir, ACommandName);
   LCommandDir := TPath.GetDirectoryName(LCommandFile);
   Result := _BuildMetadata(LCommandDir, LCommandFile);
   Result.Scope := LScope;
@@ -708,15 +849,15 @@ end;
 
 function TCommandRegistry.LoadBody(const ACommandName: string): string;
 var
-  LRoot: string;
+  LDir: string;
   LScope: TCommandScope;
   LCommandFile: string;
   LContent: string;
   LParsed: TFrontmatterParseResult;
 begin
-  if not _FindCommandRoot(ACommandName, LRoot, LScope) then
+  if not _FindCommandsDir(ACommandName, LDir, LScope) then
     raise ECommandNotFound.CreateFmt('Command "%s" not found', [ACommandName]);
-  LCommandFile := _CommandFile(LRoot, ACommandName);
+  LCommandFile := _CommandFileIn(LDir, ACommandName);
   LContent := _ReadAllTextUtf8(LCommandFile);
   LParsed := _ParseFrontmatter(LContent);
   Result := LParsed.BodyText;
@@ -724,15 +865,15 @@ end;
 
 function TCommandRegistry.LoadCommand(const ACommandName: string): TCanonicalCommand;
 var
-  LRoot: string;
+  LDir: string;
   LScope: TCommandScope;
   LCommandFile: string;
   LCommandDir: string;
   LParsed: TFrontmatterParseResult;
 begin
-  if not _FindCommandRoot(ACommandName, LRoot, LScope) then
+  if not _FindCommandsDir(ACommandName, LDir, LScope) then
     raise ECommandNotFound.CreateFmt('Command "%s" not found', [ACommandName]);
-  LCommandFile := _CommandFile(LRoot, ACommandName);
+  LCommandFile := _CommandFileIn(LDir, ACommandName);
   LParsed := _ParseFrontmatter(_ReadAllTextUtf8(LCommandFile));
   LCommandDir := TPath.GetDirectoryName(LCommandFile);
   Result.Name := LParsed.Name;
@@ -744,13 +885,13 @@ end;
 function TCommandRegistry.LoadReference(const ACommandName,
   AReferenceName: string): string;
 var
-  LRoot: string;
+  LDir: string;
   LScope: TCommandScope;
   LRefFile: string;
 begin
-  if not _FindCommandRoot(ACommandName, LRoot, LScope) then
+  if not _FindCommandsDir(ACommandName, LDir, LScope) then
     raise ECommandNotFound.CreateFmt('Command "%s" not found', [ACommandName]);
-  LRefFile := _ReferenceFile(LRoot, ACommandName, AReferenceName);
+  LRefFile := _ReferenceFileIn(LDir, ACommandName, AReferenceName);
   if not TFile.Exists(LRefFile) then
     raise ECommandNotFound.CreateFmt(
       'Reference "%s" of command "%s" not found at %s',


### PR DESCRIPTION
Decision, watched live: *"Add sem copiar nada, Install faria só o registro para os comandos aparecerem no chat, só registrar e não copiar."*

A folder store **is** the install. The commands are already on disk, in a folder the user maintains. Copying them bought nothing and cost three things:

- a second copy, stale the moment the first is edited;
- an install that overwrites same-named commands **adopts** them — measured: the addon install took over the 16 commands his own `install.ps1` had written, and uninstalling the addon then **deleted** them;
- 228 payload files duplicated for an engine that already had a home.

### What changes
An addon from a folder store, carrying no `mcp` and no `tools`, is now **LINKED**: nothing is copied, the ledger records where the bundle lives, and `~/.aefos/addons/command-roots.json` publishes that folder. `Uninstall` drops the record and **leaves the folder untouched** — it is the user's working directory, not ours to delete.

`mcp`/`tools` bundles are still copied, and say so: that is code Aefos launches, and it needs a path that survives the bundle being moved.

### Plugin side
The command registry resolves **project → global → linked**, for *reading only*. `SaveCommand`/`SaveReference` keep to project/global, because a linked folder belongs to the user and Aefos does not write into it. A linked root whose folder is gone is skipped rather than raised: one moved bundle must not empty the picker. Linked commands report `Scope = csGlobal` — what they are to the user — so the enum stays a two-value type no consumer has to relearn.

### Proof, and its limit
CLI side, against the real bundle in a fake `%USERPROFILE%`: install prints `= linked`, `~/.aefos` gets **0 commands and 0 skills**, the aggregate names the folder, and the source directory is byte-identical afterwards.

**Not proven here:** the plugin actually listing them in the chat. That needs the IDE — it is the live check, and it is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)