### PR TITLE
A link in a message opens the file; it no longer navigates the chat away

### DIFF
--- a/source/chat/Core/Aefos.OTA.Chat.Core.CommandExecutor.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.CommandExecutor.pas
@@ -145,6 +145,7 @@ type
     // because it is Delphi-only (TMCPProvision's resource-backed provisioning).
     procedure _ResolveMcpWiring(const AProfileKind: TExecutorKind;
       var AWiring: TAefosCliMcpWiring);
+    function _LoadStoredBody(const AText: string): string;
     function _PrepareContext(const ACommandName, ASelection: string;
       out ARendered: string; out ACommandBody: string): Boolean;
     procedure _StopMcpServer;
@@ -211,6 +212,7 @@ uses
   Aefos.MCP.ServerMerge,
   Aefos.Provider.Registry,
   Aefos.OTA.Chat.Core.BuiltInCommands,
+  Aefos.OTA.Chat.Core.ChatCommand,
   Aefos.OTA.Chat.Core.ModelFallbackPolicy,
   Aefos.OTA.Chat.UI.Options.Binding,
   Aefos.OTA.Options.AIFlow;
@@ -850,6 +852,44 @@ begin
   end;
 end;
 
+// Loads a stored command's body, accepting "<name> <what the developer wants>".
+//
+// The slash is the whole signal, and it is why the panel now dispatches the text
+// AS TYPED. "/release these notes" is the command plus a request; "release these
+// notes" is a sentence that happens to start with the name of an installed
+// command. Without the slash the two are the same string, and the only safe
+// reading of an identical pair is the literal one.
+//
+// Same shape the built-ins have always had (FindBuiltInCommand splits on the
+// first space) - stored and addon commands simply never got it, so anything
+// typed after the name reached the model as raw text with the COMMAND.md never
+// loaded. Measured live on /analyst.
+function TCommandExecutor._LoadStoredBody(const AText: string): string;
+var
+  LText, LName, LArgs: string;
+  LSpace: Integer;
+begin
+  LText := Trim(AText);
+  if not LText.StartsWith('/') then
+    // No slash: the caller means this exact name (the picker's path) or it is
+    // free text. Unchanged behaviour - LoadBody raises and the caller falls back.
+    Exit(FRegistry.LoadBody(LText));
+  LText := Trim(Copy(LText, 2, MaxInt));
+  LArgs := '';
+  LSpace := Pos(' ', LText);
+  if LSpace > 0 then
+  begin
+    LArgs := Trim(Copy(LText, LSpace + 1, MaxInt));
+    LName := Copy(LText, 1, LSpace - 1);
+  end
+  else
+    LName := LText;
+  Result := FRegistry.LoadBody(LName);
+  if LArgs <> '' then
+    Result := Result + sLineBreak + sLineBreak +
+      'The developer''s initial request: ' + LArgs;
+end;
+
 function TCommandExecutor._PrepareContext(const ACommandName, ASelection: string;
   out ARendered: string; out ACommandBody: string): Boolean;
 var
@@ -857,8 +897,15 @@ var
   LLastRoot: string;
   LUserText: string;
   LBuiltin: TBuiltInCommand;
+  LBare: string;
 begin
   Result := False;
+  // The panel dispatches the text AS TYPED so the slash survives to
+  // _LoadStoredBody, which is the only thing that needs it. Everything else here
+  // wants the bare text: the built-in table matches on names without one, and
+  // the free-chat fallback must not echo a slash the user's prompt did not mean
+  // as a command.
+  LBare := StripLeadingSlash(Trim(ACommandName));
   try
     // No active project (e.g. the agent just closed them all) must NOT abort the
     // dispatch — the chat should still converse/act. Degrade each project-bound
@@ -870,7 +917,7 @@ begin
         ; // no project/commands folder yet — nothing to preinstall, carry on
     end;
     try
-      if FindBuiltInCommand(ACommandName, LBuiltin, LUserText) and
+      if FindBuiltInCommand(LBare, LBuiltin, LUserText) and
          (LBuiltin.Kind = bikAgentic) then
       begin
         // Built-in agentic command (e.g. /new-project): inject its prompt-guide
@@ -883,7 +930,7 @@ begin
             'The developer''s initial request: ' + LUserText;
       end
       else
-        ACommandBody := FRegistry.LoadBody(ACommandName);
+        ACommandBody := _LoadStoredBody(ACommandName);
     except
       // Free-form chat fallback: ANY failure to load a command body means the typed
       // text isn't a command, so treat the text itself as the prompt and let the
@@ -893,7 +940,7 @@ begin
       // threw. A plain message or a path then goes straight to the CLI instead of
       // crashing with "Invalid characters in path".
       on Exception do
-        ACommandBody := ACommandName;
+        ACommandBody := LBare;
     end;
     try
       LContext := FBuilder.Build(ASelection);

--- a/source/chat/UI/Aefos.OTA.Chat.UI.ChatPanel.pas
+++ b/source/chat/UI/Aefos.OTA.Chat.UI.ChatPanel.pas
@@ -327,6 +327,11 @@ type
     // AFromQueue = a drain re-entry from _DrainQueuedMessage: the bubble was
     // already echoed when the message was queued, so the echo is skipped and
     // the queue gate is bypassed (else the drain would just re-queue).
+    { Opens a link the user clicked in a message, WITHOUT navigating this panel:
+      a project file goes to the IDE editor (that is where a .md of this project
+      belongs), a real URL goes to the system browser, and anything unresolvable
+      says so in the chat instead of failing silently. }
+    procedure _OpenLink(const AHref: string);
     procedure _DispatchCommand(const AText: string;
       const AFromQueue: Boolean = False);
     procedure _DrainQueuedMessage;
@@ -547,6 +552,7 @@ uses
   Vcl.Dialogs,
   Vcl.Themes,
   DeskUtil,
+  Winapi.ShellAPI,
   ToolsAPI,
   Aefos.OTA.Chat.Core.ChatCommand,
   Aefos.OTA.Chat.Core.CommandAutoReplicate,
@@ -2179,6 +2185,14 @@ begin
     _DispatchCommand(Copy(AMessage, Length('send:') + 1, MaxInt));
     Exit;
   end;
+  // A link the user clicked in a message. The page cancelled the navigation and
+  // sent us the href, because this WebView is the conversation itself - see the
+  // click handler in OutputPanel.Assets for what happens when it navigates.
+  if AMessage.StartsWith('openlink:') then
+  begin
+    _OpenLink(Trim(Copy(AMessage, Length('openlink:') + 1, MaxInt)));
+    Exit;
+  end;
   // The shell page reports a broken JS runtime (e.g. window.marked missing
   // because the shell file loaded truncated). Reload the shell once — Navigate
   // rewrites the file and the nav-completed replay rebuilds the conversation,
@@ -2546,6 +2560,75 @@ begin
   end;
 end;
 
+procedure TAefosChatPanel._OpenLink(const AHref: string);
+var
+  LHref, LPath, LRoot: string;
+  LModule: IOTAModuleServices;
+
+  // Says it in the chat, where the click happened. A link that does nothing and
+  // explains nothing is the same silence that made the navigation bug hard to
+  // read in the first place.
+  procedure _Notify(const AText: string);
+  begin
+    if Assigned(FController) then
+      FController.EnqueueFooter(AText, True);
+  end;
+
+begin
+  LHref := Trim(AHref);
+  if LHref = '' then
+    Exit;
+  // A real URL: hand it to the system, which is the only thing that should own
+  // a browser window. Never this panel.
+  if LHref.StartsWith('http://', True) or LHref.StartsWith('https://', True) or
+     LHref.StartsWith('mailto:', True) then
+  begin
+    ShellExecute(0, 'open', PChar(LHref), nil, nil, SW_SHOWNORMAL);
+    Exit;
+  end;
+  // Everything else is meant as a FILE. The agent writes project-relative paths
+  // (`.project/analysis/project-overview.md`) because that is how it refers to
+  // what it just wrote; a browser reads the same string as a URL and mangles the
+  // backslashes. Resolve it the way the sentence meant it.
+  LPath := LHref;
+  if LPath.StartsWith('file:///', True) then
+    LPath := Copy(LPath, Length('file:///') + 1, MaxInt);
+  LPath := StringReplace(LPath, '/', PathDelim, [rfReplaceAll]);
+  LPath := StringReplace(LPath, '%5C', PathDelim, [rfReplaceAll, rfIgnoreCase]);
+  LPath := StringReplace(LPath, '%20', ' ', [rfReplaceAll]);
+  LModule := nil;
+  if not Supports(BorlandIDEServices, IOTAModuleServices, LModule) then
+    LModule := nil;
+  if not TPath.IsPathRooted(LPath) then
+  begin
+    // Relative means relative to the PROJECT: that is what the agent meant when
+    // it wrote the path, because that is the directory it ran in.
+    LRoot := '';
+    if Assigned(LModule) and Assigned(LModule.GetActiveProject) then
+      LRoot := TPath.GetDirectoryName(LModule.GetActiveProject.FileName);
+    if LRoot = '' then
+    begin
+      _Notify('Cannot open "' + LHref +
+        '": it is a relative path and no project is open to resolve it against.');
+      Exit;
+    end;
+    LPath := TPath.Combine(LRoot, LPath);
+  end;
+  if not TFile.Exists(LPath) then
+  begin
+    // Name the path that was tried. "File not found" on its own is the message
+    // that sends someone hunting through three folders.
+    _Notify('File not found: ' + LPath);
+    Exit;
+  end;
+  // The IDE editor, not a browser: it is a file of the project the developer has
+  // open, and the editor is where they can actually do something with it.
+  if Assigned(LModule) then
+    LModule.OpenModule(LPath)
+  else
+    ShellExecute(0, 'open', PChar(LPath), nil, nil, SW_SHOWNORMAL);
+end;
+
 procedure TAefosChatPanel._DispatchCommand(const AText: string;
   const AFromQueue: Boolean);
 var
@@ -2677,7 +2760,14 @@ begin
   // builtin matched just above, or a stored command resolved by an exact name hit
   // - so a free-text prompt (LCmd = the whole prompt) never pollutes recents.
   _RecordRecent(LCmd, LIsBuiltin, LBuiltin);
-  FOnCommand(LCmd);
+  // Dispatch the text AS TYPED, slash and all. The executor needs that slash to
+  // tell "/release these notes" (the command, plus what the developer wants)
+  // from "release these notes" (a sentence that happens to start with the name
+  // of an installed command). Stripping it here left both looking identical,
+  // and the only safe reading of an identical pair is the literal one - which
+  // is why a command with anything after it used to reach the model as raw
+  // text, with its COMMAND.md never loaded.
+  FOnCommand(AText);
 end;
 
 procedure TAefosChatPanel._DrainQueuedMessage;

--- a/source/chat/UI/Aefos.OTA.Chat.UI.OutputPanel.Assets.pas
+++ b/source/chat/UI/Aefos.OTA.Chat.UI.OutputPanel.Assets.pas
@@ -4389,6 +4389,25 @@ const
     '  };' + sLineBreak +
     '  window.dsSyncPad();' + sLineBreak +
     '  window.addEventListener("resize", function(){ window.dsSyncPad(); });' + sLineBreak +
+    // A link in an assistant message must never NAVIGATE this page. This page IS
+    // the conversation: navigating it away replaces the whole chat with whatever
+    // the href pointed at, and the transcript goes with it. Measured live - the
+    // agent wrote `.project/analysis/project-overview.md`, the click resolved it
+    // to file:///C:/%5CUsers%5C... (a Windows path is not a URL), the WebView
+    // showed "can't reach this page", and only Alt+Left brought the chat back.
+    // Nobody guesses Alt+Left.
+    // So: cancel every anchor click and hand the href to the host, which knows
+    // what a project-relative path means and where a real URL should open.
+    '  document.addEventListener("click", function(e){' + sLineBreak +
+    '    var a = e.target && e.target.closest ? e.target.closest("a[href]") : null;' + sLineBreak +
+    '    if(!a) return;' + sLineBreak +
+    '    var h = a.getAttribute("href") || "";' + sLineBreak +
+    // In-page anchors are the one navigation that is not a navigation: they
+    // scroll. Leave those to the browser.
+    '    if(h.charAt(0) === "#") return;' + sLineBreak +
+    '    e.preventDefault();' + sLineBreak +
+    '    try{ window.chrome.webview.postMessage("openlink:" + h); }catch(err){}' + sLineBreak +
+    '  }, true);' + sLineBreak +
     '  /* Visual Scanner. A pure function of the payload the Pascal side emits' + sLineBreak +
     '     (TAefosVisualSession.ToJson): no state, no timers, no inference. A step' + sLineBreak +
     '     spins because the payload said "active", and for no other reason. */' + sLineBreak +


### PR DESCRIPTION
Two things hit in one live run of `/analyst`.

### 1. A link killed the conversation
The agent wrote `.project/analysis/project-overview.md`. Clicking it navigated **this WebView** — the page that *is* the chat — to `file:///C:/%5CUsers%5CUser%5C...` (a Windows path is not a URL), which failed with `ERR_INVALID_URL` and replaced the whole transcript with an error page. Closing and reopening did not bring it back; **only Alt+Left did**, and nobody guesses Alt+Left.

Now the page cancels every anchor click (in-page `#anchors` excepted — those scroll) and hands the href to the host, which decides:

- **http / https / mailto** → the system browser, the only thing that should own a browser window;
- **anything else** → a **file**. A relative path resolves against the **active project** — that is the directory the agent ran in, and what it meant when it wrote the path — and opens in the **IDE editor**, because it is a file of the project the developer has open;
- **unresolvable** → says so in the chat, **naming the path it tried**. "File not found" without the path sends someone hunting through three folders.

### 2. A command with text after it was never loaded
`/analyst <situation>` made the registry look for a command named `analyst <situation>`, miss, and fall back to sending the raw text — so `COMMAND.md` never reached the model, which then answered about its own environment. Confirmed by the model when asked: *"o texto `analyst` chegou apenas como parte literal da sua mensagem"*.

Stored and addon commands now accept `<name> <what you want>` — the shape the **built-ins have always had**. The panel dispatches the text **as typed** for this: the slash is the whole signal. `/release these notes` is a command plus a request; `release these notes` is a sentence starting with the name of an installed command, and with the slash stripped the two were the same string.

Both are the same failure mode: something did nothing and said nothing.

### Proof and its limit
D13 + D12 build. **Not proven here:** the click path itself — that needs the IDE, and it is the live check.

Still open, noted rather than done: wiring `NavigationStarting` as a belt-and-braces cancel, so no future redirect can take the conversation with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)