### PR TITLE
The command that opens the store is /addons, not /install

### DIFF
--- a/source/chat/Core/Aefos.OTA.Chat.Core.BuiltInCommands.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.BuiltInCommands.pas
@@ -313,11 +313,13 @@ begin
     Modal('mcp', 'MCP servers'),
     Modal('inspector', 'MCP Tool Inspector'),
     Modal('command', 'Create/edit a command'),
-    // Named for what it DOES. "addons" is a noun - it says what the window is
-    // about and not that anything gets installed, or by whom. /addons and
-    // /store still work (see ChatPanel._DispatchCommand); only one of the three
+    // Named for what it IS, not for what it does. "addons" is a noun - it says
+    // what the window is about, and it is the word Aefos uses everywhere else
+    // (the store, the contract, ~/.aefos/addons), so the command carries the
+    // product's own identity instead of a generic verb. /install and /store
+    // still answer (see ChatPanel._DispatchCommand); only one of the three
     // belongs in the picker.
-    Modal('install', 'Install addons from the Aefos store'),
+    Modal('addons', 'Browse and install addons from the Aefos store'),
     // Agentic built-ins (dispatched with a guide).
     LNewProject,
     LSuggest,

--- a/source/chat/UI/Aefos.OTA.Chat.UI.ChatPanel.pas
+++ b/source/chat/UI/Aefos.OTA.Chat.UI.ChatPanel.pas
@@ -2701,10 +2701,10 @@ begin
     _OpenMcpModal;
     Exit;
   end;
-  // /install: open the addon store - the catalogue of every configured store,
+  // /addons: open the addon store - the catalogue of every configured store,
   // with an Install button. Never echoed nor dispatched to the executor: it is
-  // a window, not a prompt. /addons and /store answer too, because both are
-  // what someone would try.
+  // a window, not a prompt. /install and /store answer too, because both are
+  // what someone would try (the picker offers only /addons).
   if SameText(LCmd, 'install') or SameText(LCmd, 'addons') or
      SameText(LCmd, 'store') then
   begin


### PR DESCRIPTION
The picker offered `/install` -- a generic verb that says an action happens without saying what the window is. Every other surface already calls these things addons: the store, the contract, `~/.aefos/addons`. The command now carries the product's own word.

- Picker lists **`/addons`** -- *Browse and install addons from the Aefos store*
- `/install` and `/store` keep answering, because both are what someone would try; only one of the three belongs in the picker.

Staged and compiled on 23.0 and 37.0 (exit 0) before the installer build for the old-IDE test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)