### PR TITLE
The store called a rebuild an update, on every fresh install

### DIFF
--- a/cli/Aefos.Addons.Catalog.pas
+++ b/cli/Aefos.Addons.Catalog.pas
@@ -427,6 +427,30 @@ begin
   LEntry := ARow.Entry;
   TAddonCatalog.EnsureIdentity(LEntry);
   if LItem.DecideUpdate(LEntry) = uaUpToDate then
+  begin
+    AObj.AddPair('state', 'installed');
+    Exit;
+  end;
+  // Same version, different bytes is NOT an update - it is another BUILD of the
+  // same release, and the store must not nag about it forever.
+  //
+  // The installer seeds the Desktop MCP offline from a dist this tree packed
+  // (scripts\pack-desktop-addon.ps1 deliberately ships the exe WE built, not one
+  // downloaded from the gallery - see its own comment). Two honest builds of
+  // v0.4.1 have two different sha256, so every freshly installed machine showed
+  // "Update" on an addon that was current, on every IDE, forever. Reported from
+  // a Delphi 10 + Delphi 13 machine where both said Update while the gallery
+  // served the very same version.
+  //
+  // So the BUTTON asks the user-facing question - "is there a newer release?" -
+  // and answers it by version. Identity stays sha256 everywhere it matters:
+  // `aefos update <slug>` still goes through DecideUpdate untouched, so a
+  // re-published bundle can still be pulled deliberately; this only stops the
+  // catalogue from calling a lateral rebuild an upgrade. A version that is
+  // missing on either side leaves the sha answer as it was, because then there
+  // is nothing better to compare.
+  if (Trim(LItem.Version) <> '') and (Trim(LEntry.Version) <> '') and
+     (TAddonVersion.Compare(LItem.Version, LEntry.Version) >= 0) then
     AObj.AddPair('state', 'installed')
   else
     AObj.AddPair('state', 'update');


### PR DESCRIPTION
A freshly installed machine showed **"Update"** on the Desktop MCP in the store — on **Delphi 10 and Delphi 13 alike**, for an addon that was already the newest published release, and it would never have stopped saying it.

## Cause

The installer seeds that addon **offline**, from a dist this tree packs. `scripts/pack-desktop-addon.ps1` deliberately ships **the exe we built**, not one downloaded from the gallery — *"anyone building from source ships their own binary; a build that quietly embedded someone else's would make the source meaningless."* That decision is right and is untouched here.

The catalogue then decided the button with `DecideUpdate`, which compares **sha256** (`cli/Aefos.Addons.Types.pas:270-277`). Two honest builds of the same `v0.4.1` have two different sha256 → `state: "update"`, permanently.

## What changed

Sha256 is the right identity and stays the identity. What was wrong is the **question the button answers**: a user reads "Update" as *there is a newer release*, and a lateral rebuild of the same version is not one.

So `_AddState` answers by version, and only when both sides declare one:

- installed **>=** published → `installed`
- installed **older** → `update`
- version missing on either side → falls back to the sha answer (nothing better to compare)

`aefos update <slug>` is **untouched** — still `DecideUpdate`, still sha — so a re-published bundle can still be pulled deliberately. Only the catalogue stops calling a rebuild an upgrade.

## Proof

Against the real CLI, ledger backed up and restored:

| ledger | store | state |
|---|---|---|
| sha equal, v0.4.1 | v0.4.1 | `installed` (unchanged) |
| **sha different, v0.4.1** | v0.4.1 | **`installed`** — was `update` |
| sha different, v0.3.0 | v0.4.1 | `update` (unchanged) |

And with a mismatched sha, `aefos update desktop --check` still reports `desktop: update available` — the deliberate path is intact.

No HTML or resource change: the page already renders `state: "installed"` as ✓ Installed + Remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
