### PR TITLE
One UTF-8 read for eight compilers

### DIFF
--- a/cli/Aefos.Addons.Catalog.pas
+++ b/cli/Aefos.Addons.Catalog.pas
@@ -85,6 +85,7 @@ implementation
 uses
   Classes,
   IOUtils,
+  Aefos.Compat.IO,
   Types,
   Aefos.Compat.Json,
   Aefos.Compat.JsonFormat,
@@ -138,7 +139,7 @@ begin
   AEntry.KindName := AEntry.Kind.ToStr;
   LJson := '';
   try
-    LJson := TFile.ReadAllText(LManifestPath, TEncoding.UTF8);
+    LJson := TAefosText.ReadAllUtf8(LManifestPath);
   except
     LJson := '';
   end;

--- a/cli/Aefos.Addons.Installer.pas
+++ b/cli/Aefos.Addons.Installer.pas
@@ -379,7 +379,7 @@ var
 begin
   if not TFile.Exists(ASrcFile) then
     Exit;
-  LJson := TFile.ReadAllText(ASrcFile, TEncoding.UTF8);
+  LJson := TAefosText.ReadAllUtf8(ASrcFile);
   LJson := TAddonMcpRewrite.RewriteRootToken(LJson, AAddonRootAbs);
   ForceDirectories(ExtractFileDir(ADstFile));
   TFile.WriteAllBytes(ADstFile, TEncoding.UTF8.GetBytes(LJson));
@@ -453,7 +453,7 @@ begin
       if not TFile.Exists(LFragPath) then
         Continue;
       try
-        LFrag := TFile.ReadAllText(LFragPath, TEncoding.UTF8);
+        LFrag := TAefosText.ReadAllUtf8(LFragPath);
       except
         Continue;
       end;
@@ -860,7 +860,7 @@ begin
         'bundle "%s" carries no addon.json - see docs\addons-contract.md for ' +
         'the format Aefos installs.', [ASlug]);
     LManifest := TAddonManifestParser.ParseManifest(
-      TFile.ReadAllText(LManifestPath, TEncoding.UTF8));
+      TAefosText.ReadAllUtf8(LManifestPath));
     if not SameText(LManifest.Slug, ASlug) then
       raise EAddonManifest.CreateFmt(
         'bundle slug "%s" does not match "%s".', [LManifest.Slug, ASlug]);

--- a/cli/Aefos.Addons.Ledger.pas
+++ b/cli/Aefos.Addons.Ledger.pas
@@ -233,7 +233,7 @@ begin
   if not TFile.Exists(LPath) then
     Exit(nil);
   try
-    Result := TAddonLedger.Deserialize(TFile.ReadAllText(LPath, TEncoding.UTF8));
+    Result := TAddonLedger.Deserialize(TAefosText.ReadAllUtf8(LPath));
   except
     on E: Exception do
       Result := nil; // an unreadable ledger reads as "nothing installed"

--- a/cli/Aefos.Addons.Net.pas
+++ b/cli/Aefos.Addons.Net.pas
@@ -168,7 +168,7 @@ begin
       LSrc := TPath.GetFullPath(LSrc);
     if not TFile.Exists(LSrc) then
       raise EAddonError.CreateFmt('local registry not found: %s', [LSrc]);
-    Exit(TFile.ReadAllText(LSrc, TEncoding.UTF8));
+    Exit(TAefosText.ReadAllUtf8(LSrc));
   end;
   if not TAefosHttp.TryGetText(AUrl, LStatus, LBody, LError) then
     raise EAddonError.CreateFmt('download failed (%s): %s', [AUrl, LError]);

--- a/cli/Aefos.Addons.Sources.pas
+++ b/cli/Aefos.Addons.Sources.pas
@@ -121,6 +121,7 @@ implementation
 uses
   Classes,
   IOUtils,
+  Aefos.Compat.IO,
   Aefos.Compat.Json,
   Aefos.Compat.JsonFormat,
   Aefos.Addons.Paths;
@@ -217,7 +218,7 @@ begin
   if not TFile.Exists(LPath) then
     Exit;
   try
-    LText := TFile.ReadAllText(LPath, TEncoding.UTF8);
+    LText := TAefosText.ReadAllUtf8(LPath);
   except
     Exit;                               // unreadable config => official alone
   end;

--- a/cli/Aefos.Agent.Session.pas
+++ b/cli/Aefos.Agent.Session.pas
@@ -26,6 +26,7 @@ uses
   System.SysUtils,
   System.Classes,
   System.IOUtils,
+  Aefos.Compat.IO,
   System.JSON,
   {$ENDIF}
   Aefos.Provider.Ollama.Core;
@@ -111,7 +112,7 @@ begin
     Exit;
   end;
   LRoot := TJSONObject.ParseJSONValue(
-    TFile.ReadAllText(LPath, TEncoding.UTF8));
+    TAefosText.ReadAllUtf8(LPath));
   try
     if not (LRoot is TJSONObject) then
     begin

--- a/packages/Delphi/Aefos.MCP.Core.dpk
+++ b/packages/Delphi/Aefos.MCP.Core.dpk
@@ -58,7 +58,6 @@ contains
   Aefos.Compat.JsonFormat in '..\..\source\compat\Aefos.Compat.JsonFormat.pas',
   Aefos.Compat.MainThread in '..\..\source\compat\Aefos.Compat.MainThread.pas',
   Aefos.Compat.Sha256 in '..\..\source\compat\Aefos.Compat.Sha256.pas',
-  Aefos.Compat.IO in '..\..\source\compat\Aefos.Compat.IO.pas',
   Aefos.MCP.Server in '..\..\source\mcp\Core\Aefos.MCP.Server.pas',
   Aefos.MCP.AddonGateway in '..\..\source\mcp\Core\Aefos.MCP.AddonGateway.pas',
   Aefos.MCP.AuditLog in '..\..\source\mcp\Core\Aefos.MCP.AuditLog.pas',

--- a/packages/Delphi/Aefos.Tools.dpk
+++ b/packages/Delphi/Aefos.Tools.dpk
@@ -34,6 +34,14 @@ requires
   rtl;
 
 contains
+  // The IO shim lives in the ROOT package on purpose. It carries TAefosText,
+  // whose ReadAllUtf8 is the only UTF-8 read that behaves the same on all eight
+  // compilers, and every other Aefos package requires this one (directly or
+  // through Aefos.MCP.Core) - so one copy here reaches all of them. It used to
+  // sit in Aefos.MCP.Core, which is DOWNSTREAM of this package: units here could
+  // not see it (F2613), which is why the read bug had to be fixed one unit at a
+  // time until now.
+  Aefos.Compat.IO in '..\..\source\compat\Aefos.Compat.IO.pas',
   Aefos.Tools.Text in '..\..\source\mcp\Tools\Aefos.Tools.Text.pas',
   Aefos.Tools.Templates in '..\..\source\mcp\Tools\Aefos.Tools.Templates.pas',
   Aefos.Tools.Files in '..\..\source\mcp\Tools\Aefos.Tools.Files.pas',

--- a/source/chat/Aefos.OTA.Chat.Register.pas
+++ b/source/chat/Aefos.OTA.Chat.Register.pas
@@ -29,6 +29,7 @@ uses
   System.StrUtils,
   System.Classes,
   System.IOUtils,
+  Aefos.Compat.IO,
   System.Generics.Collections,
   System.Variants,
   System.NetEncoding,
@@ -1816,7 +1817,7 @@ begin
   if (AFilePath <> '') and TFile.Exists(AFilePath) then
   begin
     try
-      ASource := TFile.ReadAllText(AFilePath, TEncoding.UTF8);
+      ASource := TAefosText.ReadAllUtf8(AFilePath);
       Result := ASource <> '';
     except
       ASource := '';
@@ -1948,7 +1949,7 @@ function _TryReadUnitText(const APath: string; out AText: string): Boolean;
 begin
   Result := False;
   try
-    AText := TFile.ReadAllText(APath, TEncoding.UTF8);
+    AText := TAefosText.ReadAllUtf8(APath);
     Result := True;
   except
     AText := '';
@@ -2125,7 +2126,7 @@ begin
   AChanged := False;
   if not TFile.Exists(ADProjPath) then
     Exit;
-  LSnapshot := TFile.ReadAllText(ADProjPath, TEncoding.UTF8);
+  LSnapshot := TAefosText.ReadAllUtf8(ADProjPath);
   try
     LDoc := TXMLDocument.Create(nil);
     LDoc.LoadFromFile(ADProjPath);
@@ -3497,7 +3498,7 @@ begin
         LJson := nil;
         try
           try
-            LRaw := TFile.ReadAllText(LManifest, TEncoding.UTF8);
+            LRaw := TAefosText.ReadAllUtf8(LManifest);
             LJson := TJSONObject.ParseJSONValue(LRaw) as TJSONObject;
           except
             LJson := nil;

--- a/source/chat/Core/Aefos.Executor.Models.pas
+++ b/source/chat/Core/Aefos.Executor.Models.pas
@@ -159,7 +159,7 @@ begin
   if TFile.Exists(_ModelsConfigPath) then
     try
       LVal := TJSONObject.ParseJSONValue(
-        TFile.ReadAllText(_ModelsConfigPath, TEncoding.UTF8));
+        TAefosText.ReadAllUtf8(_ModelsConfigPath));
       if LVal is TJSONObject then
         Result := TJSONObject(LVal)
       else

--- a/source/chat/Core/Aefos.OTA.Chat.Core.CommandExecutor.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.CommandExecutor.pas
@@ -206,6 +206,7 @@ implementation
 
 uses
   System.IOUtils,
+  Aefos.Compat.IO,
   System.JSON,
   System.Generics.Collections,
   Aefos.MCP.Provision,
@@ -358,7 +359,7 @@ begin
   if not TFile.Exists(LPath) then
     Exit;
   try
-    Result := Trim(TFile.ReadAllText(LPath, TEncoding.UTF8));
+    Result := Trim(TAefosText.ReadAllUtf8(LPath));
   except
     // A locked/garbled memory file must never break a dispatch.
     Result := '';
@@ -389,7 +390,7 @@ begin
   if not TFile.Exists(LPath) then
     Exit;
   try
-    Result := Trim(TFile.ReadAllText(LPath, TEncoding.UTF8));
+    Result := Trim(TAefosText.ReadAllUtf8(LPath));
     if Result = '' then
       Result := '{}';
   except

--- a/source/chat/Core/Aefos.OTA.Chat.Core.CommandReplicator.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.CommandReplicator.pas
@@ -80,8 +80,8 @@ type
 implementation
 
 uses
-  System.IOUtils;
-
+  System.IOUtils,
+  Aefos.Compat.IO;
 constructor TCommandReplicator.Create(const ARegistry: ICommandRegistry;
   const AProjectRootResolver: TFunc<string>;
   const AProfile: IExecutorProfile);
@@ -114,7 +114,7 @@ var
 begin
   // Read tolerating a BOM, convert, write UTF-8 without BOM (R-3):
   // TEncoding.UTF8.GetBytes emits no preamble.
-  LCanonical := TFile.ReadAllText(ACanonicalPath, TEncoding.UTF8);
+  LCanonical := TAefosText.ReadAllUtf8(ACanonicalPath);
   LConverted := FProfile.ConvertCommand(LCanonical);
   TFile.WriteAllBytes(ATargetFile, TEncoding.UTF8.GetBytes(LConverted));
 end;

--- a/source/chat/Core/Aefos.OTA.Chat.Core.SessionStore.SQLite.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.SessionStore.SQLite.pas
@@ -32,6 +32,7 @@ uses
   System.SysUtils,
   System.Types,
   System.IOUtils,
+  Aefos.Compat.IO,
   System.JSON,
   System.DateUtils,
   System.Generics.Collections,
@@ -92,7 +93,7 @@ begin
   try
     if not TFile.Exists(APath) then
       Exit(False);
-    LText := TFile.ReadAllText(APath, TEncoding.UTF8);
+    LText := TAefosText.ReadAllUtf8(APath);
     LValue := TJSONObject.ParseJSONValue(LText);
     if LValue = nil then
       Exit(False);

--- a/source/chat/UI/Aefos.OTA.Chat.UI.Options.Binding.pas
+++ b/source/chat/UI/Aefos.OTA.Chat.UI.Options.Binding.pas
@@ -334,7 +334,7 @@ begin
   if TFile.Exists(_ApiKeysConfigPath) then
     try
       LVal := TJSONObject.ParseJSONValue(
-        TFile.ReadAllText(_ApiKeysConfigPath, TEncoding.UTF8));
+        TAefosText.ReadAllUtf8(_ApiKeysConfigPath));
       if LVal is TJSONObject then
         Result := TJSONObject(LVal)
       else if LVal <> nil then

--- a/source/compat/Aefos.Compat.IO.pas
+++ b/source/compat/Aefos.Compat.IO.pas
@@ -114,7 +114,64 @@ type
 
 {$ENDIF}
 
+type
+  { UTF-8 text reads that answer the same on all eight compilers.
+
+    MEASURED 2026-08-10 against the six IDEs in the build VM: on Delphi 10
+    Seattle (17.0) and 10.1 Berlin (18.0), System.IOUtils.TFile.ReadAllText(path,
+    TEncoding.UTF8) DISCARDS THE FIRST THREE BYTES of a file that has no BOM --
+    it charges the preamble whether or not the file paid it. 10.2 Tokyo (19.0)
+    and up return the file whole. The one-argument overload reads it whole
+    everywhere but decodes as ANSI when there is no BOM, so it is not the answer
+    either.
+
+    That is silent and it bites twice. The addon aggregate is written UTF-8
+    without a BOM on purpose, so on those two IDEs an installed MCP addon
+    disappeared from /MCP and from the .mcp.json handed to the CLI (v1.5.1). And
+    a .pas file usually has no BOM either, so every code tool that reads one was
+    losing the first three characters of `unit` on Seattle and Berlin.
+
+    So: read the bytes, strip a UTF-8 BOM only when one is actually there, decode.
+    Byte-identical to what the FPC branch below already did, and to what
+    Aefos.MCP.AddonGateway hand-rolled -- which is why the in-IDE tools kept
+    working while the config leg went silent. One implementation now. }
+  TAefosText = record
+  public
+    { The file's text decoded as UTF-8, with a leading BOM removed when present.
+      Raises like TFile.ReadAllText when the file cannot be opened. }
+    class function ReadAllUtf8(const APath: string): string; static;
+  end;
+
 implementation
+
+{$IFNDEF FPC}
+uses
+  System.SysUtils,
+  System.Classes;
+{$ENDIF}
+
+{ TAefosText }
+
+class function TAefosText.ReadAllUtf8(const APath: string): string;
+var
+  LStream: TFileStream;
+  LBytes: TBytes;
+  LStart: Integer;
+begin
+  LStream := TFileStream.Create(APath, fmOpenRead or fmShareDenyWrite);
+  try
+    SetLength(LBytes, LStream.Size);
+    if Length(LBytes) > 0 then
+      LStream.ReadBuffer(LBytes[0], Length(LBytes));
+  finally
+    LStream.Free;
+  end;
+  LStart := 0;
+  if (Length(LBytes) >= 3) and (LBytes[0] = $EF) and (LBytes[1] = $BB) and
+    (LBytes[2] = $BF) then
+    LStart := 3;
+  Result := TEncoding.UTF8.GetString(LBytes, LStart, Length(LBytes) - LStart);
+end;
 
 {$IFDEF FPC}
 

--- a/source/mcp/Core/Aefos.MCP.Provision.pas
+++ b/source/mcp/Core/Aefos.MCP.Provision.pas
@@ -100,6 +100,7 @@ uses
   System.SysUtils,
   System.Classes,
   System.IOUtils,
+  Aefos.Compat.IO,
   System.JSON,
   Aefos.MCP.ServerMerge,
   Aefos.Compat.JsonFormat;
@@ -195,47 +196,6 @@ begin
   Result := TPath.Combine(GetEnvironmentVariable('USERPROFILE'), '.aefos');
 end;
 
-// UTF-8 text that reads the same on all eight compilers.
-//
-// MEASURED 2026-08-10 against the six IDEs in the build VM: on 10 Seattle (17.0)
-// and 10.1 Berlin (18.0), System.IOUtils.TFile.ReadAllText(path, TEncoding.UTF8)
-// DISCARDS THE FIRST THREE BYTES of a file that carries no BOM -- it charges the
-// preamble whether or not the file paid it. 10.2 Tokyo (19.0) and up return the
-// file whole. The one-argument overload is fine everywhere, but it decodes as
-// ANSI when there is no BOM, so it is not the answer either.
-//
-// Every file this unit reads is written UTF-8 WITHOUT a BOM on purpose (a BOM
-// makes some JSON readers choke), so on those two IDEs the addon aggregate came
-// back as `"mcpServers": ...` with its opening brace gone, failed to parse, and
-// degraded to "no servers": the installed Desktop MCP disappeared from /MCP and
-// from the .mcp.json handed to the CLI, while the store still -- correctly --
-// listed it as installed. Reported from a Delphi 10 Seattle machine where the
-// same profile's Delphi 13 showed it fine.
-//
-// So: read the bytes, strip a BOM only when one is really there, decode as UTF-8.
-// Same answer on 17.0 as on 37.0. Aefos.MCP.AddonGateway already reads the
-// aggregate this way, which is why the in-IDE tools kept working while the
-// config leg went silent -- the two legs disagreed, and only one was right.
-function _ReadAllUtf8(const APath: string): string;
-var
-  LStream: TFileStream;
-  LBytes: TBytes;
-  LStart: Integer;
-begin
-  LStream := TFileStream.Create(APath, fmOpenRead or fmShareDenyWrite);
-  try
-    SetLength(LBytes, LStream.Size);
-    if Length(LBytes) > 0 then
-      LStream.ReadBuffer(LBytes[0], Length(LBytes));
-  finally
-    LStream.Free;
-  end;
-  LStart := 0;
-  if (Length(LBytes) >= 3) and (LBytes[0] = $EF) and (LBytes[1] = $BB) and
-    (LBytes[2] = $BF) then
-    LStart := 3;
-  Result := TEncoding.UTF8.GetString(LBytes, LStart, Length(LBytes) - LStart);
-end;
 
 // The 'aefos' server object:
 //   powershell -ExecutionPolicy Bypass -NonInteractive -File <bridge> -Session <s>.
@@ -275,7 +235,7 @@ begin
   if not TFile.Exists(LPath) then
     Exit;
   try
-    Result := Trim(_ReadAllUtf8(LPath));
+    Result := Trim(TAefosText.ReadAllUtf8(LPath));
   except
     // Locked/garbled aggregate => contributes nothing; never breaks a caller.
     Result := '';
@@ -292,7 +252,7 @@ begin
   Result := nil;
   if TFile.Exists(APath) then
   begin
-    LRaw := _ReadAllUtf8(APath);
+    LRaw := TAefosText.ReadAllUtf8(APath);
     LVal := TJSONObject.ParseJSONValue(LRaw);
     if LVal is TJSONObject then
       Result := TJSONObject(LVal)
@@ -322,7 +282,7 @@ begin
   LRaw := '';
   if TFile.Exists(LPath) then
     try
-      LRaw := _ReadAllUtf8(LPath);
+      LRaw := TAefosText.ReadAllUtf8(LPath);
     except
       LRaw := '';  // unreadable => provision a fresh doc
     end;

--- a/source/mcp/Core/Aefos.MCP.Tools.PyTools.pas
+++ b/source/mcp/Core/Aefos.MCP.Tools.PyTools.pas
@@ -81,6 +81,7 @@ implementation
 uses
   System.SysUtils,
   System.IOUtils,      // System.Types is in the interface uses (TStringDynArray)
+  Aefos.Compat.IO,     // TAefosText.ReadAllUtf8 -- see that unit's comment
   System.JSON,
   Aefos.Tools.Process,
   Aefos.Tools.PyTool,
@@ -331,7 +332,7 @@ begin
     LJson := nil;
     try
       try
-        LRaw := TFile.ReadAllText(LManifest, TEncoding.UTF8);
+        LRaw := TAefosText.ReadAllUtf8(LManifest);
         LJson := TJSONObject.ParseJSONValue(LRaw) as TJSONObject;
       except
         LJson := nil;

--- a/source/mcp/Core/Aefos.MCP.Tools.Rename.pas
+++ b/source/mcp/Core/Aefos.MCP.Tools.Rename.pas
@@ -99,6 +99,7 @@ implementation
 uses
   System.Classes,
   System.IOUtils,
+  Aefos.Compat.IO,
   System.RegularExpressions,
   System.Generics.Collections;
 
@@ -247,7 +248,7 @@ var
 begin
   if not TFile.Exists(APath) then
     Exit;
-  LText := TFile.ReadAllText(APath, TEncoding.UTF8);
+  LText := TAefosText.ReadAllUtf8(APath);
   LText := StringReplace(LText, AOldToken, ANewToken,
     [rfReplaceAll, rfIgnoreCase]);
   TFile.WriteAllText(APath, LText, TEncoding.UTF8);
@@ -453,7 +454,7 @@ begin
 
       // Rewrite the `unit X;` clause in the renamed source.
       TFile.WriteAllText(LNewPas,
-        _RewriteUnitClause(TFile.ReadAllText(LNewPas, TEncoding.UTF8),
+        _RewriteUnitClause(TAefosText.ReadAllUtf8(LNewPas),
           LOldBase, ANewUnitName), TEncoding.UTF8);
 
       if LHasDfm then

--- a/source/mcp/Core/Aefos.MCP.Tools.Scaffold.pas
+++ b/source/mcp/Core/Aefos.MCP.Tools.Scaffold.pas
@@ -48,6 +48,7 @@ implementation
 uses
   System.SysUtils,
   System.IOUtils,
+  Aefos.Compat.IO,
   System.JSON,
   Aefos.Tools.Templates,
   Aefos.Tools.Project,
@@ -208,7 +209,7 @@ begin
         LJson := nil;
         try
           try
-            LRaw := TFile.ReadAllText(LManifest, TEncoding.UTF8);
+            LRaw := TAefosText.ReadAllUtf8(LManifest);
             LJson := TJSONObject.ParseJSONValue(LRaw) as TJSONObject;
           except
             LJson := nil;

--- a/source/mcp/OTA/Aefos.MCP.OTA.CodeIntelReadService.pas
+++ b/source/mcp/OTA/Aefos.MCP.OTA.CodeIntelReadService.pas
@@ -48,6 +48,7 @@ uses
   System.SysUtils,
   System.Classes,
   System.IOUtils,
+  Aefos.Compat.IO,
   System.Generics.Collections,
   ToolsAPI,
   Aefos.MCP.PasParser,
@@ -89,7 +90,7 @@ begin
   end;
   if LFilePath = '' then Exit;
   try
-    LSource := TFile.ReadAllText(LFilePath, TEncoding.UTF8);
+    LSource := TAefosText.ReadAllUtf8(LFilePath);
   except
     LSource := '';
   end;
@@ -145,7 +146,7 @@ begin
   if LFilePath = '' then Exit;
   if LSource = '' then
     try
-      LSource := TFile.ReadAllText(LFilePath, TEncoding.UTF8);
+      LSource := TAefosText.ReadAllUtf8(LFilePath);
     except
       LSource := '';
     end;
@@ -197,7 +198,7 @@ begin
     for LFor := 0 to High(LPaths) do
     begin
       try
-        LSource := TFile.ReadAllText(LPaths[LFor], TEncoding.UTF8);
+        LSource := TAefosText.ReadAllUtf8(LPaths[LFor]);
       except
         Continue;
       end;
@@ -252,7 +253,7 @@ begin
   if LFilePath = '' then Exit;
   if LSource = '' then
     try
-      LSource := TFile.ReadAllText(LFilePath, TEncoding.UTF8);
+      LSource := TAefosText.ReadAllUtf8(LFilePath);
     except
       LSource := '';
     end;
@@ -280,7 +281,7 @@ begin
   for LFor := 0 to High(APaths) do
   begin
     try
-      LSource := TFile.ReadAllText(APaths[LFor], TEncoding.UTF8);
+      LSource := TAefosText.ReadAllUtf8(APaths[LFor]);
     except
       Continue;
     end;

--- a/source/mcp/OTA/Aefos.MCP.OTA.DiffViewService.pas
+++ b/source/mcp/OTA/Aefos.MCP.OTA.DiffViewService.pas
@@ -82,6 +82,7 @@ uses
   System.SysUtils,
   System.Classes,
   System.IOUtils,
+  Aefos.Compat.IO,
   System.DateUtils,
   Winapi.ActiveX,
   ToolsAPI,
@@ -407,7 +408,7 @@ begin
         LReason := 'file-not-found';
         Exit;
       end;
-      LText := TFile.ReadAllText(LFile, TEncoding.UTF8);
+      LText := TAefosText.ReadAllUtf8(LFile);
       LOk := True;
     end);
   AFileName := LFile;

--- a/source/mcp/OTA/Aefos.MCP.OTA.FormDesignerService.pas
+++ b/source/mcp/OTA/Aefos.MCP.OTA.FormDesignerService.pas
@@ -87,6 +87,7 @@ uses
   System.Rtti,
   System.TypInfo,
   System.IOUtils,
+  Aefos.Compat.IO,
   System.NetEncoding,
   System.Generics.Collections,
   Vcl.Controls,
@@ -643,7 +644,7 @@ begin
       AIsBinary := True;
     end
     else
-      AContent := TFile.ReadAllText(LDFMPath, TEncoding.UTF8);
+      AContent := TAefosText.ReadAllUtf8(LDFMPath);
     Result := True;
   except
     AContent  := '';
@@ -739,7 +740,7 @@ begin
           LOldDfm := '';
       if LOldDfm = '' then
         try
-          LOldDfm := TFile.ReadAllText(LDfmPath, TEncoding.UTF8);
+          LOldDfm := TAefosText.ReadAllUtf8(LDfmPath);
         except
           LOldDfm := '';
         end;

--- a/source/mcp/OTA/Aefos.MCP.OTA.ProjectLifecycleService.pas
+++ b/source/mcp/OTA/Aefos.MCP.OTA.ProjectLifecycleService.pas
@@ -46,6 +46,7 @@ uses
   System.SysUtils,
   System.Classes,
   System.IOUtils,
+  Aefos.Compat.IO,
   ToolsAPI,
   Aefos.MCP.OTA.FacadeShared,
   Aefos.MCP.OTA.UnitCreatePolicy;
@@ -293,7 +294,7 @@ begin
   Result := False;
   if not TFile.Exists(ADProjPath) then Exit;
   try
-    LText := TFile.ReadAllText(ADProjPath, TEncoding.UTF8);
+    LText := TAefosText.ReadAllUtf8(ADProjPath);
   except
     Exit;
   end;

--- a/source/mcp/OTA/Aefos.MCP.OTA.StructuralWriteService.pas
+++ b/source/mcp/OTA/Aefos.MCP.OTA.StructuralWriteService.pas
@@ -49,6 +49,7 @@ uses
   System.SysUtils,
   System.Classes,
   System.IOUtils,
+  Aefos.Compat.IO,
   System.RegularExpressions,
   System.Generics.Collections,
   ToolsAPI,
@@ -123,7 +124,7 @@ var
   LSrc, LNew: string;
 begin
   if not TFile.Exists(AFilePath) then Exit;
-  LSrc := TFile.ReadAllText(AFilePath, TEncoding.UTF8);
+  LSrc := TAefosText.ReadAllUtf8(AFilePath);
   LNew := TRegEx.Replace(LSrc,
     '(?im)^(\s*unit\s+)' + TRegEx.Escape(AOldBase) + '\b',
     '${1}' + ANewName);

--- a/source/mcp/OTA/Aefos.MCP.OTA.UsesWriteService.pas
+++ b/source/mcp/OTA/Aefos.MCP.OTA.UsesWriteService.pas
@@ -50,6 +50,7 @@ uses
   System.Classes,
   System.Generics.Collections,
   System.IOUtils,
+  Aefos.Compat.IO,
   ToolsAPI,
   Aefos.Harness.View,         // WithLiveSource (S2 code-mutation seam, silent apply)
   Aefos.MCP.Types,            // TMCPDiffDecision
@@ -388,7 +389,7 @@ begin
   end;
   if LFilePath = '' then Exit;
   try
-    LSource := TFile.ReadAllText(LFilePath, TEncoding.UTF8);
+    LSource := TAefosText.ReadAllUtf8(LFilePath);
   except
     LSource := '';
   end;

--- a/source/mcp/OTA/Aefos.OTA.MCP.PyToolsManager.pas
+++ b/source/mcp/OTA/Aefos.OTA.MCP.PyToolsManager.pas
@@ -36,6 +36,7 @@ uses
   System.StrUtils,   // StartsText - the stale-menu match is by prefix now
   System.Classes,
   System.IOUtils,
+  Aefos.Compat.IO,
   System.JSON,
   Vcl.Forms,
   Vcl.Controls,
@@ -263,7 +264,7 @@ begin
   try
     try
       LJson := TJSONObject.ParseJSONValue(
-        TFile.ReadAllText(LManifest, TEncoding.UTF8)) as TJSONObject;
+        TAefosText.ReadAllUtf8(LManifest)) as TJSONObject;
     except
       LJson := nil;
     end;
@@ -283,7 +284,7 @@ begin
       FMemoSchema.Text := '';
     LCodePath := TPath.Combine(LDir, LEntry);
     if TFile.Exists(LCodePath) then
-      FMemoCode.Text := TFile.ReadAllText(LCodePath, TEncoding.UTF8)
+      FMemoCode.Text := TAefosText.ReadAllUtf8(LCodePath)
     else
       FMemoCode.Text := '';
   finally

--- a/source/mcp/Tools/Aefos.Tools.Templates.pas
+++ b/source/mcp/Tools/Aefos.Tools.Templates.pas
@@ -84,6 +84,7 @@ uses
   System.SysUtils,
   System.StrUtils,
   System.IOUtils,
+  Aefos.Compat.IO,
   System.Generics.Collections;
 
 { TToolTemplateVar }
@@ -180,7 +181,7 @@ begin
   if not TFile.Exists(LPath) then
     Exit(tplUnknownTemplate);
   try
-    AContent := TFile.ReadAllText(LPath, TEncoding.UTF8);
+    AContent := TAefosText.ReadAllUtf8(LPath);
   except
     Exit(tplReadError);
   end;

--- a/source/terminal/Core/Aefos.OTA.Terminal.Core.ActionStore.pas
+++ b/source/terminal/Core/Aefos.OTA.Terminal.Core.ActionStore.pas
@@ -102,7 +102,7 @@ uses
   Aefos.Compat.IO, Generics.Collections,
   LCLProc, LCLType;
   {$ELSE}
-  System.IOUtils, System.Generics.Collections,
+  System.IOUtils, Aefos.Compat.IO, System.Generics.Collections,
   Vcl.Menus;
   {$ENDIF}
 
@@ -305,7 +305,7 @@ begin
       // The compat shim has no encoding-less overload; UTF-8 matches the
       // BOM'd file SaveCatalog writes (the shim strips a leading BOM on read).
       {$IFDEF FPC}
-      LContent := TFile.ReadAllText(FFilePath, TEncoding.UTF8);
+      LContent := TAefosText.ReadAllUtf8(FFilePath);
       {$ELSE}
       LContent := TFile.ReadAllText(FFilePath);
       {$ENDIF}
@@ -395,7 +395,7 @@ begin
 
   try
     {$IFDEF FPC}
-    LContent := TFile.ReadAllText(AFilePath, TEncoding.UTF8);
+    LContent := TAefosText.ReadAllUtf8(AFilePath);
     {$ELSE}
     LContent := TFile.ReadAllText(AFilePath);
     {$ENDIF}

--- a/source/terminal/UI/Aefos.OTA.Terminal.UI.ComposerMemory.pas
+++ b/source/terminal/UI/Aefos.OTA.Terminal.UI.ComposerMemory.pas
@@ -43,6 +43,7 @@ implementation
 uses
   System.SysUtils,
   System.IOUtils,
+  Aefos.Compat.IO,
   Vcl.Graphics;
 
 function GlobalMemoryPath: string;
@@ -60,7 +61,7 @@ begin
   if not TFile.Exists(LPath) then
     Exit;
   try
-    Result := TFile.ReadAllText(LPath, TEncoding.UTF8);
+    Result := TAefosText.ReadAllUtf8(LPath);
   except
     // A locked / garbled memory file must never break the editor.
     Result := '';


### PR DESCRIPTION
Closes #59 — the rest of what 1.5.1 fixed in a single unit.

## Why it was left half done

On **10 Seattle (17.0)** and **10.1 Berlin (18.0)**, `TFile.ReadAllText(path, TEncoding.UTF8)` discards the first three bytes of a BOM-less file. 1.5.1 fixed `Aefos.MCP.Provision` with a local helper, because the obvious shared one could not be reached: `Aefos.Compat.IO` — which has done this correctly for FPC all along — lived in `Aefos.MCP.Core`, **downstream** of most of the tree, so units in `Aefos.Tools`, `Aefos.OTA.Chat` and `Aefos.OTA.Terminal` answered `F2613`.

## What changed

The shim moves to **`Aefos.Tools`, the root package** — it requires `rtl` alone, and every other Aefos package reaches it directly or through `Aefos.MCP.Core`. It carries `TAefosText.ReadAllUtf8`, and **42 call sites across 26 units** now go through it, including the local copy 1.5.1 left behind. No `TFile.ReadAllText(…, TEncoding.UTF8)` remains outside the two deliberate exclusions below.

The sharp ones are the **code tools**: a `.pas` usually has no BOM, so on those two IDEs every tool that read one was losing the first three characters of `unit`.

**`Aefos.Providers` is deliberately not swept.** It requires `rtl` alone, so pulling the shim in would static-link a second copy of a unit `Aefos.Tools` contains — and `Aefos.OTA.Chat` requires both. Its one read is of a cache we write with `TFile.WriteAllText`, which emits a BOM, so it was never exposed. The Lazarus tree is untouched: it already used the correct FPC branch.

## Proof

A probe compiled by **Seattle's own `dcc32`**, reading two files from this repository:

| file | old RTL | `TAefosText` |
|---|---|---|
| `Aefos.MCP.Provision.pas` (no BOM) | `"t Aefos.MCP.Provision;"` | `"unit Aefos.MCP.Provisi"` — **differ by 3** |
| `Aefos.MCP.Server.pas` (BOM) | `"unit Aefos.MCP.Server;"` | `"unit Aefos.MCP.Server;"` — identical |

Where the RTL was right, the new reader returns the same bytes.

Builds: **17.0 → 22.0 in the VM, exit 0 on all six**; 23.0 on the host, exit 0; `Aefos.Compat.IO` compiles under **FPC 3.2.2** (exit 0, no new warnings).

⚠️ The **full Lazarus gate could not run here**: `build-sqlite-fpc.ps1` wants an i386 mingw-w64 gcc this machine does not have. That is a pre-existing prerequisite and it fails before any Pascal is compiled — but it does mean the Lazarus build is unproven on this branch by anything stronger than the unit-level FPC compile above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)