### PR TITLE
The CLA gate has never passed on an open pull request

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -43,7 +43,16 @@ jobs:
           branch: cla-signatures
           # The copyright holder does not sign an agreement with himself, and
           # bots have no copyright to grant.
-          allowlist: isaquepinheiro,dependabot[bot],github-actions[bot]
+          #
+          # `claude` is here for the same reason as the other two. Commits
+          # written with an AI assistant carry a Co-Authored-By trailer, which
+          # GitHub resolves to that account and the action then counts as a
+          # committer. The authorship and the copyright are the human author's;
+          # the tool has nothing to license and no way to comment a signature,
+          # so without this every such pull request is blocked by a signature
+          # that can never arrive. This allowlists the TOOL, never a person: a
+          # human contributor still signs, exactly as CLA.md describes.
+          allowlist: isaquepinheiro,claude,dependabot[bot],github-actions[bot]
           custom-notsigned-prcomment: >-
             Thank you for the pull request. Before it can be merged, please sign the
             [Contributor License Agreement](https://github.com/ModernDelphiWorks/Aefos/blob/main/CLA.md).


### PR DESCRIPTION
The CLA check has never passed on an open pull request. Not once since it was added.

It looks healthy because of *when* the green runs happen: the workflow fires on `closed` as well, and that run's only job is to lock the merged pull request. So everything already merged shows a green check, and only whatever is open right now shows red — which reads as "this particular PR has a problem" instead of "this gate has never worked".

I verified it rather than inferred it. Every successful `pull_request_target` run in the history contains `Locking the Pull Request to safe guard the Pull Request CLA Signatures`; every run triggered by opening or updating a pull request failed.

## Two causes, unrelated to each other

**1 — the signature store did not exist.** `cla.yml` says signatures live as JSON on the orphan branch `cla-signatures`, "so the record lives with the project and needs no external service and no extra secret". The branch was never created, so every run ended on:

```
Error occurred when creating the signed contributors file:
Branch cla-signatures not found.
```

This is the one that actually costs something. A contributor who read CLA.md and replied with the exact sentence would have had it accepted nowhere, and been asked again on their next pull request, forever. The path the whole file exists to make work was the path that could not run. **Fixed outside this PR** — `cla-signatures` now exists, seeded with an empty `signatures/v1/cla.json`, because an orphan data branch cannot arrive through a pull request into `main`.

**2 — this PR.** Commits written with an AI assistant carry a `Co-Authored-By` trailer. GitHub resolves it to the `claude` account and the action counts it as an unsigned committer. It cannot sign: it has no way to leave a comment, and nothing to license — the authorship and the copyright are the human author's. So the check demanded a signature that could never arrive.

The allowlist already carries `dependabot[bot]` and `github-actions[bot]`, under a comment reading *"bots have no copyright to grant."* This applies that existing rule to the same kind of account, and spells the reasoning out in the file so the next person does not have to rediscover it.

**What this does not do:** it does not let a human contribute unsigned. A person still signs, once, exactly as CLA.md describes. What is allowlisted is the tool.

## Why it matters more now than last month

The dual-licensing position depends on one holder being able to relicense the whole tree, and this check is what protects that. Now that the repository is public, the first outside contribution is the moment it has to work — and until this PR, the honest state was that a green CLA column meant "merged", not "signed".

## Note on this PR's own check

`pull_request_target` runs the workflow from the base branch, so this PR is judged by the allowlist it is replacing and will fail exactly like the others. It passes on the PR after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
