### PR TITLE
The prompt was too big to be an argument, so it stops being one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 Dates are in `YYYY-MM-DD`.
 
+## [Unreleased]
+
+### Fixed
+
+**With a project open, every Chat message failed instantly.** The turn never
+reached the CLI — it died in the spawn with
+`CreateProcess failed for "…\claude.exe" (last error: 206)`. Closing the project
+made the same question work, which made the bug look like it was about the
+project and not about the message.
+
+Error 206 is `ERROR_FILENAME_EXCED_RANGE`, and despite the name it is not a path
+problem: `CreateProcess` returns it when the command line passes 32767
+characters. The prompt was the last token of that command line, and the prompt
+carries the rendered project context — whose active-unit body alone is capped at
+32 KB (`ProjectContextBuilder.ACTIVE_UNIT_MAX_BYTES`). That cap is already one
+byte past what a command line can hold, before the executable, the flags and the
+quoting are added. Hence the exact correlation: with no project open the context
+degrades to a single short line and the same prompt fits.
+
+The prompt now travels on **stdin** for Claude Code, which reads it there and
+which the dispatcher has always opened a pipe for (it just closed it empty). A
+dedicated writer thread feeds it, so a payload larger than the pipe buffer cannot
+deadlock against a child that writes output before draining its input. Off the
+command line, the 32 KB limit no longer applies at all.
+
+Each driver declares its own answer (`IExecutorProfile.PromptViaStdin`), because
+where a CLI accepts its prompt is that CLI's dialect: Codex, Copilot, Gemini and
+the local agent CLI keep the command line, unchanged, until their stdin form can
+be verified against a real binary. For those, an over-long command line is now
+refused up front with a message that says what actually happened, instead of
+surfacing as a bare `last error: 206`.
+
 ## [1.5.1] - 2026-08-10
 
 **Two things the addon store and the MCP list disagreed about.** Both were found

--- a/source/chat/Core/Aefos.Chat.Core.CliHarness.pas
+++ b/source/chat/Core/Aefos.Chat.Core.CliHarness.pas
@@ -440,6 +440,11 @@ begin
       ; // no continuity: the driver ignores the session fields entirely
   end;
   Result.Args := AProfile.BuildDispatchArgs(LCtx);
+  // Prompt channel, straight from the driver: the CLI's own dialect decides
+  // whether the prompt is the last command-line token or arrives on stdin. Asked
+  // AFTER BuildDispatchArgs purely so the two read in the order the dispatcher
+  // uses them; the answer does not depend on the args.
+  Result.PromptViaStdin := AProfile.PromptViaStdin;
   // Tags the per-executor session log file (YYYY-MM-DD-<executor>.log).
   Result.Executor := TProviderRegistry.ExecutorKindToString(AConfig.Executor);
   // Persisted runtime settings: seconds -> ms; a non-positive value disables the

--- a/source/chat/Core/Aefos.OTA.Chat.Core.CLIDispatcher.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.CLIDispatcher.pas
@@ -456,6 +456,14 @@ begin
   LSpec.CommandLine := TCliCommandLine.Build(ARequest);
   LSpec.EnvBlock := TCliCommandLine.BuildEnvBlock(LOverrides);
   LSpec.WorkingDirectory := ARequest.WorkingDirectory;
+  // The prompt goes on exactly ONE of the two channels, never both: Build above
+  // already left it off the command line for a PromptViaStdin driver, and this is
+  // where it picks the other one up. A command-line driver gets '' here, which is
+  // the same closed-stdin child the runner has always spawned.
+  if ARequest.PromptViaStdin then
+    LSpec.StdinText := ARequest.Prompt
+  else
+    LSpec.StdinText := '';
 
   FStartTick := GetTickCount;
 

--- a/source/chat/Core/Aefos.OTA.Chat.Core.Dispatcher.Decode.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.Dispatcher.Decode.pas
@@ -127,6 +127,9 @@ type
     // Builds the child command line: "executor" "arg0" .. "argN" "prompt"
     // (executor -> Args -> Prompt). Byte-identical to the pre-refactor
     // _BuildCommandLine (AC-04).
+    //   ARequest.PromptViaStdin drops the trailing "prompt" token: that driver's
+    // CLI reads the prompt from stdin, so the command line is executor -> Args
+    // only. Every other request is unaffected.
     class function Build(const ARequest: TDispatchRequest): string; static;
     // Ensures NO_COLOR=1 is present among the env overrides: injected when absent,
     // left untouched when already supplied (case-insensitive). Caller overrides for
@@ -355,7 +358,14 @@ begin
     LBuilder.Append(_QuoteArg(ARequest.ExecutorPath));
     for LFor := 0 to High(ARequest.Args) do
       LBuilder.Append(string(' ')).Append(_QuoteArg(ARequest.Args[LFor]));
-    LBuilder.Append(string(' ')).Append(_QuoteArg(ARequest.Prompt));
+    // The prompt is the last token ONLY for the drivers whose CLI reads it there.
+    // Under PromptViaStdin it is left off entirely and travels on stdin instead
+    // (TProcessStartSpec.StdinText) — the whole point being that a command line
+    // cannot hold it: CreateProcess caps it at 32767 characters and the prompt
+    // carries the project context. Everything BEFORE this line is unchanged, so a
+    // command-line driver still gets the byte-identical string it always got.
+    if not ARequest.PromptViaStdin then
+      LBuilder.Append(string(' ')).Append(_QuoteArg(ARequest.Prompt));
     Result := LBuilder.ToString;
   finally
     LBuilder.Free;

--- a/source/chat/Core/Aefos.OTA.Chat.Core.Dispatcher.ProcessRunner.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.Dispatcher.ProcessRunner.pas
@@ -14,6 +14,20 @@
   of it was lifted verbatim (C-2) from the pre-refactor Core.CLIDispatcher
   (TCLIDispatcherRun + TCLIDispatcherReadThread); behaviour is byte-identical.
 
+  The stdin leg carries a payload now (TProcessStartSpec.StdinText). The pipe
+  itself is not new -- this runner has always created one and closed it right
+  after the spawn, so the child read end-of-input at once -- what is new is
+  writing to it first, on its own thread, and letting THAT close signal the end.
+  A caller that sends nothing takes the old path unchanged.
+    Why it exists: a command line cannot exceed 32766 characters
+  (MAX_COMMAND_LINE_CHARS), and the assembled chat prompt carries the rendered
+  project context, whose active-unit body alone is capped at 32 KB. With a
+  project open that overran the limit and CreateProcess failed every turn with
+  ERROR_FILENAME_EXCED_RANGE (206). Off the command line there is no such cap.
+  Which drivers use it is the drivers' call (IExecutorProfile.PromptViaStdin);
+  the ones that stay on the command line now get an explicit over-length error
+  from _RejectOverLongCommandLine instead of a bare 206.
+
   COVERAGE EXCLUSION (ADR-262 / BR-5, no-silent-caps):
     This unit is DELIBERATELY ABSENT from the coverage list. Its lines
     need a *real* child process to execute, which a 32-bit dcc32 runner debugged
@@ -66,8 +80,33 @@ uses
 
 const
   READ_BUFFER_SIZE = 4096;
+  WRITE_BUFFER_SIZE = 4096;
+  // Longest command line CreateProcess accepts with lpApplicationName = nil.
+  // The documented cap is 32767 INCLUDING the terminating null, so 32766 is the
+  // last length that spawns; 32767 and up fail with ERROR_FILENAME_EXCED_RANGE
+  // (206). Measured, not assumed: 32766 -> success, 32767 -> 206.
+  MAX_COMMAND_LINE_CHARS = 32766;
 
 type
+  // Feeds the child's stdin and closes the pipe, which is what signals end of
+  // input. Runs OFF the spawn thread on purpose: a payload larger than the pipe
+  // buffer (64 KB by default, and a prompt carrying the project context can pass
+  // that) blocks in WriteFile until the child drains it, and the child may not
+  // drain it before writing output of its own. On the spawn thread that is a
+  // deadlock -- the parent has not started its stdout/stderr readers yet, so the
+  // child would block on a full stdout pipe while the parent blocks on stdin.
+  //   Owns the handle it is given: the session hands it over and forgets it, so
+  // nothing else can close it underneath this thread.
+  TWin32StdinWriteThread = class(TThread)
+  private
+    FPipeHandle: THandle;
+    FPayload: TBytes;
+  protected
+    procedure Execute; override;
+  public
+    constructor Create(const APipeHandle: THandle; const APayload: TBytes);
+  end;
+
   TWin32ReadThread = class(TThread)
   private
     FPipeHandle: THandle;
@@ -95,9 +134,10 @@ type
     FStdinRead: THandle;
     FStdinWrite: THandle;
     procedure _OpenPipes;
-    procedure _CloseChildSideAndStdin;
+    procedure _CloseChildSideAndStdin(const AStdinText: string);
     procedure _CloseAllHandles;
     procedure _PrepareStartupInfo(out AInfo: TStartupInfoW);
+    procedure _RejectOverLongCommandLine(const ASpec: TProcessStartSpec);
     function _DoCreateProcess(const ASpec: TProcessStartSpec): Boolean;
     procedure _StartReadThreads(const AOnChunk: TProcessChunkProc;
       const AOnStreamEnd: TProcessStreamEndProc);
@@ -218,12 +258,33 @@ begin
       'CreatePipe(stdin) failed (last error: %d)', [GetLastError]);
 end;
 
-procedure TWin32ProcessSession._CloseChildSideAndStdin;
+procedure TWin32ProcessSession._CloseChildSideAndStdin(
+  const AStdinText: string);
+var
+  LWriter: TWin32StdinWriteThread;
+  LPayload: TBytes;
 begin
+  // The child holds its own copies now; the parent's ends must go or the read
+  // loops never see end-of-stream.
   _CloseHandleSafe(FStdoutWrite);
   _CloseHandleSafe(FStderrWrite);
   _CloseHandleSafe(FStdinRead);
-  _CloseHandleSafe(FStdinWrite);
+  if AStdinText = '' then
+  begin
+    // Nothing to send: close at once, byte-identical to what this runner has
+    // always done -- the child reads end-of-input immediately. Every
+    // command-line-prompt driver takes this branch, so their spawn is unchanged.
+    _CloseHandleSafe(FStdinWrite);
+    Exit;
+  end;
+  // Hand the write end to the writer thread and drop it from the session in the
+  // same breath, so neither _CloseAllHandles nor the destructor can close it
+  // out from under the write in progress. The thread closes it when the payload
+  // is out -- that close IS the end-of-input signal.
+  LPayload := TEncoding.UTF8.GetBytes(AStdinText);
+  LWriter := TWin32StdinWriteThread.Create(FStdinWrite, LPayload);
+  FStdinWrite := INVALID_HANDLE_VALUE;
+  LWriter.Start;
 end;
 
 procedure TWin32ProcessSession._CloseAllHandles;
@@ -255,6 +316,27 @@ begin
   // back to the default desktop if creation fails.
   if _EnsureCliDesktop then
     AInfo.lpDesktop := PChar(CLI_DESKTOP_NAME);
+end;
+
+procedure TWin32ProcessSession._RejectOverLongCommandLine(
+  const ASpec: TProcessStartSpec);
+begin
+  if Length(ASpec.CommandLine) <= MAX_COMMAND_LINE_CHARS then
+    Exit;
+  // Checked BEFORE the pipes are opened, so nothing has to be cleaned up, and
+  // before CreateProcess so the failure is named instead of arriving as a bare
+  // "last error: 206" the reader has to look up. 206 is
+  // ERROR_FILENAME_EXCED_RANGE, which reads like a path problem and is not one:
+  // the command line simply does not fit.
+  //   A driver only reaches this if it puts the prompt on the command line
+  // (IExecutorProfile.PromptViaStdin = False) and the prompt outgrew it. The fix
+  // is that flag, not a shorter prompt, so the message says so.
+  raise EDispatcherSpawnFailed.CreateFmt(
+    'Command line too long for "%s": %d characters, but CreateProcess accepts ' +
+    'at most %d. The prompt (which carries the project context) does not fit ' +
+    'as an argument for this executor; it has to be delivered on stdin ' +
+    '(IExecutorProfile.PromptViaStdin).',
+    [ASpec.ExecutorPath, Length(ASpec.CommandLine), MAX_COMMAND_LINE_CHARS]);
 end;
 
 function TWin32ProcessSession._DoCreateProcess(
@@ -297,6 +379,8 @@ end;
 
 procedure TWin32ProcessSession.Spawn(const ASpec: TProcessStartSpec);
 begin
+  _RejectOverLongCommandLine(ASpec);
+
   _OpenPipes;
 
   if not _DoCreateProcess(ASpec) then
@@ -307,7 +391,7 @@ begin
       [ASpec.ExecutorPath, GetLastError]);
   end;
 
-  _CloseChildSideAndStdin;
+  _CloseChildSideAndStdin(ASpec.StdinText);
 end;
 
 procedure TWin32ProcessSession.BeginRead(const AOnChunk: TProcessChunkProc;
@@ -339,6 +423,52 @@ begin
       GetExitCodeProcess(FProcessHandle, Result)
     else
       Result := DWORD(-1);
+  end;
+end;
+
+{ TWin32StdinWriteThread }
+
+constructor TWin32StdinWriteThread.Create(const APipeHandle: THandle;
+  const APayload: TBytes);
+begin
+  inherited Create(True);
+  // Self-freeing, unlike the read threads: this one keeps nothing alive and
+  // nobody waits on it. It owns only its handle and its own copy of the payload,
+  // touches no session state, and is done as soon as the bytes are out -- so
+  // there is nothing left for anyone to join.
+  FreeOnTerminate := True;
+  FPipeHandle := APipeHandle;
+  FPayload := APayload;
+end;
+
+procedure TWin32StdinWriteThread.Execute;
+var
+  LOffset: Integer;
+  LChunk: DWORD;
+  LWritten: DWORD;
+begin
+  try
+    LOffset := 0;
+    while LOffset < Length(FPayload) do
+    begin
+      LChunk := DWORD(Length(FPayload) - LOffset);
+      if LChunk > WRITE_BUFFER_SIZE then
+        LChunk := WRITE_BUFFER_SIZE;
+      LWritten := 0;
+      // A failure here is normal, not exceptional: a cancelled or crashed child
+      // leaves a broken pipe. Stop writing and close, which is what a child that
+      // is still alive is waiting for anyway.
+      if not WriteFile(FPipeHandle, FPayload[LOffset], LChunk, LWritten, nil) then
+        Break;
+      if LWritten = 0 then
+        Break;
+      Inc(LOffset, Integer(LWritten));
+    end;
+  finally
+    // Unconditional: the close is the end-of-input signal. Skipping it on an
+    // error path would leave the child waiting for data that is never coming,
+    // which looks exactly like a hang.
+    _CloseHandleSafe(FPipeHandle);
   end;
 end;
 

--- a/source/chat/Core/Aefos.OTA.Chat.Core.Dispatcher.Types.pas
+++ b/source/chat/Core/Aefos.OTA.Chat.Core.Dispatcher.Types.pas
@@ -76,6 +76,16 @@ type
     TimeoutMs: Cardinal;
     // Stdout filter policy (ADR-289). Default ofpStrip preserves today.
     OutputFilter: TOutputFilterPolicy;
+    // Where the child reads Prompt from. False (the zero value, so every
+    // Default(TDispatchRequest) caller keeps today's behaviour byte-for-byte)
+    // appends Prompt as the last token of the command line. True keeps Prompt
+    // OFF the command line and hands it to the child on stdin instead.
+    //
+    // Set from IExecutorProfile.PromptViaStdin — it is the CLI's dialect that
+    // decides, not this record. It exists because a command line is capped at
+    // 32767 characters by CreateProcess and the prompt carries the project
+    // context, which alone can fill that (see the profile member's comment).
+    PromptViaStdin: Boolean;
   end;
 
   IDispatcherRunHandle = interface
@@ -142,6 +152,15 @@ type
     CommandLine: string;
     EnvBlock: string;
     WorkingDirectory: string;
+    // Text to feed the child on stdin, UTF-8 encoded by the runner. Empty (the
+    // zero value) means what it has always meant: the child's stdin is closed
+    // immediately after the spawn, so it reads end-of-input at once. A non-empty
+    // payload is written and THEN the pipe is closed — the close is what signals
+    // end of input, so a runner that forgets it hangs the child.
+    //   The write happens off the spawn thread: a payload can be far larger than
+    // the pipe buffer, and a child that emits output before draining its stdin
+    // would otherwise deadlock against a parent blocked in WriteFile.
+    StdinText: string;
   end;
 
   // One started child process. Owns its OS handles and read threads; closes

--- a/source/providers/Aefos.Provider.Claude.pas
+++ b/source/providers/Aefos.Provider.Claude.pas
@@ -29,6 +29,7 @@ type
     function ResolveReplicationRoot(const AProjectRoot: string): string;
     function BuildDispatchArgs(
       const ACtx: TProviderDispatchContext): TArray<string>;
+    function PromptViaStdin: Boolean;
     function SessionSupport: TSessionSupport;
     function TryCaptureSessionId(const AOutput: UnicodeString;
       out ASessionId: UnicodeString): Boolean;
@@ -201,6 +202,24 @@ begin
     Result := Result + ['--resume', ACtx.SessionId]
   else
     Result := Result + ['--session-id', ACtx.SessionId];
+end;
+
+function TClaudeExecutorProfile.PromptViaStdin: Boolean;
+begin
+  // Claude Code reads the prompt from stdin when no positional prompt is given,
+  // and a piped (non-TTY) stdin is already what puts it in non-interactive print
+  // mode -- which is how this driver has ALWAYS run, since the dispatcher opens a
+  // stdin pipe for every child. So nothing else changes: the args built above end
+  // with the session flag and are complete without a trailing prompt token.
+  //   Verified live against claude.exe 2.1.246 on the reporter's shape:
+  //     printf '<prompt>' | claude.exe --session-id <uuid>
+  //   answers and exits 0, with no -p and no positional argument.
+  //   This is the fix for the CreateProcess 206 (ERROR_FILENAME_EXCED_RANGE) that
+  // made every chat turn fail WITH A PROJECT OPEN: the rendered project context
+  // rides in the prompt, and its active-unit body alone is capped at 32 KB --
+  // one byte over what a command line can hold. Off the command line, there is no
+  // limit to exceed.
+  Result := True;
 end;
 
 function TClaudeExecutorProfile.SessionSupport: TSessionSupport;

--- a/source/providers/Aefos.Provider.Codex.pas
+++ b/source/providers/Aefos.Provider.Codex.pas
@@ -34,6 +34,7 @@ type
     function ResolveReplicationRoot(const AProjectRoot: string): string;
     function BuildDispatchArgs(
       const ACtx: TProviderDispatchContext): TArray<string>;
+    function PromptViaStdin: Boolean;
     function SessionSupport: TSessionSupport;
     function TryCaptureSessionId(const AOutput: UnicodeString;
       out ASessionId: UnicodeString): Boolean;
@@ -351,6 +352,19 @@ begin
             '"-NonInteractive","-File","' + LBridge +
             '","-Session","' + ACtx.McpSession + '"]'];
   end;
+end;
+
+function TCodexExecutorProfile.PromptViaStdin: Boolean;
+begin
+  // Left on the command line: `codex exec` takes the prompt positionally (see
+  // BuildDispatchArgs) and this driver's stdin contract was not verified against
+  // a real codex binary, so flipping it would be a guess on the path every turn
+  // of every Codex chat goes through. The transport supports it the moment
+  // someone can prove the dialect -- this is a one-line change, not a redesign.
+  //   Until then an over-long command line no longer dies as an opaque
+  // CreateProcess 206: the dispatcher checks the length up front and says what
+  // actually happened (Dispatcher.ProcessRunner._RejectOverLongCommandLine).
+  Result := False;
 end;
 
 function TCodexExecutorProfile.SessionSupport: TSessionSupport;

--- a/source/providers/Aefos.Provider.Copilot.pas
+++ b/source/providers/Aefos.Provider.Copilot.pas
@@ -34,6 +34,7 @@ type
     function ResolveReplicationRoot(const AProjectRoot: string): string;
     function BuildDispatchArgs(
       const ACtx: TProviderDispatchContext): TArray<string>;
+    function PromptViaStdin: Boolean;
     function SessionSupport: TSessionSupport;
     function TryCaptureSessionId(const AOutput: UnicodeString;
       out ASessionId: UnicodeString): Boolean;
@@ -157,6 +158,18 @@ begin
       '@' + ACtx.McpConfigPath, '-s', '-p']
   else
     Result := Result + ['--allow-all-tools', '-s', '-p'];
+end;
+
+function TCopilotExecutorProfile.PromptViaStdin: Boolean;
+begin
+  // Left on the command line: this driver's args END with `-p`, which takes the
+  // prompt as its VALUE (see BuildDispatchArgs), so dropping the last token would
+  // leave a dangling flag rather than a working stdin invocation. Making Copilot
+  // read stdin means changing its args too, and neither half could be verified
+  // here against a real copilot binary. Not guessed on the shared dispatch path.
+  //   An over-long command line is now reported for what it is instead of failing
+  // as an opaque CreateProcess 206 (Dispatcher.ProcessRunner).
+  Result := False;
 end;
 
 function TCopilotExecutorProfile.SessionSupport: TSessionSupport;

--- a/source/providers/Aefos.Provider.Gemini.pas
+++ b/source/providers/Aefos.Provider.Gemini.pas
@@ -34,6 +34,7 @@ type
     function ResolveReplicationRoot(const AProjectRoot: string): string;
     function BuildDispatchArgs(
       const ACtx: TProviderDispatchContext): TArray<string>;
+    function PromptViaStdin: Boolean;
     function SessionSupport: TSessionSupport;
     function TryCaptureSessionId(const AOutput: UnicodeString;
       out ASessionId: UnicodeString): Boolean;
@@ -173,6 +174,19 @@ begin
     Result := Result + ['--allowed-mcp-server-names',
       Aefos.Provider.Base.ResolveMcpServerName(ACtx.McpServerName)];
   Result := Result + ['-p'];
+end;
+
+function TGeminiExecutorProfile.PromptViaStdin: Boolean;
+begin
+  // Left on the command line for the same reason as Copilot: these args END with
+  // `-p`, whose VALUE is the prompt, so removing the last token would leave the
+  // flag dangling. The Gemini CLI's own help does say `-p` is "appended to input
+  // on stdin (if any)", which is the seam a stdin switch would use -- but that
+  // needs the args changed with it and proven against a live run, and this is the
+  // path every Gemini chat turn takes. Not flipped on documentation alone.
+  //   An over-long command line is now reported for what it is instead of failing
+  // as an opaque CreateProcess 206 (Dispatcher.ProcessRunner).
+  Result := False;
 end;
 
 function TGeminiExecutorProfile.SessionSupport: TSessionSupport;

--- a/source/providers/Aefos.Provider.Ollama.Profile.pas
+++ b/source/providers/Aefos.Provider.Ollama.Profile.pas
@@ -43,6 +43,7 @@ type
     function ResolveReplicationRoot(const AProjectRoot: string): string;
     function BuildDispatchArgs(
       const ACtx: TProviderDispatchContext): TArray<string>;
+    function PromptViaStdin: Boolean;
     function SessionSupport: TSessionSupport;
     function TryCaptureSessionId(const AOutput: UnicodeString;
       out ASessionId: UnicodeString): Boolean;
@@ -171,6 +172,15 @@ begin
   if ACtx.AgentMode and (ACtx.McpSession <> '') then
     Result := Result + ['--mcp-pipe', CPipePrefix + ACtx.McpSession,
       '--permission-mode', 'auto-edits'];
+end;
+
+function TOllamaExecutorProfile.PromptViaStdin: Boolean;
+begin
+  // The local agent CLI takes the prompt positionally, like today. Its args are
+  // ours (AefosAgent.dpr), so this is the one driver where the stdin dialect
+  // could be DEFINED rather than discovered -- but that means changing the CLI
+  // and the driver together, which is a different change from fixing the 206.
+  Result := False;
 end;
 
 function TOllamaExecutorProfile.SessionSupport: TSessionSupport;

--- a/source/providers/Aefos.Provider.Types.pas
+++ b/source/providers/Aefos.Provider.Types.pas
@@ -110,8 +110,24 @@ type
     // with the session flag). The driver owns ITS dialect; the executor stays
     // generic. Profile-driven dispatch (the per-CLI flags used to live in
     // CommandExecutor).
+    //   A driver that returns True from PromptViaStdin below gets NO positional
+    // prompt appended, so its args must be complete on their own.
     function BuildDispatchArgs(
       const ACtx: TProviderDispatchContext): TArray<string>;
+    // Where this CLI reads the prompt from. False (the default for every driver
+    // that has not been proven otherwise) keeps the prompt as the last token of
+    // the command line. True hands it to the child on STDIN instead, and the
+    // dispatcher then leaves it off the command line entirely.
+    //
+    // This is not a style preference, it is a hard OS limit: CreateProcess with
+    // lpApplicationName = nil rejects a command line of 32767 characters or more
+    // with ERROR_FILENAME_EXCED_RANGE (206), and the assembled prompt carries the
+    // project context -- whose active-unit body alone is capped at 32 KB
+    // (ProjectContextBuilder.ACTIVE_UNIT_MAX_BYTES), already over the limit by
+    // itself. Any driver whose CLI can read the prompt from stdin should say so
+    // here; the ones that cannot keep the command line and are protected by the
+    // dispatcher's explicit over-length error instead of an opaque 206.
+    function PromptViaStdin: Boolean;
     // How this CLI carries a conversation across turns. The executor owns the
     // session STATE; the driver only formats the flag (ssPinned) or knows the
     // marker its CLI prints (ssCaptured). Drivers that return ssNone ignore


### PR DESCRIPTION
With a project open, every Chat turn died in the spawn:

  CreateProcess failed for "...\claude.exe" (last error: 206)

and the same question answered fine with the project closed, which made the bug look like it was about the project rather than about the message.

206 is ERROR_FILENAME_EXCED_RANGE and, despite the name, is not a path problem: CreateProcess returns it when the command line reaches 32767 characters. Measured on the reporter's own binary, with lpApplicationName nil as this runner passes it: 32766 spawns, 32767 fails.

The prompt was the last token of that command line (Dispatcher.Decode TCliCommandLine.Build) and the prompt carries the rendered project context, whose active-unit body alone is capped at 32 KB by ProjectContextBuilder.ACTIVE_UNIT_MAX_BYTES. That cap is already one byte past what a command line can hold, before the executable, the flags and the quoting are counted -- so a project-open turn could not fit by construction. With no project open the context degrades to a single short line (CommandExecutor._PrepareContext's EProjectContextError branch) and the same prompt fits. That is the whole correlation; accents never entered into it.

So the prompt now travels on stdin for Claude Code. The pipe is not new: this runner has always created one and closed it empty right after the spawn, which is also what put the CLI in non-interactive mode. What is new is writing the payload first and letting that close signal the end of input.

The write runs on its own thread. A payload can be far larger than the pipe buffer, and a child that emits output before draining its stdin would otherwise deadlock against a parent blocked in WriteFile -- the parent has not started its stdout readers at that point, so nobody would be draining the other direction either. The thread owns the handle it is given and closes it in a finally, because that close is the end-of-input signal and skipping it on an error path reads as a hang.

Which channel a CLI uses is the CLI's dialect, so each driver declares its own answer (IExecutorProfile.PromptViaStdin). Only Claude flips. Codex, Copilot, Gemini and the local agent CLI keep the command line and are byte-identical: Copilot's and Gemini's args END with -p, whose VALUE is the prompt, so dropping the last token would leave a dangling flag rather than a working stdin invocation, and none of those three could be verified against a real binary here. Guessing on the path that carries every chat turn is not worth the 206 it would fix.

For those drivers the transport now refuses an over-long command line up front with a message naming what happened, instead of letting it surface as a bare "last error: 206" the reader has to go look up.

How we know it works, against claude.exe 2.1.246 in the exact argument shape this driver builds (--allowedTools ... --session-id <uuid>):

  - prompt on stdin, no -p and no positional: answers, exits 0
  - accented text round-trips intact as UTF-8
  - a 189 KB payload -- 5.8x the command-line limit -- comes back with the needle that sat on its LAST line, so the child drained all of it with no deadlock and no truncation

Aefos.Providers and Aefos.OTA.Chat compile clean (Delphi 11, Win32), with no new warnings.